### PR TITLE
fix(docker): add Upholds= drop-in for reliable boot-time activation

### DIFF
--- a/mkosi.images/docker/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-docker.conf
+++ b/mkosi.images/docker/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-docker.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=docker.service


### PR DESCRIPTION
The `WantedBy=multi-user.target` + preset approach doesn't reliably work for sysext-provided services. At PID 1 startup the sysext hasn't been merged yet, so the `/etc/systemd/system/multi-user.target.wants/` symlink points to a missing unit file. systemd silently drops the dangling `Wants=` reference and never retriggers it after the daemon-reload that `reload-sysext.service` performs.

Add `usr/lib/systemd/system/multi-user.target.d/10-docker.conf` to the sysext with `Upholds=docker.service`. This drop-in is brand-new to systemd after the post-merge daemon-reload, so it is processed cleanly when `multi-user.target` activates — ensuring dockerd starts on every boot without modification to the base image.

Same fix as applied to tailscale in #238.