### PR TITLE
feat: Use DoT via systemd-resolved with Cloudflare DNS by default

### DIFF
--- a/mkosi.images/base/mkosi.extra/etc/systemd/resolved.conf
+++ b/mkosi.images/base/mkosi.extra/etc/systemd/resolved.conf
@@ -1,0 +1,4 @@
+[Resolve]
+DNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com
+DNSOverTLS=yes
+Cache=yes

--- a/mkosi.images/base/mkosi.extra/usr/lib/NetworkManager/conf.d/01-systemd-resolved.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/NetworkManager/conf.d/01-systemd-resolved.conf
@@ -1,0 +1,2 @@
+[main]
+dns=systemd-resolved


### PR DESCRIPTION
fix: Ensure NetworkManager is explicitly configured for systemd-resolved

Fixes #50 