### PR TITLE
fix: correct snowfield surface include path

### DIFF
--- a/mkosi.profiles/snowfield/mkosi.conf
+++ b/mkosi.profiles/snowfield/mkosi.conf
@@ -35,6 +35,6 @@ BuildScripts=%D/shared/snow/scripts/build/surface-cert.chroot
 # snow packages
 Include=%D/shared/packages/snow/mkosi.conf
 # surface kernel
-Include=%D/shared/kernel/surface/mkosi.conf# snow packages
+Include=%D/shared/kernel/surface/mkosi.conf
 # OCI Output
 Include=%D/shared/outformat/oci/mkosi.conf


### PR DESCRIPTION
Fix malformed Include path in the snowfield profile so the surface kernel config is referenced correctly.