### PR TITLE
chore: dedupe mkosi package definitions

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check mkosi package duplicates
+        run: ./check-duplicate-packages.sh
+
       - name: Generate build date
         id: date
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check mkosi package duplicates
+        run: ./check-duplicate-packages.sh
+
       - name: Generate build date
         id: date
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT

--- a/check-duplicate-packages.sh
+++ b/check-duplicate-packages.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+python3 - <<'PY'
+from collections import defaultdict
+from pathlib import Path
+import subprocess
+import sys
+
+files = subprocess.check_output(
+    ["git", "ls-files", "**/mkosi.conf"], text=True
+).splitlines()
+files = [f for f in files if not f.startswith("saved-unused/")]
+
+has_duplicates = False
+
+for rel_path in files:
+    path = Path(rel_path)
+    lines = path.read_text().splitlines()
+
+    package_lines = defaultdict(list)
+    in_packages = False
+
+    for idx, raw in enumerate(lines, start=1):
+        stripped = raw.strip()
+
+        if not stripped or raw.lstrip().startswith("#"):
+            continue
+
+        entry = None
+        if raw.startswith("Packages="):
+            in_packages = True
+            entry = raw.split("=", 1)[1]
+        elif in_packages and (raw.startswith(" ") or raw.startswith("\t")):
+            entry = raw
+        else:
+            in_packages = False
+
+        if entry is None:
+            continue
+
+        pkg = entry.split("#", 1)[0].strip()
+        if pkg:
+            package_lines[pkg].append(idx)
+
+    duplicates = {pkg: locs for pkg, locs in package_lines.items() if len(locs) > 1}
+    if duplicates:
+        has_duplicates = True
+        print(f"Duplicate package entries in {rel_path}:")
+        for pkg, locs in sorted(duplicates.items()):
+            locs_str = ", ".join(str(n) for n in locs)
+            print(f"  - {pkg}: lines {locs_str}")
+
+if has_duplicates:
+    sys.exit(1)
+
+print("No duplicate package entries found in mkosi.conf files.")
+PY

--- a/mkosi.images/base/mkosi.conf
+++ b/mkosi.images/base/mkosi.conf
@@ -25,13 +25,11 @@ Packages=erofs-utils
          gpg
          iproute2
          iputils-ping
-         network-manager
          rsync
          skopeo
          sudo
          tpm2-tools
          xfsprogs
-         zstd
          systemd-cryptsetup
          libfido2-1
          libfido2-dev

--- a/shared/kernel/backports/mkosi.conf
+++ b/shared/kernel/backports/mkosi.conf
@@ -20,8 +20,6 @@ Packages=linux-image-amd64/trixie-backports
   firmware-intel-sound/trixie-backports
   firmware-iwlwifi/trixie-backports
   firmware-libertas/trixie-backports
-  firmware-linux-nonfree/trixie-backports
-  firmware-linux/trixie-backports
   firmware-marvell-prestera/trixie-backports
   firmware-mediatek/trixie-backports
   firmware-misc-nonfree/trixie-backports

--- a/shared/kernel/stock/mkosi.conf
+++ b/shared/kernel/stock/mkosi.conf
@@ -20,8 +20,6 @@ Packages=linux-image-amd64
   firmware-intel-sound
   firmware-iwlwifi
   firmware-libertas
-  firmware-linux-nonfree
-  firmware-linux
   firmware-marvell-prestera
   firmware-mediatek
   firmware-misc-nonfree

--- a/shared/kernel/surface/mkosi.conf
+++ b/shared/kernel/surface/mkosi.conf
@@ -23,8 +23,6 @@ Packages=linux-image-surface
   firmware-intel-sound/trixie-backports
   firmware-iwlwifi/trixie-backports
   firmware-libertas/trixie-backports
-  firmware-linux-nonfree/trixie-backports
-  firmware-linux/trixie-backports
   firmware-marvell-prestera/trixie-backports
   firmware-mediatek/trixie-backports
   firmware-misc-nonfree/trixie-backports

--- a/shared/packages/snow/mkosi.conf
+++ b/shared/packages/snow/mkosi.conf
@@ -91,11 +91,9 @@ Packages=cups
 
 
 # GNOME extras
-Packages=gnome-backgrounds
-         gnome-browser-connector
+Packages=gnome-browser-connector
          gnome-disk-utility
          gnome-keyring-pkcs11
-         gnome-remote-desktop
          gnome-user-share
          geoclue-2.0
          malcontent
@@ -179,7 +177,6 @@ Packages=apt
          grub-efi-amd64-bin
          grub-efi-amd64-signed
          gstreamer1.0-packagekit
-         gvfs-fuse
          hunspell-en-us
          ibus-gtk
          ibverbs-providers
@@ -189,7 +186,6 @@ Packages=apt
          libalgorithm-diff-perl
          libalgorithm-diff-xs-perl
          libalgorithm-merge-perl
-         libatk-adaptor
          libauthen-sasl-perl
          libbabeltrace1
          libbdplus0
@@ -305,7 +301,6 @@ Packages=apt
          linux-cpupower
          linux-perf
          linux-sysctl-defaults
-         locales-all
          login
          lsb-release
          luit


### PR DESCRIPTION
## Summary
- remove duplicate package entries from active mkosi config files
- add  to detect duplicate  entries
- run duplicate check early in both build workflows

## Validation
- ./check-duplicate-packages.sh
- mkosi --profile snow summary
- mkosi --profile snowfield summary