### PR TITLE
Add linux-entra-sso to loaded images

### DIFF
--- a/mkosi.profiles/snowfieldloaded/mkosi.conf
+++ b/mkosi.profiles/snowfieldloaded/mkosi.conf
@@ -59,5 +59,7 @@ Include=%D/shared/packages/bitwarden/mkosi.conf
 Include=%D/shared/packages/virt/mkosi.conf
 # Intel Wireless Firmware
 Include=%D/shared/packages/fw-ipw/mkosi.conf
+# Entra SSO
+Include=%D/shared/packages/entra-sso/mkosi.conf
 # Image Output
 Include=%D/shared/outformat/image/mkosi.conf

--- a/mkosi.profiles/snowloaded/mkosi.conf
+++ b/mkosi.profiles/snowloaded/mkosi.conf
@@ -59,6 +59,8 @@ Include=%D/shared/packages/bitwarden/mkosi.conf
 Include=%D/shared/packages/virt/mkosi.conf
 # Intel Wireless Firmware
 Include=%D/shared/packages/fw-ipw/mkosi.conf
+# Entra SSO
+Include=%D/shared/packages/entra-sso/mkosi.conf
 # Image Output
 Include=%D/shared/outformat/image/mkosi.conf
 

--- a/shared/packages/entra-sso/mkosi.conf
+++ b/shared/packages/entra-sso/mkosi.conf
@@ -1,0 +1,2 @@
+[Content]
+Packages=linux-entra-sso/trixie-backports


### PR DESCRIPTION
## Summary
- Add `linux-entra-sso` package from trixie-backports to snowloaded and snowfieldloaded desktop images
- Create shared package config at `shared/packages/entra-sso/mkosi.conf`
- Include the new config in both loaded profile definitions

## Test plan
- [x] Verify `linux-entra-sso` appears in snowloaded image manifest after build
- [x] Verify `linux-entra-sso` appears in snowfieldloaded image manifest after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)