### PR TITLE
fix: Add latest bootc image recommendations from the chunkah project

### DIFF
--- a/shared/outformat/image/chunkah-package.sh
+++ b/shared/outformat/image/chunkah-package.sh
@@ -18,7 +18,9 @@ LOADED=$(podman run --rm \
     --mount=type=image,src="$IMAGE_REF",dst=/chunkah \
     -e "CHUNKAH_CONFIG_STR=$CONFIG" \
     -e "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" \
-    quay.io/jlebon/chunkah@sha256:9d0cb34737ca390df52be72beff22109e4f97f924e0cc155bfdb7e78410e2fc7 build --max-layers $MAX_LAYERS | podman load)
+    quay.io/jlebon/chunkah@sha256:9d0cb34737ca390df52be72beff22109e4f97f924e0cc155bfdb7e78410e2fc7 \
+    build --prune /sysroot/ --max-layers $MAX_LAYERS \
+    --label ostree.commit- --label ostree.final-diffid- | podman load)
 
 echo "$LOADED"
 


### PR DESCRIPTION
https://github.com/coreos/chunkah?tab=readme-ov-file#compatibility-with-bootable-bootc-images