### PR TITLE
fix: stop enabling conflicting gnome-remote-desktop-headless service

### DIFF
--- a/shared/snow/scripts/postinstall/snow.postinst.chroot
+++ b/shared/snow/scripts/postinstall/snow.postinst.chroot
@@ -58,10 +58,12 @@ systemctl enable gdm.service
 # Enable gnome-remote-desktop user services
 # (systemctl --user enable doesn't work in chroot, create symlinks directly)
 # this doesn't turn on remote desktop by default, just ensures the services are enabled when the user enables them in settings
+# NOTE: gnome-remote-desktop-headless.service declares Conflicts=gnome-remote-desktop.service,
+# so we must NOT enable both — the headless variant is for sessions without a physical display.
 mkdir -p /etc/systemd/user/gnome-session.target.wants
 ln -sf /usr/lib/systemd/user/gnome-remote-desktop.service /etc/systemd/user/gnome-session.target.wants/gnome-remote-desktop.service
 ln -sf /usr/lib/systemd/user/gnome-remote-desktop-handover.service /etc/systemd/user/gnome-session.target.wants/gnome-remote-desktop-handover.service
-ln -sf /usr/lib/systemd/user/gnome-remote-desktop-headless.service /etc/systemd/user/gnome-session.target.wants/gnome-remote-desktop-headless.service
+rm -f /etc/systemd/user/gnome-session.target.wants/gnome-remote-desktop-headless.service
 
 # Add build information to os-release
 # echo "BUILD_ID=\"$BUILD_ID\"" >> /usr/lib/os-release


### PR DESCRIPTION
## Summary

- **Root cause:** `gnome-remote-desktop-headless.service` declares `Conflicts=gnome-remote-desktop.service`, but the build script enabled both in `gnome-session.target.wants/`. The headless variant won the startup race, preventing `gnome-remote-desktop.service` from ever starting on login.
- **Fix:** Remove the headless service enablement and add an explicit `rm -f` cleanup in case `deb-systemd-helper` recreates the symlink during package installation. The headless variant is only for GNOME sessions without a physical display — not applicable to snosi desktop images.

## Test plan

- [ ] Build a snow image and verify `gnome-remote-desktop.service` starts on login
- [ ] Verify `gnome-remote-desktop-handover.service` still starts normally
- [ ] Confirm remote desktop works when enabled in GNOME Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)