### PR TITLE
fix: Use deterministic timestamps in Chunkah from last commit time

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -118,9 +118,15 @@ jobs:
             "org.opencontainers.image.url=https://github.com/${{ github.repository_owner }}/${{ env.REPO_NAME }}/tree/${{ github.sha }}" \
             "org.opencontainers.image.documentation=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.REPO_NAME }}/${{ github.sha }}/README.md"
 
+      - name: Compute last commit epoch
+        run: |
+          echo "SOURCE_DATE_EPOCH=$(date -d '${{ github.event.head_commit.timestamp }}' +%s)" >> $GITHUB_ENV
+
       - name: Chunk image
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
+          MAX_LAYERS: 64
+          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
         run: |
           sudo ./shared/outformat/image/chunkah-package.sh \
           "$IMAGE:${{ steps.version.outputs.tag }}"

--- a/shared/outformat/image/chunkah-package.sh
+++ b/shared/outformat/image/chunkah-package.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 IMAGE_REF="$1"
-MAX_LAYERS=64
+MAX_LAYERS="${MAX_LAYERS:-64}"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-}"
 
-echo "==> Chunkifying $IMAGE_REF..."
+echo "==> Chunkifying $IMAGE_REF (Max Layers: $MAX_LAYERS) - Date: $SOURCE_DATE_EPOCH"
 
 # Get config from existing image
 CONFIG=$(podman inspect "$IMAGE_REF")
@@ -16,6 +17,7 @@ LOADED=$(podman run --rm \
     --security-opt label=type:unconfined_t \
     --mount=type=image,src="$IMAGE_REF",dst=/chunkah \
     -e "CHUNKAH_CONFIG_STR=$CONFIG" \
+    -e "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" \
     quay.io/jlebon/chunkah:latest build --max-layers $MAX_LAYERS | podman load)
 
 echo "$LOADED"


### PR DESCRIPTION
chore: Convert MAX_LAYERS to an environment variable for future customization per-image if needed