### PR TITLE
docs: document Upholds= drop-in as required pattern for sysext services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ Sysexts can ONLY provide files under `/usr`. They cannot modify `/etc` or `/var`
 
 Every sysext must have matching `<name>.transfer` and `<name>.feature` files in `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/`. The `.transfer` file defines how systemd-sysupdate downloads the sysext; the `.feature` file provides metadata and defaults to `Enabled=false`. Use existing files as templates.
 
+**Service activation in sysexts:** Do NOT rely on `WantedBy=multi-user.target` + preset alone. At boot, the sysext is not yet merged when PID 1 scans units — the `.wants/` symlink is dangling and silently dropped. Always ship a `usr/lib/systemd/system/multi-user.target.d/10-<name>.conf` drop-in inside the sysext with `[Unit]\nUpholds=<name>.service`. This drop-in is new to systemd after the post-merge daemon-reload, so activation fires correctly. The preset is still required for enabled state; the drop-in handles timing.
+
 The shared sysext postoutput script (`shared/sysext/postoutput/sysext-postoutput.sh`) handles versioned naming and manifest processing. It requires the `KEYPACKAGE` env var set in each sysext's `mkosi.conf`.
 
 ## Key Directories

--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ When creating a new sysext, verify:
 - [ ] Symlinks/alternatives created manually (no `update-alternatives`)
 - [ ] State directories expected in `/var` (not baked into image)
 - [ ] Use tmpfiles.d, sysusers.d and systemd presets first, as a last resort add a one-shot systemd unit for any preconfiguration that usually would happen in the debian package's postinst scripts
+- [ ] **If the sysext ships a systemd service:** add `usr/lib/systemd/system/multi-user.target.d/10-<name>.conf` with `[Unit]\nUpholds=<name>.service` — do NOT rely on `WantedBy=` + preset alone (the sysext isn't merged when PID 1 first scans units)
 
 #### Basic Sysext Template
 

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -93,6 +93,7 @@ Some sysexts include extra files via `mkosi.extra/`:
 
 ### tailscale
 - `usr/lib/systemd/system-preset/40-tailscale.preset` — Enable tailscaled
+- `usr/lib/systemd/system/multi-user.target.d/10-tailscale.conf` — `Upholds=tailscaled.service` drop-in for reliable boot activation
 - `usr/lib/tmpfiles.d/tailscale-sysext.conf` — Runtime directory setup
 
 ## Version Extraction and Naming
@@ -144,6 +145,27 @@ Enabled=false
 
 All sysexts default to `Enabled=false` — users opt in via systemd-sysupdate configuration.
 
+## Service Activation Pattern (Upholds=)
+
+**Do not rely on `WantedBy=multi-user.target` + preset alone for sysext-provided services.** This combination breaks at boot because:
+
+1. PID 1 scans unit files before the sysext is merged — `tailscaled.service` doesn't exist yet
+2. The `/etc/systemd/system/multi-user.target.wants/` symlink points to a missing file and is silently dropped
+3. After `reload-sysext.service` merges the overlay and runs `daemon-reload`, the previously-dropped `Wants=` is not re-triggered
+
+**Required pattern:** Ship a `multi-user.target.d/10-<name>.conf` drop-in **inside the sysext** with:
+
+```ini
+[Unit]
+Upholds=<name>.service
+```
+
+This drop-in is brand-new to systemd after the post-merge `daemon-reload`, so it is processed cleanly when `multi-user.target` activates. `Upholds=` also provides crash-restart behavior — if the service dies, systemd will restart it.
+
+Example path inside the sysext: `usr/lib/systemd/system/multi-user.target.d/10-tailscale.conf`
+
+The preset (`40-<name>.preset`) is still required to set the enabled state; the drop-in handles the activation timing.
+
 ## Runtime Setup Service Pattern
 
 Some sysexts need to modify files that already exist in the base image (e.g., `/etc/nsswitch.conf`, PAM configs). The tmpfiles `C` (copy-if-absent) directive cannot overwrite existing files, so a runtime setup service is needed instead.
@@ -162,5 +184,6 @@ The setup script must be idempotent — safe to run on every boot without accumu
 3. Add any extra files in `mkosi.images/<name>/mkosi.extra/`
 4. If configs needed in `/etc`: create `mkosi.finalize` to capture to `/usr/share/factory/etc/`, add tmpfiles.d rules
 5. Create `<name>.transfer` and `<name>.feature` in `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/`
-6. Add the sysext name to root `mkosi.conf` Dependencies list
+6. **If the sysext ships a systemd service:** add `usr/lib/systemd/system/multi-user.target.d/10-<name>.conf` with `Upholds=<name>.service` (see [Service Activation Pattern](#service-activation-pattern-upholds) above)
+7. Add the sysext name to root `mkosi.conf` Dependencies list
 7. Add a corresponding update check to `.github/workflows/check-dependencies.yml` if it has external downloads


### PR DESCRIPTION
## Summary

Documents the `Upholds=` drop-in pattern as the required approach for any sysext that ships a systemd service.

## Background

`WantedBy=multi-user.target` + preset alone silently fails for sysext-provided services. The root cause:

1. PID 1 scans unit files at startup — the sysext is **not yet merged**, so the service unit doesn't exist
2. The `.wants/` symlink is dangling → systemd silently drops the `Wants=` reference
3. After `reload-sysext.service` merges the overlay and runs `daemon-reload`, the already-evaluated wants list for `multi-user.target` is not re-triggered

The fix (already applied to tailscale in #238 and verified in production): ship `usr/lib/systemd/system/multi-user.target.d/10-NAME.conf` inside the sysext with `Upholds=NAME.service`. Since this drop-in is brand-new to systemd after the daemon-reload, it fires correctly when `multi-user.target` activates.

## Changes

- **`yeti/sysexts.md`**: New "Service Activation Pattern (Upholds=)" section explaining the problem and fix; updated tailscale extra files entry; added step to "Adding a New Sysext" list
- **`README.md`**: Added checklist item to the sysext checklist  
- **`CLAUDE.md`**: Added note to the sysext constraints paragraph so AI agents know about this when creating new sysexts