### PR TITLE
fix: Drop X11 packages

### DIFF
--- a/shared/packages/snow/mkosi.conf
+++ b/shared/packages/snow/mkosi.conf
@@ -123,22 +123,6 @@ Packages=gstreamer1.0-gtk4
 # Avahi/mDNS
 Packages=avahi-daemon
 
-# X.org / Xserver
-Packages=xserver-xorg
-         xserver-xorg-core
-         xserver-xorg-input-libinput
-         xserver-xorg-input-wacom
-         xserver-xorg-video-amdgpu
-         xserver-xorg-video-ati
-         xserver-xorg-video-intel
-         xserver-xorg-video-nouveau
-         xserver-xorg-video-radeon
-         xserver-xephyr
-         xauth
-         xfonts-base
-
-
-
 # Accessibility
 Packages=speech-dispatcher-espeak-ng
 


### PR DESCRIPTION
Removed X.org / Xserver packages from mkosi configuration.