### PR TITLE
chore: apply strict mode to packagediff script

### DIFF
--- a/packagediff.sh
+++ b/packagediff.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
+set -euo pipefail
 
-jq -r '.packages[] | .name' output/base.manifest | sort > /tmp/manifest_packages.txt
-grep -v '^Listing' /usr/share/snow/snow.packages.txt | awk -F/ '{print $1}' | sort > /tmp/local_packages.txt
-echo "Manifest packages: $(wc -l < /tmp/manifest_packages.txt)"
-echo "Local packages: $(wc -l < /tmp/local_packages.txt)"
+TMP_MANIFEST=$(mktemp)
+TMP_LOCAL=$(mktemp)
+trap 'rm -f "$TMP_MANIFEST" "$TMP_LOCAL"' EXIT
+
+jq -r '.packages[] | .name' output/base.manifest | sort > "$TMP_MANIFEST"
+grep -v '^Listing' /usr/share/snow/snow.packages.txt | awk -F/ '{print $1}' | sort > "$TMP_LOCAL"
+echo "Manifest packages: $(wc -l < "$TMP_MANIFEST")"
+echo "Local packages: $(wc -l < "$TMP_LOCAL")"
 echo ""
 echo "=== In MANIFEST but NOT on local system ==="
-comm -23 /tmp/manifest_packages.txt /tmp/local_packages.txt
+comm -23 "$TMP_MANIFEST" "$TMP_LOCAL"
 echo ""
 echo "=== On LOCAL system but NOT in manifest ==="
-comm -13 /tmp/manifest_packages.txt /tmp/local_packages.txt
+comm -13 "$TMP_MANIFEST" "$TMP_LOCAL"


### PR DESCRIPTION
Adds set -euo pipefail and replaces fixed /tmp paths with mktemp + trap cleanup in packagediff.sh.