### PR TITLE
docs: mark legacy artifacts as archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ External repositories are configured in `mkosi.sandbox/etc/apt/` for packages no
 - **linux-surface**: Surface kernel packages
 - **Frostyard**: Custom packages (nbc, chairlift, updex)
 
+Legacy/archival files under `saved-unused/` are kept for historical reference and are not part of active build inputs.
+
 ## CI/CD Pipeline
 
 The project uses GitHub Actions for automated builds and publishing:

--- a/saved-unused/old-plan-not-current.md
+++ b/saved-unused/old-plan-not-current.md
@@ -1,4 +1,7 @@
-# monorepo plan
+# monorepo plan (archival reference only)
+
+> Archived planning notes for a previous repository layout.  
+> This file is not used by current mkosi builds or CI workflows.
 
 ```
                           base            <- stuff that makes debian + bootc


### PR DESCRIPTION
Clarifies that  content is archival only and not part of active build inputs.