### PR TITLE
fix: Mask unwanted systemd services/timers

### DIFF
--- a/shared/snow/tree/usr/lib/systemd/system-preset/99-disable-unwanted-services.preset
+++ b/shared/snow/tree/usr/lib/systemd/system-preset/99-disable-unwanted-services.preset
@@ -1,0 +1,4 @@
+mask systemd-boot-update.service
+mask apt-daily-upgrade.timer
+mask apt-daily.timer
+mask dpkg-db-backup.timer


### PR DESCRIPTION
Fixes #25
Fixes #24
Fixes #23

File may need to be moved to /etc depending on how systemd handles load order for presets.