### PR TITLE
fix(ci): resolve image-build disk exhaustion on runner /

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -28,6 +28,9 @@ jobs:
       id-token: write
       attestations: write
     strategy:
+      # Don't let one variant's failure (e.g. disk exhaustion on a "loaded"
+      # image) cancel the other in-flight builds. Each variant is independent.
+      fail-fast: false
       matrix:
         include:
           - profile: cayo
@@ -49,11 +52,26 @@ jobs:
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          # We don't use the runner's preinstalled language toolchains; reclaim
+          # the tool cache (~8-12GB) on / for extra headroom on large builds.
+          tool-cache: true
 
       - name: Mount BTRFS for podman storage
         uses: ublue-os/container-storage-action@main
         with:
           target-dir: /var/lib/containers
+
+      - name: Redirect temp to /mnt
+        # / (/dev/root) has ~45G free after cleanup; /mnt has ~70G free. mkosi's
+        # build workspace and podman/buildah tar staging default to TMPDIR
+        # (/var/tmp on /), which overflows / on the large "loaded" variants and
+        # crashes the runner with "No space left on device". Point TMPDIR at the
+        # roomy /mnt volume for all subsequent steps.
+        run: |
+          sudo mkdir -p /mnt/tmp
+          sudo chmod 1777 /mnt/tmp
+          echo "TMPDIR=/mnt/tmp" >> "$GITHUB_ENV"
 
       - name: Show disk space (after)
         run: sudo df -h
@@ -79,7 +97,7 @@ jobs:
 
       - name: Build Image
         run: |
-          sudo mkosi --profile ${{ matrix.profile }} \
+          sudo TMPDIR="$TMPDIR" mkosi --profile ${{ matrix.profile }} \
             --image-version "${{ steps.version.outputs.tag }}" \
             build
 
@@ -87,7 +105,7 @@ jobs:
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
         run: |
-          sudo ./shared/outformat/image/buildah-package.sh \
+          sudo TMPDIR="$TMPDIR" ./shared/outformat/image/buildah-package.sh \
             output/${{ matrix.profile }} \
             "$IMAGE:${{ steps.version.outputs.tag }}" \
             "org.opencontainers.image.title=${{ matrix.profile }}" \
@@ -104,7 +122,7 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
           MAX_LAYERS: 128
         run: |
-          sudo ./shared/outformat/image/chunkah-package.sh \
+          sudo TMPDIR="$TMPDIR" ./shared/outformat/image/chunkah-package.sh \
           "$IMAGE:${{ steps.version.outputs.tag }}" \
           $(date -d '${{ github.event.head_commit.timestamp }}' +%s)
 
@@ -135,7 +153,7 @@ jobs:
         run: |
           SBOM="$(mktemp -d)/sbom.json"
           export SYFT_PARALLELISM=$(($(nproc)*2))
-          sudo "${SYFT_CMD}" --source-name "${PROFILE}" "output/${PROFILE}" -o "syft-json=${SBOM}"
+          sudo TMPDIR="$TMPDIR" "${SYFT_CMD}" --source-name "${PROFILE}" "output/${PROFILE}" -o "syft-json=${SBOM}"
           du -sh "${SBOM}"
           echo "SBOM=${SBOM}" >> "$GITHUB_OUTPUT"
 
@@ -145,7 +163,7 @@ jobs:
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
         run: |
-          sudo buildah push \
+          sudo TMPDIR="$TMPDIR" buildah push \
             --compression-format=zstd:chunked \
             --digestfile=/tmp/image-digest \
             --creds="${{ github.actor }}:${{ secrets.GHCR_PAT }}" \
@@ -162,7 +180,7 @@ jobs:
           sudo buildah tag \
             "$IMAGE:${{ steps.version.outputs.tag }}" \
             "$IMAGE:latest"
-          sudo buildah push \
+          sudo TMPDIR="$TMPDIR" buildah push \
             --compression-format=zstd:chunked \
             --creds="${{ github.actor }}:${{ secrets.GHCR_PAT }}" \
             "$IMAGE:latest" \


### PR DESCRIPTION
## Problem

`Build Image Variants` (`build-images.yml`) has been failing intermittently for ~3 days. Root cause is **disk exhaustion on the runner root filesystem (`/dev/root`, 72G)**, not a code regression.

- A `*loaded` variant (the largest images) is always the first/root job to die.
- The runner worker crashes with `System.IO.IOException: No space left on device` (it can't even write its own `_diag` log); other runs show `printf: I/O error`. The failing step produces **zero log output**.
- With the default `fail-fast: true`, that one death cancels the other 5 matrix jobs ("strategy configuration was canceled"), making it look like a total wipeout when only one job actually failed.
- It's intermittent because each `auto-update-packages` / `auto-update-checksums` PR grows the images, riding the edge of `/`'s capacity.

### Why `/` and not `/mnt`

`ublue-os/container-storage-action` relocates only `/var/lib/containers` (podman/buildah graphroot) to `/mnt` (74G, ~70G free). But mkosi's build workspace and podman/buildah tar staging default to `TMPDIR` (`/var/tmp` on `/`), which fills the ~45G free on `/`.

## Fix

- **`TMPDIR=/mnt/tmp`** for all heavy `sudo` steps (mkosi, buildah-package, chunkah, syft, buildah push). `sudo` strips the environment, so it's passed explicitly as `sudo TMPDIR="$TMPDIR" …`. This moves the entire image assembly + tar staging off `/` onto the roomy `/mnt` volume.
- **`strategy.fail-fast: false`** so one variant's failure no longer cancels the other independent builds.
- **`tool-cache: true`** on `jlumbroso/free-disk-space` to reclaim ~8–12G of unused toolchain cache on `/`.

## Verification

YAML validated; change is isolated to `build-images.yml`. Real proof is a green CI run on this PR.

## Follow-up (not in this PR)

If loaded variants keep growing, consider also relocating mkosi's `output/` to `/mnt` or splitting loaded variants into a separate job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)