### PR TITLE
feat: add code-server sysext

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -51,6 +51,15 @@ jobs:
             echo "emdash_version=$LATEST_EM" >> $GITHUB_OUTPUT
           fi
 
+          # Check code-server
+          CURRENT_CS=$(jq -r '.["code-server"].version' "$CHECKSUMS")
+          LATEST_CS=$(curl -s https://api.github.com/repos/coder/code-server/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_CS" && "$LATEST_CS" != "$CURRENT_CS" ]]; then
+            UPDATES="${UPDATES}code-server: $CURRENT_CS -> $LATEST_CS\n"
+            echo "codeserver_update=true" >> $GITHUB_OUTPUT
+            echo "codeserver_version=$LATEST_CS" >> $GITHUB_OUTPUT
+          fi
+
           # Check Surface cert (less frequent changes)
           CURRENT_SURF=$(jq -r '.["surface-cert"].version' "$CHECKSUMS")
           LATEST_SURF=$(curl -s https://api.github.com/repos/linux-surface/linux-surface/commits?path=pkg/keys/surface.cer | jq -r '.[0].sha' | head -c 12)
@@ -130,6 +139,18 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
               '.emdash.url=$u | .emdash.sha256=$s | .emdash.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "${{ steps.check.outputs.codeserver_update }}" == "true" ]]; then
+            VER="${{ steps.check.outputs.codeserver_version }}"
+            URL="https://github.com/coder/code-server/releases/download/v${VER}/code-server_${VER}_amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.["code-server"].url=$u | .["code-server"].sha256=$s | .["code-server"].version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 4 OCI desktop images (snow, snowloaded, snowfield, snowfieldloaded), 2 OCI server images (cayo, cayoloaded), and 10 sysext overlay images (1password-cli, debdev, dev, docker, emdash, himmelblau, incus, nix, podman, tailscale).
+**Outputs:** 4 OCI desktop images (snow, snowloaded, snowfield, snowfieldloaded), 2 OCI server images (cayo, cayoloaded), and 11 sysext overlay images (1password-cli, code-server, debdev, dev, docker, emdash, himmelblau, incus, nix, podman, tailscale).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: mkosi v24+, just, root/sudo access.
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 10 sysexts
+just sysexts            # Build base + all 11 sysexts
 just snow               # Build snow desktop image
 just snowloaded         # Build snowloaded variant
 just snowfield          # Build snowfield (Surface kernel)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The project produces:
 | **cayo**            | Headless server with podman + backports kernel                  | OCI archive   |
 | **cayoloaded**      | cayo + Docker + Incus (baked in)                                | OCI archive   |
 | **1password-cli**   | 1Password CLI tool                                              | sysext        |
+| **code-server**     | code-server (VS Code in the browser)                            | sysext        |
 | **debdev**          | Debian development tools (debootstrap, distro-info)             | sysext        |
 | **dev**             | Build essentials, Python, cmake, valgrind, gdb                  | sysext        |
 | **docker**          | Docker CE container runtime                                     | sysext        |
@@ -36,9 +37,9 @@ The project produces:
                 ┌───────────────┴───────────────┐
                 │                               │
              sysexts                         profiles
-    ┌────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
-    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
-  1pass debdev dev docker emdash himmelblau incus nix podman tailscale │         │
+    ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
+    │    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
+  1pass code-server debdev dev docker emdash himmelblau incus nix podman tailscale │         │
                                      snow            cayo
                                ┌──────┼──────┐        │
                                │      │      │    cayoloaded
@@ -64,6 +65,7 @@ Sysexts are overlay images that extend the base system without modifying it. The
 | Sysext            | Contents                                      | Config                                                                         |
 | ----------------- | --------------------------------------------- | ------------------------------------------------------------------------------ |
 | **1password-cli** | 1Password CLI tool                            | [mkosi.images/1password-cli/mkosi.conf](mkosi.images/1password-cli/mkosi.conf) |
+| **code-server**   | code-server (VS Code in the browser)          | [mkosi.images/code-server/mkosi.conf](mkosi.images/code-server/mkosi.conf)     |
 | **debdev**        | debootstrap, distro-info, archive keyrings    | [mkosi.images/debdev/mkosi.conf](mkosi.images/debdev/mkosi.conf)               |
 | **dev**           | build-essential, cmake, Python, valgrind, gdb | [mkosi.images/dev/mkosi.conf](mkosi.images/dev/mkosi.conf)                     |
 | **docker**        | Docker CE, containerd, buildx, compose        | [mkosi.images/docker/mkosi.conf](mkosi.images/docker/mkosi.conf)               |
@@ -258,7 +260,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all sysexts (1password-cli, debdev, dev, docker, emdash, himmelblau, incus, nix, podman, tailscale)
+1. Builds the base image and all sysexts (1password-cli, code-server, debdev, dev, docker, emdash, himmelblau, incus, nix, podman, tailscale)
 2. Publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Uploads package manifests for version tracking
 

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -2,6 +2,7 @@
 # list base + any sysexts that get built by default
 Dependencies=base
              1password-cli
+             code-server
              debdev
              dev
              docker

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/code-server.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/code-server.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=code-server (VS Code in the browser) from Coder
+Documentation=https://github.com/coder/code-server
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/code-server.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/code-server.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=code-server
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/code-server/
+MatchPattern=code-server_@v_%w_%a.raw.zst \
+             code-server_@v_%w_%a.raw.xz \
+             code-server_@v_%w_%a.raw.gz \
+             code-server_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=code-server_@v_%w_%a.raw.zst \
+             code-server_@v_%w_%a.raw.xz \
+             code-server_@v_%w_%a.raw.gz \
+             code-server_@v_%w_%a.raw
+CurrentSymlink=code-server.raw

--- a/mkosi.images/code-server/mkosi.conf
+++ b/mkosi.images/code-server/mkosi.conf
@@ -1,0 +1,15 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=code-server
+Output=code-server
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+Environment=KEYPACKAGE=code-server

--- a/mkosi.images/code-server/mkosi.postinst.chroot
+++ b/mkosi.images/code-server/mkosi.postinst.chroot
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+source "$SRCDIR/shared/download/verified-download.sh"
+mkdir -p debs
+verified_download "code-server" "debs/code-server.deb"
+
+dpkg -i debs/code-server.deb
+rm -rf debs

--- a/mkosi.images/nix/mkosi.conf
+++ b/mkosi.images/nix/mkosi.conf
@@ -13,7 +13,6 @@ Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
 Environment=KEYPACKAGE=nix-setup-systemd
-PostInstallationScripts=mkosi.postinst.chroot
 
 # Nix package manager
 Packages=nix-setup-systemd

--- a/shared/download/checksums.json
+++ b/shared/download/checksums.json
@@ -24,6 +24,11 @@
     "sha256": "dfd5145fe2aa5956a600e35848765273f5798ce6def01bd08ecec088a1268d91",
     "version": "63bc55817cae"
   },
+  "code-server": {
+    "url": "https://github.com/coder/code-server/releases/download/v4.116.0/code-server_4.116.0_amd64.deb",
+    "sha256": "a79c5c7f45447fe9ebe56ebc87543380633c000993da70c5c393d0fa3d287755",
+    "version": "4.116.0"
+  },
   "emdash": {
     "url": "https://github.com/generalaction/emdash/releases/download/v0.4.49/emdash-amd64.deb",
     "sha256": "2d0475edbde85666e415e4cdcff4c97a1663b22424524124f209e0fd2b9418c3",

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -24,7 +24,7 @@ snosi is a bootable container image build system that uses [mkosi](https://githu
 
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
-1password-cli, debdev, dev, docker, emdash, himmelblau, incus, nix, podman, tailscale
+1password-cli, code-server, debdev, dev, docker, emdash, himmelblau, incus, nix, podman, tailscale
 
 ## Architecture
 
@@ -34,7 +34,7 @@ snosi is a bootable container image build system that uses [mkosi](https://githu
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 10 sysexts)
+mkosi.images/               # Image definitions (base + 11 sysexts)
   base/                     # Foundation image: systemd, bootc, firmware, core utils
     mkosi.extra/            # Extra filesystem overlay (dracut, systemd units, tmpfiles, sysusers)
       usr/lib/sysupdate.d/  # .transfer + .feature files for all sysexts
@@ -167,7 +167,7 @@ Images are built as directories, then packaged into OCI via `buildah-package.sh`
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 10 sysexts
+just sysexts            # Build base + all 11 sysexts
 just snow               # Build snow desktop
 just snowloaded         # Build snowloaded variant
 just snowfield          # Build snowfield (Surface)

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -6,7 +6,7 @@
 
 **Trigger:** Push/PR to main, manual dispatch
 
-Builds the base image and all 10 sysexts, publishes to the Frostyard repository on Cloudflare R2.
+Builds the base image and all 11 sysexts, publishes to the Frostyard repository on Cloudflare R2.
 
 **Steps:**
 1. Aggressive cleanup of runner (removes JDK, .NET, Android SDK, etc. to free disk space)

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -17,6 +17,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | Sysext | KEYPACKAGE | Description |
 |--------|------------|-------------|
 | **1password-cli** | 1password-cli | 1Password CLI tool |
+| **code-server** | code-server | code-server (VS Code in the browser) — downloaded via `verified_download()` from coder/code-server GitHub releases |
 | **debdev** | debootstrap | Debian development tools (debootstrap, distro-info, arch-test) |
 | **dev** | build-essential | Build essentials, cmake, Python3, valgrind, gdb, strace |
 | **docker** | docker-ce | Docker CE, containerd, buildx, compose |
@@ -62,6 +63,9 @@ Key settings:
 ## Sysext-Specific Extra Files
 
 Some sysexts include extra files via `mkosi.extra/`:
+
+### code-server
+- `mkosi.postinst.chroot` — Downloads code-server .deb via `verified_download()`, installs with `dpkg -i`. Upstream package targets `/usr/lib/code-server` with `/usr/bin/code-server` symlink and systemd units under `/usr/lib/systemd/`, so no relocation is required.
 
 ### emdash
 - `mkosi.postinst.chroot` — Downloads emdash .deb via `verified_download()`, relocates `/opt/Emdash` → `/usr/lib/emdash`, creates `/usr/bin/emdash` symlink, sets SUID on chrome-sandbox


### PR DESCRIPTION
## Summary
- New sysext for Coder's [code-server](https://github.com/coder/code-server) (VS Code in the browser), pinned to v4.116.0. Upstream .deb installs to `/usr/lib/code-server` with a `/usr/bin/code-server` symlink, so no `/opt` relocation is needed.
- Registered in base `sysupdate.d` (defaults to `Enabled=false`), added to root `mkosi.conf` dependencies, and wired into the weekly `check-dependencies.yml` update check.
- Drive-by fix: removed a dangling `PostInstallationScripts=mkosi.postinst.chroot` from `mkosi.images/nix/mkosi.conf` (referenced file was deleted in 61ab86f). Newer mkosi errors hard on the missing file, breaking `just sysexts` locally — CI's pinned mkosi tolerated it.

## Test plan
- [x] `just sysexts` builds all 11 sysexts, including `code-server_4.116.0_13_x86-64.raw` (~428 MiB)
- [x] `shellcheck` clean on `mkosi.images/code-server/mkosi.postinst.chroot`
- [x] `jq` validates new `code-server` entry in `checksums.json`
- [x] Workflow YAML parses (`check-dependencies.yml`)
- [ ] CI `build.yml` green on this branch
- [ ] Manual smoke test: activate sysext on a running snosi host and hit `code-server` on the default port

🤖 Generated with [Claude Code](https://claude.com/claude-code)