### PR TITLE
chore: gate build script tracing behind DEBUG_BUILD

### DIFF
--- a/mkosi.images/1password-cli/mkosi.postinst.chroot
+++ b/mkosi.images/1password-cli/mkosi.postinst.chroot
@@ -3,4 +3,6 @@
 # Add any customizations here
 set -euo pipefail
 
-set -x
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi

--- a/mkosi.images/docker/mkosi.postinst.chroot
+++ b/mkosi.images/docker/mkosi.postinst.chroot
@@ -3,4 +3,6 @@
 # Add any customizations here
 set -euo pipefail
 
-set -x
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi

--- a/mkosi.images/incus/mkosi.postinst.chroot
+++ b/mkosi.images/incus/mkosi.postinst.chroot
@@ -3,5 +3,6 @@
 # Add any customizations here
 set -euo pipefail
 
-set -x
-
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi

--- a/mkosi.images/podman/mkosi.postinst.chroot
+++ b/mkosi.images/podman/mkosi.postinst.chroot
@@ -3,4 +3,6 @@
 # Add any customizations here
 set -euo pipefail
 
-set -x
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi

--- a/shared/packages/bitwarden/mkosi.postinst.d/bitwarden.chroot
+++ b/shared/packages/bitwarden/mkosi.postinst.d/bitwarden.chroot
@@ -4,7 +4,9 @@
 
 set -euo pipefail
 
-set -x
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
 if [[ "${UID}" == "0" ]]; then
     SUDO=""
 else

--- a/shared/packages/edge/mkosi.postinst.d/edge.chroot
+++ b/shared/packages/edge/mkosi.postinst.d/edge.chroot
@@ -2,7 +2,9 @@
 # Post-install script for sysext
 # Add any customizations here
 set -euo pipefail
-set -x
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
 
 
 if [[ "${UID}" == "0" ]]; then

--- a/shared/packages/vscode/mkosi.postinst.d/vscode.chroot
+++ b/shared/packages/vscode/mkosi.postinst.d/vscode.chroot
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
-set -x
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
 
 if [[ "${UID}" == "0" ]]; then
     SUDO=""


### PR DESCRIPTION
Default build scripts no longer enable xtrace output; tracing is now opt-in via DEBUG_BUILD=1.