### PR TITLE
fix: run dconf update in postinstall to compile GNOME settings databases

### DIFF
--- a/shared/snow/scripts/postinstall/snow.postinst.chroot
+++ b/shared/snow/scripts/postinstall/snow.postinst.chroot
@@ -26,6 +26,9 @@ ln -sf /usr/lib/systemd/user/gnome-remote-desktop.service /etc/systemd/user/gnom
 ln -sf /usr/lib/systemd/user/gnome-remote-desktop-handover.service /etc/systemd/user/gnome-session.target.wants/gnome-remote-desktop-handover.service
 rm -f /etc/systemd/user/gnome-session.target.wants/gnome-remote-desktop-headless.service
 
+# Compile dconf databases to avoid "expect degraded performance" warnings in GNOME services
+dconf update
+
 # Remove fish desktop entry
 rm -f /usr/share/applications/fish.desktop
 


### PR DESCRIPTION
Without this, GNOME services log 'unable to open file /etc/dconf/db/local' and 'expect degraded performance' on every session start.