### PR TITLE
fix: use which to find the path to just

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set dotenv-load := true
 
-just := "/home/linuxbrew/.linuxbrew/bin/just"
+just := `which just`
 mkosi := `which mkosi`
 
 default:


### PR DESCRIPTION
This PR uses the path for the `just` executable from `which` (e.g. if it's installed in `/usr/bin/just` as is the case in Bluefin)