### PR TITLE
Fix: bootc link in project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A bootable container image build system using [mkosi](https://github.com/systemd
 
 ## What This Project Does
 
-snosi builds immutable, bootable OCI container images based on Debian Trixie. These images are designed for use with [bootc](https://containers.github.io/bootc/) / systemd-boot and can be deployed as atomic, updateable operating system images.
+snosi builds immutable, bootable OCI container images based on Debian Trixie. These images are designed for use with [bootc](https://bootc-dev.github.io/bootc/) / systemd-boot and can be deployed as atomic, updateable operating system images.
 
 The project produces:
 


### PR DESCRIPTION
Updated broken bootc link in README.md to the correct URL.