### PR TITLE
fix: harden artifact move helper scripts

### DIFF
--- a/manifestmv.sh
+++ b/manifestmv.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
 
 # move manifest files in output directory to a dedicated manifests subdirectory
-set -e
-if [ -z "$OUTPUTDIR" ]; then
+set -euo pipefail
+shopt -s nullglob
+
+if [ -z "${OUTPUTDIR:-}" ]; then
     echo "WARNING: OUTPUTDIR is not set. Defaulting to './output'."
     OUTPUTDIR="output"
 fi
 MANIFEST_DIR="$OUTPUTDIR/manifests"
 mkdir -p "$MANIFEST_DIR"
-for file in "$OUTPUTDIR"/*.manifest.json; do
+
+manifest_files=("$OUTPUTDIR"/*.manifest.json)
+if [ ${#manifest_files[@]} -eq 0 ]; then
+    echo "No manifest files found in $OUTPUTDIR."
+    exit 0
+fi
+
+for file in "${manifest_files[@]}"; do
     # the IMAGE_ID is the text before the first dot in the filename
     IMAGE_ID=$(basename "$file" | cut -d'.' -f1)
     mkdir -p "$MANIFEST_DIR/$IMAGE_ID"
-    if [ -f "$file" ]; then
-        mv "$file" "$MANIFEST_DIR/$IMAGE_ID/"
-        echo "Moved manifest file: $(basename "$file") to $MANIFEST_DIR/$IMAGE_ID/"
-    fi
+    mv "$file" "$MANIFEST_DIR/$IMAGE_ID/"
+    echo "Moved manifest file: $(basename "$file") to $MANIFEST_DIR/$IMAGE_ID/"
 done

--- a/sysextmv.sh
+++ b/sysextmv.sh
@@ -2,16 +2,23 @@
 
 # move sysext files in output directory to a dedicated sysexts subdirectory
 # files we want to move match the pattern <image_id>_<version>_<arch>.<ext>
-set -e
-if [ -z "$OUTPUTDIR" ]; then
+set -euo pipefail
+shopt -s nullglob
+
+if [ -z "${OUTPUTDIR:-}" ]; then
     echo "Error: OUTPUTDIR is not set."
     OUTPUTDIR="output"
 fi
 SYSEXT_DIR="$OUTPUTDIR/sysexts"
 mkdir -p "$SYSEXT_DIR"
-for file in "$OUTPUTDIR"/*_*_*.*; do
-    if [ -f "$file" ]; then
-        mv "$file" "$SYSEXT_DIR/"
-        echo "Moved sysext file: $(basename "$file") to $SYSEXT_DIR/"
-    fi
+
+sysext_files=("$OUTPUTDIR"/*_*_*.*)
+if [ ${#sysext_files[@]} -eq 0 ]; then
+    echo "No sysext files found in $OUTPUTDIR."
+    exit 0
+fi
+
+for file in "${sysext_files[@]}"; do
+    mv "$file" "$SYSEXT_DIR/"
+    echo "Moved sysext file: $(basename "$file") to $SYSEXT_DIR/"
 done


### PR DESCRIPTION
## Summary
- add strict mode to manifest and sysext move scripts
- handle no-match glob cases explicitly with nullglob + early exit
- remove ambiguous wildcard behavior and keep deterministic logging

## Validation
- bash -n manifestmv.sh sysextmv.sh
- ran both scripts against empty and populated temp output dirs