### PR TITLE
feat: compile bootc + ostree from source in the base image

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -51,6 +51,27 @@ jobs:
             echo "codeserver_version=$LATEST_CS" >> $GITHUB_OUTPUT
           fi
 
+          # Check ostree
+          CURRENT_OSTREE=$(jq -r '.ostree.version' "$CHECKSUMS")
+          LATEST_OSTREE=$(curl -s https://api.github.com/repos/ostreedev/ostree/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_OSTREE" && "$LATEST_OSTREE" != "$CURRENT_OSTREE" ]]; then
+            UPDATES="${UPDATES}ostree: $CURRENT_OSTREE -> $LATEST_OSTREE\n"
+            echo "ostree_update=true" >> $GITHUB_OUTPUT
+            echo "ostree_version=$LATEST_OSTREE" >> $GITHUB_OUTPUT
+          fi
+
+          # Check bootc (bootc + bootc-vendor version together)
+          # NOTE: on a bootc bump, also re-check RUST_VERSION in
+          # shared/bootc/build/bootc.chroot — a new bootc release may raise the
+          # rustc version needed to BUILD it (its build deps, not just MSRV).
+          CURRENT_BOOTC=$(jq -r '.bootc.version' "$CHECKSUMS")
+          LATEST_BOOTC=$(curl -s https://api.github.com/repos/bootc-dev/bootc/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_BOOTC" && "$LATEST_BOOTC" != "$CURRENT_BOOTC" ]]; then
+            UPDATES="${UPDATES}bootc: $CURRENT_BOOTC -> $LATEST_BOOTC\n"
+            echo "bootc_update=true" >> $GITHUB_OUTPUT
+            echo "bootc_version=$LATEST_BOOTC" >> $GITHUB_OUTPUT
+          fi
+
           # Check Surface cert (less frequent changes)
           CURRENT_SURF=$(jq -r '.["surface-cert"].version' "$CHECKSUMS")
           LATEST_SURF=$(curl -s https://api.github.com/repos/linux-surface/linux-surface/commits?path=pkg/keys/surface.cer | jq -r '.[0].sha' | head -c 12)
@@ -132,6 +153,35 @@ jobs:
               '.["code-server"].url=$u | .["code-server"].sha256=$s | .["code-server"].version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
+          fi
+
+          if [[ "${{ steps.check.outputs.ostree_update }}" == "true" ]]; then
+            VER="${{ steps.check.outputs.ostree_version }}"
+            URL="https://github.com/ostreedev/ostree/releases/download/v${VER}/libostree-${VER}.tar.xz"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.ostree.url=$u | .ostree.sha256=$s | .ostree.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "${{ steps.check.outputs.bootc_update }}" == "true" ]]; then
+            VER="${{ steps.check.outputs.bootc_version }}"
+            URL="https://github.com/bootc-dev/bootc/releases/download/v${VER}/bootc-${VER}.tar.zstd"
+            VURL="https://github.com/bootc-dev/bootc/releases/download/v${VER}/bootc-${VER}-vendor.tar.zstd"
+            TMP=$(mktemp); VTMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            curl -fsSL -o "$VTMP" "$VURL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            VSHA=$(sha256sum "$VTMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+               --arg vu "$VURL" --arg vs "$VSHA" \
+              '.bootc.url=$u | .bootc.sha256=$s | .bootc.version=$v
+               | .["bootc-vendor"].url=$vu | .["bootc-vendor"].sha256=$vs | .["bootc-vendor"].version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP" "$VTMP"
           fi
 
           if [[ "${{ steps.check.outputs.brew_update }}" == "true" ]]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,19 @@ Scripts execute in order: **BuildScripts** (in chroot) -> **PostInstallationScri
 
 **Critical pattern:** Packages installing to `/opt` must be relocated to `/usr/lib/<package>` at build time with symlinks in `/usr/bin`. This applies to both desktop images and sysexts.
 
+### Base Image: In-Tree bootc + ostree Build
+
+bootc and ostree are **not** installed from APT; they are compiled from pinned source during the base image build.
+
+- **Why:** `frostyard/bootc-debian` (the former private packaging repo) is archived. Debian Trixie ships no bootc package and only ostree 2025.2 (too old for current bootc).
+- **Where:** `shared/bootc/build/bootc.chroot` runs as a mkosi `BuildScript` (wired via `BuildScripts=` in `mkosi.images/base/mkosi.conf`). (The image rootfs has no `apt` — mkosi manages packages externally — so build deps cannot be apt-installed from inside a postinstall chroot; a BuildScript with `BuildPackages=` is required.)
+- **Versions:** Pinned in `shared/download/checksums.json` (keys `ostree`, `bootc`, `bootc-vendor`); tracked weekly by `check-dependencies.yml`.
+- **Build deps:** declared in `BuildPackages=` in `mkosi.images/base/mkosi.conf`. mkosi installs them into the build overlay only; the overlay (and every build dep) is discarded after the build script, so they never ship in the image. There is no `apt` call and no purge logic in the script.
+- **Rust toolchain:** Debian's `rustc` (1.85) is too old to *build* bootc 1.16.2 (its xtask/build deps need rustc ≥ 1.91). The script installs a pinned toolchain (`RUST_VERSION`) via `rustup` (from `BuildPackages=`) and runs `make` under `rustup run`.
+- **ostree double-install:** the BuildScript runs `make install DESTDIR="$DESTDIR"` (ships in image) AND `make install DESTDIR=` (explicit empty — mkosi exports `DESTDIR` into the build env, so the empty value is needed to install into the overlay's real `/usr` so the bootc build finds `ostree-1.pc` and can run the bootc binary for docgen).
+- **dpkg registration:** `shared/bootc/postinst/bootc-register.chroot` (a `PostInstallationScript`) builds metadata-only stub `.deb`s (versions from `checksums.json`) and `dpkg -i`s them, so `dpkg -l`/`apt list --installed` and dependency checks see `bootc` + `libostree-1-1` as installed. The files come from the BuildScript; dpkg does not own them.
+- **Runtime libs:** bootc/ostree runtime dependencies (e.g. `libglib2.0-0t64`, `libcurl4t64`) are listed in base `Packages=` so they ship in the image and the compiled binaries link against them at runtime.
+
 ### Sysext Constraints
 
 Sysexts can ONLY provide files under `/usr`. They cannot modify `/etc` or `/var` at runtime. Configs needed in `/etc` must be:
@@ -70,6 +83,7 @@ The shared sysext postoutput script (`shared/sysext/postoutput/sysext-postoutput
 ## Key Directories
 
 - `shared/download/` - Verified download system: `checksums.json` pins URLs+SHA256s, `verified-download.sh` provides the `verified_download()` helper
+- `shared/bootc/` - In-tree source build of bootc (v1.16.2) and ostree (v2026.1); `build/bootc.chroot` is a base image **BuildScript** (wired via `BuildScripts=`); build deps come from `BuildPackages=` (overlay-only, discarded after build); compiles both tools (autotools for ostree, offline vendored cargo for bootc) and installs into `$DESTDIR`, which mkosi copies into the image
 - `shared/kernel/` - Kernel configs (backports, surface, stock) and dracut scripts
 - `shared/packages/` - Package set definitions, some with postinstall scripts for relocation
 - `shared/outformat/image/` - Image output format config (directory), finalize scripts, and `buildah-package.sh` for OCI packaging

--- a/docs/superpowers/plans/2026-06-29-inline-bootc-build.md
+++ b/docs/superpowers/plans/2026-06-29-inline-bootc-build.md
@@ -1,0 +1,510 @@
+# Inline bootc + ostree Build Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compile ostree and bootc from pinned source inside the snosi base image build, and remove the `bootc` and `libostree-1-1` APT packages that came from the (now-archived) Frostyard packaging repo.
+
+**Architecture:** A `postinst.chroot` script runs inside the base image chroot. It installs build dependencies via apt, downloads SHA256-verified release tarballs through the existing `verified_download` helper, compiles ostree (autotools) and bootc (Cargo, offline vendored) directly into the image's `/usr`, then purges the build-only dependencies. The two ex-APT packages are dropped from `mkosi.images/base/mkosi.conf`, and ostree's runtime shared libraries are added to `Packages=` so they survive the post-build purge.
+
+**Tech Stack:** mkosi, bash, autotools (ostree), Cargo/rustc (bootc), Debian Trixie.
+
+## Global Constraints
+
+- **bootc version:** `v1.16.2` — tarball `bootc-1.16.2.tar.zstd`, vendor `bootc-1.16.2-vendor.tar.zstd`.
+- **ostree version:** `v2026.1` — tarball `libostree-2026.1.tar.xz`.
+- **Rust toolchain:** Debian Trixie's `rustc` (1.85) is too OLD to build bootc 1.16.2 — its xtask/build deps (`cargo_metadata`, `cargo-platform`) need rustc >= 1.91 despite the crate's declared MSRV of 1.85. The build script installs a pinned toolchain (`RUST_VERSION=1.96.0`) via `rustup` (from `BuildPackages=`) and runs `make` under `rustup run "$RUST_VERSION"`. (Do NOT rely on Debian's rustc/cargo.)
+- **Pinning:** every external download has a `checksums.json` entry (URL + SHA256 + version) and a matching update check in `.github/workflows/check-dependencies.yml`. Never `latest`/branch names.
+- **Shell scripts:** `set -euo pipefail` at top; build scripts that run in chroot use `.chroot` extension; pass shellcheck (`validate.yml` enforces it).
+- **Build mechanism:** ostree/bootc are compiled by a mkosi **BuildScript**; build deps come from `BuildPackages=` (build-overlay only) and the artifacts are installed to `$DESTDIR`. The image rootfs has no `apt`, so build deps are NOT apt-installed in-script. Build deps must NOT remain in the final image (mkosi discards the overlay automatically).
+- **Immutable FS:** all compiled files land under `/usr` (ostree's `--sysconfdir=/etc` config files are the one intentional exception, matching prior dpkg behavior).
+- **Verified SHA256 values (computed 2026-06-29):**
+  - ostree `libostree-2026.1.tar.xz`: `8e77c285dd6fa5ec5fb063130390977be727fe11107335ed8778a40385069e95`
+  - bootc `bootc-1.16.2.tar.zstd`: `b407aa47a61ecda39256c3e3dbeef25c31585c5644ad6d40f5397522a4d2edc7`
+  - bootc vendor `bootc-1.16.2-vendor.tar.zstd`: `53d759ca521144a675af67e68d23c3f5f18dca784e4e900052d0cfdc4467732b`
+
+---
+
+### Task 1: Pin sources in checksums.json
+
+**Files:**
+- Modify: `shared/download/checksums.json`
+
+**Interfaces:**
+- Produces: three `verified_download` keys — `ostree`, `bootc`, `bootc-vendor` — consumed by the build script in Task 3.
+
+- [ ] **Step 1: Add the three entries**
+
+Add these keys to the JSON object in `shared/download/checksums.json` (alongside existing entries; mind the trailing commas so the file stays valid JSON):
+
+```json
+  "ostree": {
+    "url": "https://github.com/ostreedev/ostree/releases/download/v2026.1/libostree-2026.1.tar.xz",
+    "sha256": "8e77c285dd6fa5ec5fb063130390977be727fe11107335ed8778a40385069e95",
+    "version": "2026.1"
+  },
+  "bootc": {
+    "url": "https://github.com/bootc-dev/bootc/releases/download/v1.16.2/bootc-1.16.2.tar.zstd",
+    "sha256": "b407aa47a61ecda39256c3e3dbeef25c31585c5644ad6d40f5397522a4d2edc7",
+    "version": "1.16.2"
+  },
+  "bootc-vendor": {
+    "url": "https://github.com/bootc-dev/bootc/releases/download/v1.16.2/bootc-1.16.2-vendor.tar.zstd",
+    "sha256": "53d759ca521144a675af67e68d23c3f5f18dca784e4e900052d0cfdc4467732b",
+    "version": "1.16.2"
+  }
+```
+
+- [ ] **Step 2: Verify the file is valid JSON and keys resolve**
+
+Run:
+```bash
+jq -e '.ostree.url, .bootc.url, ."bootc-vendor".url' shared/download/checksums.json
+```
+Expected: prints the three URLs, exit 0 (no JSON parse error).
+
+- [ ] **Step 3: Verify the helper can resolve and download+checksum each key**
+
+Run (uses the real helper end-to-end against the network):
+```bash
+CHECKSUMS_FILE=shared/download/checksums.json bash -c '
+  source shared/download/verified-download.sh
+  for k in ostree bootc bootc-vendor; do
+    verified_download "$k" "/tmp/vd-$k" || exit 1
+  done'
+```
+Expected: `Verified ostree`, `Verified bootc`, `Verified bootc-vendor`; exit 0. (A checksum mismatch here means the pinned SHA256 is wrong — stop and fix.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shared/download/checksums.json
+git commit -m "feat: pin ostree v2026.1 and bootc v1.16.2 source tarballs"
+```
+
+---
+
+### Task 2: Write the bootc + ostree build script
+
+**Files:**
+- Create: `shared/bootc/build/bootc.chroot`
+
+**Interfaces:**
+- Consumes: `verified_download` keys `ostree`, `bootc`, `bootc-vendor` (Task 1); `$SRCDIR/shared/download/verified-download.sh`.
+- Produces: `/usr/bin/bootc`, `/usr/bin/ostree`, `libostree` shared libs under `/usr/lib/<multiarch>`, bootc systemd units + dracut module — relied on by Task 3's wiring and Task 5's smoke checks.
+
+Notes for the implementer:
+- This is a mkosi **BuildScript** (wired via `BuildScripts=` in Task 3), NOT a postinstall script. It runs inside the build overlay, which has the image's packages plus the `BuildPackages=` toolchain. There is NO `apt` in this script — mkosi installs the build deps (the image rootfs has no apt; that is why the earlier postinst.chroot approach failed). Follow the `$SRCDIR`-sourcing pattern from `shared/snow/scripts/build/hotedge.chroot` (also a BuildScript).
+- The overlay is discarded after the script; only files placed in `$DESTDIR` are copied into the image. So ostree is installed twice: `make install DESTDIR="$DESTDIR"` (to ship) and `make install DESTDIR=` (explicitly empty — overrides the `DESTDIR` mkosi exports into the build env — so it installs into the overlay's real `/usr`, where the bootc build finds ostree-1.pc and loads libostree). bootc installs once: `make install-all DESTDIR="$DESTDIR"`.
+- ostree tarball extracts to `libostree-2026.1/` and ships a prebuilt `configure` (no `autogen.sh`/submodules needed).
+- bootc source extracts to `bootc-1.16.2/`; the vendor tarball extracts to a `vendor/` dir that must sit at `bootc-1.16.2/vendor/`, and bootc ships `.cargo/vendor-config.toml` to wire it up for an offline build.
+
+- [ ] **Step 1: Write the script**
+
+Create `shared/bootc/build/bootc.chroot`:
+
+```bash
+#!/bin/bash
+# Compile ostree and bootc from pinned source and install them into the image.
+# Replaces the formerly-APT-installed `bootc` and `libostree-1-1` packages
+# (built by the now-archived frostyard/bootc-debian recipe).
+#
+# This runs as a mkosi BuildScript: it executes inside the build overlay, which
+# contains the image's packages PLUS the build-only packages from BuildPackages=
+# (Task 3). The overlay — and therefore every build dependency — is discarded
+# after this script; only what we install into $DESTDIR is copied into the final
+# image. So there is no apt install/purge here: mkosi provides the toolchain and
+# mkosi cleans it up.
+set -euo pipefail
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+# Pinned Rust toolchain. Debian's rustc (1.85) is too OLD to build bootc 1.16.2
+# (xtask/build deps need >= 1.91). Install this exact toolchain via rustup.
+RUST_VERSION="1.96.0"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+source "$SRCDIR/shared/download/verified-download.sh"
+
+MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+
+# --- Install the pinned Rust toolchain into the (discarded) build overlay ---
+export RUSTUP_HOME="$WORK/rustup"
+export CARGO_HOME="$WORK/cargo"
+rustup toolchain install "$RUST_VERSION" --profile minimal
+
+# --- Build ostree. Install into $DESTDIR (ships in the image) AND into the
+#     overlay's live /usr (so the bootc build below can link against it). ---
+verified_download "ostree" "$WORK/ostree.tar.xz"
+tar -xJf "$WORK/ostree.tar.xz" -C "$WORK"
+OSTREE_SRC="$(find "$WORK" -maxdepth 1 -type d -name 'libostree-*' | head -n1)"
+[[ -n "$OSTREE_SRC" ]] || { echo "Error: ostree source dir not found" >&2; exit 1; }
+(
+    cd "$OSTREE_SRC"
+    ./configure \
+        --prefix=/usr \
+        --libdir="/usr/lib/${MULTIARCH}" \
+        --sysconfdir=/etc \
+        --with-curl \
+        --with-dracut
+    make -j"$(nproc)"
+    make install DESTDIR="$DESTDIR"
+    # DESTDIR= explicitly empty: override the DESTDIR mkosi exports into the
+    # build env, so this install reaches the overlay's real /usr (needed so the
+    # bootc build can find ostree-1.pc and run the bootc binary for docgen).
+    make install DESTDIR=
+)
+ldconfig
+
+# --- Build bootc (offline, vendored crates); install into $DESTDIR. ---
+verified_download "bootc" "$WORK/bootc.tar.zstd"
+verified_download "bootc-vendor" "$WORK/bootc-vendor.tar.zstd"
+tar --use-compress-program=unzstd -xf "$WORK/bootc.tar.zstd" -C "$WORK"
+BOOTC_SRC="$(find "$WORK" -maxdepth 1 -type d -name 'bootc-*' | head -n1)"
+[[ -n "$BOOTC_SRC" ]] || { echo "Error: bootc source dir not found" >&2; exit 1; }
+# Vendor tarball extracts a top-level vendor/ dir; place it inside the source
+# tree and activate the shipped offline cargo config.
+tar --use-compress-program=unzstd -xf "$WORK/bootc-vendor.tar.zstd" -C "$BOOTC_SRC"
+cp "$BOOTC_SRC/.cargo/vendor-config.toml" "$BOOTC_SRC/.cargo/config.toml"
+(
+    cd "$BOOTC_SRC"
+    export PKG_CONFIG_PATH="/usr/lib/${MULTIARCH}/pkgconfig:/usr/share/pkgconfig"
+    export CARGO_NET_OFFLINE=true
+    # Run make under the pinned toolchain so nested `cargo` calls use it.
+    rustup run "$RUST_VERSION" make bin
+    rustup run "$RUST_VERSION" make install-all DESTDIR="$DESTDIR"
+)
+
+echo "bootc and ostree built and installed into \$DESTDIR"
+```
+
+- [ ] **Step 2: Verify it passes shellcheck**
+
+Run:
+```bash
+shellcheck shared/bootc/build/bootc.chroot
+```
+Expected: no output, exit 0. (`validate.yml` runs shellcheck on PRs — this must be clean.)
+
+- [ ] **Step 3: Verify executable bit**
+
+Run:
+```bash
+chmod +x shared/bootc/build/bootc.chroot
+test -x shared/bootc/build/bootc.chroot && echo OK
+```
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shared/bootc/build/bootc.chroot
+git commit -m "feat: add in-tree bootc + ostree source build script"
+```
+
+---
+
+### Task 3: Wire the build into the base image and drop the APT packages
+
+**Files:**
+- Modify: `mkosi.images/base/mkosi.conf`
+
+**Interfaces:**
+- Consumes: the build script `shared/bootc/build/bootc.chroot` (Task 2).
+- Produces: a base image that no longer pulls `bootc`/`libostree-1-1` from APT and runs the source build instead.
+
+- [ ] **Step 1: Remove the two ex-APT packages**
+
+In `mkosi.images/base/mkosi.conf`, delete these two lines (the `# bootc` block at ~line 103-105):
+```
+# bootc
+Packages=bootc
+         libostree-1-1
+```
+Replace the block with ostree's/bootc's runtime shared-library dependencies (these ship in the image and are what the compiled binaries link against at runtime):
+```
+# ostree/bootc runtime libraries (ostree + bootc are compiled from source in
+# shared/bootc/build/bootc.chroot; these are their runtime link deps)
+Packages=libcurl4t64
+         libglib2.0-0t64
+         libgpgme11t64
+         libarchive13t64
+         libsystemd0
+         zlib1g
+         libfuse3-4
+         libsoup-3.0-0
+         liblzma5
+         libzstd1
+         libmount1
+         libselinux1
+         libcom-err2
+         libext2fs2t64
+```
+(Several of these already appear in the existing `# Runtime libraries for ostree/bootc` block at ~line 50 — that's fine, duplicates are harmless, but you may consolidate them into one block.)
+
+- [ ] **Step 2: Wire the build script as a BuildScript and add the build packages**
+
+Add these to the `[Content]` section of `mkosi.images/base/mkosi.conf`. The build deps go in `BuildPackages=` — mkosi installs them into the build overlay only, so they never ship in the image (this is what makes the apt-purge dance unnecessary):
+```
+BuildScripts=%D/shared/bootc/build/bootc.chroot
+
+# Build-only deps for compiling ostree + bootc (overlay only; not shipped)
+BuildPackages=build-essential
+              pkg-config
+              autoconf
+              automake
+              libtool
+              bison
+              dpkg-dev
+              xz-utils
+              zstd
+              libcurl4-openssl-dev
+              libssl-dev
+              libsystemd-dev
+              libgpgme-dev
+              libarchive-dev
+              libfuse3-dev
+              libglib2.0-dev
+              libzstd-dev
+              liblzma-dev
+              libsoup-3.0-dev
+              e2fslibs-dev
+              libext2fs-dev
+              libmount-dev
+              libselinux1-dev
+              gobject-introspection
+              libgirepository1.0-dev
+              go-md2man
+              rustup
+```
+(If the build later reports a missing header/lib, add the corresponding `-dev` package here — this is the expected one-or-two-iteration tuning the plan calls out. Because these are overlay-only, adding extras here is cheap and safe.)
+
+- [ ] **Step 3: Verify bootc/libostree are no longer image packages**
+
+Run:
+```bash
+mkosi --directory . summary 2>/dev/null | grep -iE "^\s*Packages:.*\b(bootc|libostree-1-1)\b" && echo "STILL PRESENT (bad)" || echo "no bootc/libostree image package — good"
+```
+Expected: `no bootc/libostree image package — good`.
+
+- [ ] **Step 4: Verify the build script is scheduled**
+
+Run:
+```bash
+mkosi --directory . summary 2>/dev/null | grep -i "bootc.chroot" && echo "build script wired"
+```
+Expected: shows `bootc.chroot` under Build Scripts; `build script wired`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mkosi.images/base/mkosi.conf
+git commit -m "feat: build bootc/ostree from source in base via BuildScript, drop frostyard APT packages"
+```
+
+---
+
+### Task 4: Add dependency update checks
+
+**Files:**
+- Modify: `.github/workflows/check-dependencies.yml`
+
+**Interfaces:**
+- Consumes: `checksums.json` keys `ostree`, `bootc`, `bootc-vendor` (Task 1).
+- Produces: weekly PRs that bump those pins when upstream releases.
+
+The workflow has two relevant steps: the `check` step (id `check`) that detects updates and sets `$GITHUB_OUTPUT` flags, and the `Update checksums` step that rewrites `checksums.json`. Add to BOTH, mirroring the `code-server` blocks exactly (release tag stripped of leading `v`).
+
+- [ ] **Step 1: Add detection blocks to the `check` step**
+
+In the `Check for dependency updates` step, after the `code-server` block (around line 52), add:
+
+```bash
+          # Check ostree
+          CURRENT_OSTREE=$(jq -r '.ostree.version' "$CHECKSUMS")
+          LATEST_OSTREE=$(curl -s https://api.github.com/repos/ostreedev/ostree/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_OSTREE" && "$LATEST_OSTREE" != "$CURRENT_OSTREE" ]]; then
+            UPDATES="${UPDATES}ostree: $CURRENT_OSTREE -> $LATEST_OSTREE\n"
+            echo "ostree_update=true" >> $GITHUB_OUTPUT
+            echo "ostree_version=$LATEST_OSTREE" >> $GITHUB_OUTPUT
+          fi
+
+          # Check bootc (bootc + bootc-vendor version together)
+          CURRENT_BOOTC=$(jq -r '.bootc.version' "$CHECKSUMS")
+          LATEST_BOOTC=$(curl -s https://api.github.com/repos/bootc-dev/bootc/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_BOOTC" && "$LATEST_BOOTC" != "$CURRENT_BOOTC" ]]; then
+            UPDATES="${UPDATES}bootc: $CURRENT_BOOTC -> $LATEST_BOOTC\n"
+            echo "bootc_update=true" >> $GITHUB_OUTPUT
+            echo "bootc_version=$LATEST_BOOTC" >> $GITHUB_OUTPUT
+          fi
+```
+
+- [ ] **Step 2: Add rewrite blocks to the `Update checksums` step**
+
+In the `Update checksums` step, after the `code-server` block (around line 135), add:
+
+```bash
+          if [[ "${{ steps.check.outputs.ostree_update }}" == "true" ]]; then
+            VER="${{ steps.check.outputs.ostree_version }}"
+            URL="https://github.com/ostreedev/ostree/releases/download/v${VER}/libostree-${VER}.tar.xz"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.ostree.url=$u | .ostree.sha256=$s | .ostree.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "${{ steps.check.outputs.bootc_update }}" == "true" ]]; then
+            VER="${{ steps.check.outputs.bootc_version }}"
+            URL="https://github.com/bootc-dev/bootc/releases/download/v${VER}/bootc-${VER}.tar.zstd"
+            VURL="https://github.com/bootc-dev/bootc/releases/download/v${VER}/bootc-${VER}-vendor.tar.zstd"
+            TMP=$(mktemp); VTMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            curl -fsSL -o "$VTMP" "$VURL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            VSHA=$(sha256sum "$VTMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+               --arg vu "$VURL" --arg vs "$VSHA" \
+              '.bootc.url=$u | .bootc.sha256=$s | .bootc.version=$v
+               | .["bootc-vendor"].url=$vu | .["bootc-vendor"].sha256=$vs | .["bootc-vendor"].version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP" "$VTMP"
+          fi
+```
+
+- [ ] **Step 3: Verify the workflow is valid YAML**
+
+Run:
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/check-dependencies.yml'))" && echo "valid YAML"
+```
+Expected: `valid YAML`, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/check-dependencies.yml
+git commit -m "ci: track ostree and bootc release updates"
+```
+
+---
+
+### Task 5: Build verification (integration)
+
+**Files:** none (verification only)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-3.
+
+> This is the real test: a clean build that compiles both projects and an
+> in-image smoke check. Build-dependency lists for from-source compiles often
+> need one or two iterations — if the build fails on a missing header/lib, add
+> the corresponding `-dev` package to `BUILD_DEPS` in `shared/bootc/build/bootc.chroot`,
+> re-run, and amend Task 2's commit.
+
+- [ ] **Step 1: Clean build of the base (via a downstream image)**
+
+Run (root/sudo required, per project build docs):
+```bash
+just snow
+```
+Expected: build completes without error; in particular the `bootc.chroot` post-install step compiles ostree and bootc and the apt purge runs at the end.
+
+- [ ] **Step 2: Smoke-check the built rootfs**
+
+Run (adjust path to the snow output rootfs directory):
+```bash
+sudo chroot output/snow /usr/bin/bootc --version
+sudo chroot output/snow /usr/bin/ostree --version
+```
+Expected: bootc prints `1.16.2` (or a version string containing it); ostree prints `2026.1`.
+
+- [ ] **Step 3: Confirm build deps did not ship**
+
+Run:
+```bash
+sudo chroot output/snow bash -c 'command -v rustc cargo cc autoconf 2>/dev/null; dpkg -l | grep -E "libgpgme-dev|libarchive-dev|^ii  rustc" || echo "no build deps present"'
+```
+Expected: `no build deps present` (the toolchain and `-dev` packages were purged). `gcc`/`make` may still be present because base installs them — that's expected and fine.
+
+- [ ] **Step 4: Confirm the bootc dracut module is present**
+
+Run:
+```bash
+sudo find output/snow/usr/lib/dracut/modules.d -maxdepth 1 -iname '*bootc*'
+```
+Expected: a bootc dracut module directory exists (consumed by `30-bootc-standard.conf`).
+
+- [ ] **Step 5: No commit** (verification only). If `BUILD_DEPS` needed changes, amend the Task 2 commit instead.
+
+---
+
+### Task 6: Update documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md` (if it documents image contents / bootc origin)
+- Modify/Create: `yeti/` content (architecture/decision rationale)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+In `CLAUDE.md`, document that bootc and ostree are compiled from pinned source in `shared/bootc/build/bootc.chroot` during the base image build (not installed from the Frostyard APT repo). Note the version pins live in `checksums.json` and are tracked by `check-dependencies.yml`, and that build dependencies are installed and purged within the script. Add `shared/bootc/` to the Key Directories section.
+
+- [ ] **Step 2: Update README.md if applicable**
+
+Run:
+```bash
+grep -ni "bootc" README.md
+```
+If the README states where bootc comes from or lists APT-sourced components, update it to reflect the in-tree source build. If there is nothing relevant, skip.
+
+- [ ] **Step 3: Update yeti/ context**
+
+Run:
+```bash
+ls yeti/ && grep -rni "bootc\|libostree" yeti/ | head
+```
+Add or update the relevant yeti doc with the rationale (Frostyard packaging repo archived; Trixie has no bootc and only ostree 2025.2; we compile v2026.1/v1.16.2 in-tree for a self-contained build) and the build mechanics (postinst chroot, vendored offline cargo build, build-dep purge, runtime libs pinned in base `Packages=`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md yeti/
+git commit -m "docs: document in-tree bootc/ostree source build"
+```
+
+---
+
+## Notes on risk / execution
+
+- **No apt in the image (root cause of the first build failure):** the image rootfs has no `apt`/`apt-get`/`apt-mark` — mkosi drives the package manager from outside the image. So build deps CANNOT be apt-installed in-script. They are declared in `BuildPackages=` (Task 3); mkosi installs them into the build overlay and discards them afterward. This is why the script is a `BuildScript`, not a postinstall `.chroot`.
+- **ostree double-install:** the BuildScript installs ostree both to `$DESTDIR` (ships) and to the overlay `/usr` (so bootc can link against libostree during its build). Only `$DESTDIR` persists into the image.
+- **runtime libs:** ostree/bootc runtime link deps are in base `Packages=` (Task 3) so they ship and the compiled binaries resolve them at runtime. Do not remove them from `Packages=`.
+- **verify at Task 5:** the clean build must confirm `bootc`/`ostree` work in the image and that build deps (`rustc`, `cargo`, `-dev` libs) did NOT ship (they shouldn't, since they were overlay-only).
+- **Build time:** every clean build now compiles ostree + bootc. Expect several extra minutes per image build. This is the accepted cost of dropping the external APT dependency.
+
+---
+
+## Addendum (added during execution): dpkg registration
+
+The in-tree build installs ostree/bootc as plain files; nothing registers them
+in the dpkg database, so `dpkg -l` / `apt list --installed` (and the
+`common-postinst.sh` package manifest) wouldn't show them. To mirror the old
+`.deb` install, a `PostInstallationScript` registers them:
+
+- **File:** `shared/bootc/postinst/bootc-register.chroot`; wired via
+  `PostInstallationScripts=` in `mkosi.images/base/mkosi.conf` (runs after the
+  BuildScript's `$DESTDIR` is merged, alongside the implicit base postinst).
+- **Mechanism:** builds **metadata-only** stub `.deb`s for `libostree-1-1`
+  (version `.ostree.version`) and `bootc` (version `.bootc.version`,
+  `Depends: libostree-1-1`) with `dpkg-deb`, then `dpkg -i`s them. The packages
+  carry no files — the binaries/libs come from the BuildScript — so dpkg records
+  presence/version without owning the files.
+- **Relies on:** `dpkg` being Essential (always in the image) and
+  `CleanPackageMetadata=no` (dpkg DB retained).

--- a/docs/superpowers/specs/2026-06-29-inline-bootc-build-design.md
+++ b/docs/superpowers/specs/2026-06-29-inline-bootc-build-design.md
@@ -1,0 +1,177 @@
+# Design: Move bootc + ostree build into the snosi base image
+
+**Date:** 2026-06-29
+**Branch:** `feat/inline-bootc-build`
+**Status:** Approved (design)
+
+## Background
+
+snosi currently installs `bootc` and `libostree-1-1` as APT packages from the
+Frostyard repository (`repository.frostyard.org`). These packages were produced
+by the now-archived private repo `frostyard/bootc-debian`, whose CI cloned
+upstream ostree (`v2025.6`) and bootc (`main`), compiled both, built `.deb`
+packages, and published them to the Frostyard R2-backed APT repo.
+
+Problems with the status quo:
+
+- The packaging source repo is archived, so bootc is effectively **frozen** at
+  the last published build (`bootc 0.0.202602092157.main-frostyard1`, built
+  2026-02-09).
+- Debian Trixie ships **no** real `bootc` package (only unrelated `bootcd`,
+  `qbootctl`, `systemd-bootchart`) and ships `libostree-1-1` at `2025.2-1`,
+  older than what recent bootc needs.
+- The build lives outside snosi, so the OS image build depends on an external
+  APT repo and an out-of-tree, archived recipe.
+
+## Goal
+
+Build ostree and bootc **from pinned source inside the snosi base image build**,
+and remove the two Frostyard APT packages (`bootc`, `libostree-1-1`). The result
+is a self-contained image build with no external APT dependency for bootc.
+
+## Decisions
+
+| Decision | Choice |
+|----------|--------|
+| Version pinning | Pin to release tags, recorded in `checksums.json` (SHA256), tracked by `check-dependencies.yml` |
+| ostree version | `v2026.1` (latest; upgrade from the proven `v2025.6`) |
+| bootc version | `v1.16.2` (latest stable; upgrade from the old `main` track) |
+| Where the compile happens | A mkosi **BuildScript** (`BuildScripts=`) running in the build overlay; artifacts installed to `$DESTDIR` and copied into the image |
+| Build deps | Declared in `BuildPackages=` — mkosi installs them into the build overlay only and discards them (never shipped). NOT apt-installed in-script: the image rootfs has no `apt`. |
+| ostree scope | Compile ostree too (replicate recipe); do not rely on Debian's 2025.2 |
+
+> **Revised after first build attempt:** the original design used a
+> `postinst.chroot` that apt-installed build deps. That failed — the image
+> rootfs contains no `apt` (mkosi manages packages externally). The mechanism
+> was changed to the mkosi-native BuildScript + BuildPackages + `$DESTDIR`
+> pattern, which also removes the build-dep purge logic entirely (the overlay
+> is discarded automatically). ostree is installed twice in the BuildScript:
+> to `$DESTDIR` (ships) and to the overlay `/usr` (so bootc links against it).
+
+> Note: confirm bootc 1.16's minimum required ostree version before finalizing.
+> ostree `v2026.1` is newer than the proven `v2025.6`, so it is expected to
+> satisfy bootc 1.16; bootc requires a *minimum* ostree, and newer is acceptable.
+
+## Components
+
+### 1. `shared/download/checksums.json` — two new entries
+
+- `ostree`:
+  - URL: `https://github.com/ostreedev/ostree/releases/download/v2026.1/libostree-2026.1.tar.xz`
+  - The official release tarball bundles git submodules (libglnx, etc.) and a
+    pregenerated `configure`, so `autogen.sh`/`git submodule` are **not** needed.
+  - `sha256` + `version` fields per existing convention.
+- `bootc`:
+  - URL: the `v1.16.2` source tarball (GitHub release asset or
+    `/archive/refs/tags/v1.16.2.tar.gz`).
+  - `Cargo.lock` pins exact crate versions; `make bin` fetches them from
+    crates.io during the build (the chroot has network). Reproducible given the
+    pinned tag + lockfile.
+  - `sha256` + `version` fields.
+
+### 2. `shared/bootc/build/bootc.chroot` — new build script
+
+Wired into the base image via `PostInstallationScripts=` in
+`mkosi.images/base/mkosi.conf`. Uses `set -euo pipefail` and sources
+`shared/download/verified-download.sh`. Flow mirrors the proven recipe:
+
+1. `apt-get update` + `apt-get install --no-install-recommends` the build deps:
+   `build-essential pkg-config autoconf automake libtool bison git curl
+   ca-certificates dpkg-dev libcurl4-openssl-dev libssl-dev libsystemd-dev
+   libgpgme-dev libarchive-dev libfuse3-dev libglib2.0-dev libzstd-dev
+   liblzma-dev libsoup-3.0-dev e2fslibs-dev libext2fs-dev libmount-dev
+   libselinux1-dev gobject-introspection libgirepository1.0-dev dracut
+   go-md2man` plus a Rust toolchain.
+   - **Rust toolchain via rustup (revised after build attempt #2).** bootc
+     v1.16.2's library crate *declares* MSRV `1.85.0`, but its **build tooling**
+     (the `xtask` manpage generator and its vendored deps `cargo_metadata`
+     `0.23.1` → rustc 1.86, `cargo-platform` `0.3.3` → rustc 1.91) requires a
+     much newer rustc. Debian Trixie's `rustc 1.85.0` therefore cannot *build*
+     bootc, despite "meeting" the declared MSRV. The original frostyard recipe
+     used `rustup` for exactly this reason.
+   - The build script installs a **pinned** toolchain (`RUST_VERSION`, currently
+     `1.96.0`, the latest stable ≥ 1.91) via `rustup` (the `rustup` package from
+     `BuildPackages=`; no `curl | sh`), and runs `make` under
+     `rustup run "$RUST_VERSION"`. rustup verifies toolchain signatures. Bump
+     `RUST_VERSION` alongside bootc when a newer toolchain is needed.
+2. **ostree:** `verified_download "ostree"` → extract → from the source dir:
+   ```
+   MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+   ./configure --prefix=/usr --libdir="/usr/lib/${MULTIARCH}" \
+       --sysconfdir=/etc --with-curl --with-dracut
+   make -j"$(nproc)"
+   make install        # installs directly into the image
+   ldconfig
+   ```
+3. **bootc:** `verified_download "bootc"` → extract → from the source dir:
+   ```
+   export PKG_CONFIG_PATH="/usr/lib/${MULTIARCH}/pkgconfig:/usr/share/pkgconfig"
+   make bin
+   make install-all    # installs bootc binary, systemd units, dracut module
+   ```
+4. `ldconfig`.
+5. Cleanup: `apt-get purge` the build deps, `apt-get autoremove --purge`,
+   `apt-get clean`, remove `/var/lib/apt/lists/*`, and any temp build dirs (via
+   a `trap ... EXIT`).
+
+Failure handling: explicit error + non-zero exit if extracted source
+directories are not found (pattern borrowed from `hotedge.chroot`).
+
+### 3. `mkosi.images/base/mkosi.conf` — package changes
+
+- Remove `bootc` (line 104) and `libostree-1-1` (line 105) from `Packages=`.
+- Ensure ostree's **runtime** shared-library deps are present in `Packages=`
+  (so removing the compiled-against `-dev` packages doesn't strand the runtime
+  libs): `libcurl4t64`, `libglib2.0-0t64`, `libgpgme11t64`, `libarchive13t64`,
+  `libsystemd0`, `zlib1g`, `libfuse3-4`, `libsoup-3.0-0`, `liblzma5`,
+  `libzstd1`, `libmount1`, `libselinux1`, and the e2fs runtime libs. Most are
+  already pulled in by the base; add any that are missing.
+- Add the `PostInstallationScripts=` entry for the new build script.
+
+### 4. `.github/workflows/check-dependencies.yml` — update checks
+
+Add update checks for the ostree and bootc release tags, matching the existing
+per-dependency pattern, so weekly PRs bump `checksums.json` when new releases
+appear.
+
+## Error handling
+
+- All scripts: `set -euo pipefail`.
+- `verified_download()` already aborts on checksum mismatch.
+- Explicit guard if a source directory fails to extract.
+- Build-dep cleanup runs even on the success path; a `trap` removes temp dirs.
+
+## Testing / verification
+
+- In-image smoke: `bootc --version` and `ostree --version` succeed; the bootc
+  dracut module is present (`/usr/lib/dracut/modules.d/.../bootc` referenced by
+  `30-bootc-standard.conf`).
+- `test/tests/01-installation.sh` already asserts `bootc status` succeeds on a
+  bootc-deployed image — exercised by the existing install test.
+- Local gate before declaring done: a clean `just` build of the base (and at
+  least one downstream image, e.g. `snow`) succeeds, and `mkosi summary` is
+  clean. Confirm `bootc`/`libostree-1-1` are no longer pulled from APT and the
+  compiled binaries are present with no build deps left in the image.
+
+## Documentation
+
+Per project rules, update after implementation:
+
+- `CLAUDE.md` — bootc/ostree are compiled from source in the base image, not
+  installed from the Frostyard APT repo; document the new build script.
+- `README.md` — note the in-tree bootc/ostree build if relevant.
+- `yeti/` — architecture/decision rationale for AI context.
+
+## Tradeoffs
+
+- Compiling ostree (autotools) + bootc (Rust release build) on every **clean**
+  build (`just` always runs `mkosi clean` first) adds several minutes to the
+  base image build and therefore to every downstream image. Accepted as the
+  cost of removing the external APT dependency.
+
+## Out of scope
+
+- Re-publishing bootc to the Frostyard APT repo (we are removing that
+  dependency, not maintaining it).
+- Changes to sysexts or non-base images beyond what inheriting the new base
+  requires.

--- a/mkosi.images/base/mkosi.conf
+++ b/mkosi.images/base/mkosi.conf
@@ -47,10 +47,22 @@ Packages=erofs-utils
          shim-signed
          systemd-resolved
 
-# Runtime libraries for ostree/bootc
-Packages=libarchive13t64
-         libfuse3-4
+# ostree/bootc runtime libraries (ostree + bootc are compiled from source in
+# shared/bootc/build/bootc.chroot; these are their runtime link deps)
+Packages=libcurl4t64
+         libglib2.0-0t64
          libgpgme11t64
+         libarchive13t64
+         libsystemd0
+         zlib1g
+         libfuse3-4
+         libsoup-3.0-0
+         liblzma5
+         libzstd1
+         libmount1
+         libselinux1
+         libcom-err2
+         libext2fs2t64
 
 # Locales and keyboard
 Packages=locales
@@ -100,11 +112,6 @@ Packages=jq
 Packages=klibc-utils
          kpartx
 
-# bootc
-Packages=bootc
-         libostree-1-1
-
-
 # Misc
 Packages=bash-completion
          appstream
@@ -134,3 +141,37 @@ Packages=apparmor
          distro-info-data
          gdisk
          ubuntu-keyring
+
+BuildScripts=%D/shared/bootc/build/bootc.chroot
+
+# Register the in-tree-built ostree/bootc in the dpkg database (metadata-only)
+PostInstallationScripts=%D/shared/bootc/postinst/bootc-register.chroot
+
+# Build-only deps for compiling ostree + bootc (overlay only; not shipped).
+# (dpkg-dev and zstd are intentionally absent — they are already in base
+# Packages= and thus present in the build overlay.)
+BuildPackages=build-essential
+              pkg-config
+              autoconf
+              automake
+              libtool
+              bison
+              xz-utils
+              libcurl4-openssl-dev
+              libssl-dev
+              libsystemd-dev
+              libgpgme-dev
+              libarchive-dev
+              libfuse3-dev
+              libglib2.0-dev
+              libzstd-dev
+              liblzma-dev
+              libsoup-3.0-dev
+              e2fslibs-dev
+              libext2fs-dev
+              libmount-dev
+              libselinux1-dev
+              gobject-introspection
+              libgirepository1.0-dev
+              go-md2man
+              rustup

--- a/shared/bootc/build/bootc.chroot
+++ b/shared/bootc/build/bootc.chroot
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Compile ostree and bootc from pinned source and install them into the image.
+# Replaces the formerly-APT-installed `bootc` and `libostree-1-1` packages
+# (built by the now-archived frostyard/bootc-debian recipe).
+#
+# This runs as a mkosi BuildScript: it executes inside the build overlay, which
+# contains the image's packages PLUS the build-only packages from BuildPackages=
+# (Task 3). The overlay — and therefore every build dependency — is discarded
+# after this script; only what we install into $DESTDIR is copied into the final
+# image. So there is no apt install/purge here: the build packages come from
+# BuildPackages= and the Rust toolchain from rustup, all in the overlay mkosi
+# discards.
+set -euo pipefail
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+# Pinned Rust toolchain. Debian Trixie's rustc (1.85) is too OLD to *build*
+# bootc 1.16.2: its xtask/build dependencies (cargo_metadata, cargo-platform)
+# require rustc >= 1.91, even though bootc's library crate declares MSRV 1.85.
+# We install this exact toolchain via rustup (the `rustup` package comes from
+# BuildPackages=); rustup verifies the toolchain's signatures on download.
+# Bump this when bumping bootc if a newer toolchain is needed.
+RUST_VERSION="1.96.0"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+source "$SRCDIR/shared/download/verified-download.sh"
+
+MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+
+# --- Install the pinned Rust toolchain into the (discarded) build overlay ---
+export RUSTUP_HOME="$WORK/rustup"
+export CARGO_HOME="$WORK/cargo"
+rustup toolchain install "$RUST_VERSION" --profile minimal
+
+# --- Build ostree. Install into $DESTDIR (ships in the image) AND into the
+#     overlay's live /usr (so the bootc build below can link against it). ---
+verified_download "ostree" "$WORK/ostree.tar.xz"
+tar -xJf "$WORK/ostree.tar.xz" -C "$WORK"
+OSTREE_SRC="$(find "$WORK" -maxdepth 1 -type d -name 'libostree-*' | head -n1)"
+[[ -n "$OSTREE_SRC" ]] || { echo "Error: ostree source dir not found" >&2; exit 1; }
+(
+    cd "$OSTREE_SRC"
+    ./configure \
+        --prefix=/usr \
+        --libdir="/usr/lib/${MULTIARCH}" \
+        --sysconfdir=/etc \
+        --with-curl \
+        --with-dracut
+    make -j"$(nproc)"
+    # Install once into $DESTDIR (this is what mkosi copies into the image)...
+    make install DESTDIR="$DESTDIR"
+    # ...and once into the overlay's REAL /usr so the bootc build below can find
+    # ostree-1.pc (pkg-config) and load libostree at runtime (the docgen step
+    # runs the bootc binary). DESTDIR= is set EXPLICITLY EMPTY here to override
+    # the DESTDIR mkosi exports into the build environment — otherwise this
+    # second install would also land in $DESTDIR and never reach /usr.
+    make install DESTDIR=
+)
+ldconfig
+
+# --- Build bootc (offline, vendored crates); install into $DESTDIR. ---
+verified_download "bootc" "$WORK/bootc.tar.zstd"
+verified_download "bootc-vendor" "$WORK/bootc-vendor.tar.zstd"
+tar --use-compress-program=unzstd -xf "$WORK/bootc.tar.zstd" -C "$WORK"
+BOOTC_SRC="$(find "$WORK" -maxdepth 1 -type d -name 'bootc-*' | head -n1)"
+[[ -n "$BOOTC_SRC" ]] || { echo "Error: bootc source dir not found" >&2; exit 1; }
+# Vendor tarball extracts a top-level vendor/ dir; place it inside the source
+# tree and activate the shipped offline cargo config.
+tar --use-compress-program=unzstd -xf "$WORK/bootc-vendor.tar.zstd" -C "$BOOTC_SRC"
+cp "$BOOTC_SRC/.cargo/vendor-config.toml" "$BOOTC_SRC/.cargo/config.toml"
+(
+    cd "$BOOTC_SRC"
+    export PKG_CONFIG_PATH="/usr/lib/${MULTIARCH}/pkgconfig:/usr/share/pkgconfig"
+    export CARGO_NET_OFFLINE=true
+    # Run make under the pinned toolchain so the Makefile's nested `cargo`
+    # invocations (e.g. the xtask manpage generator) use $RUST_VERSION.
+    rustup run "$RUST_VERSION" make bin
+    rustup run "$RUST_VERSION" make install-all DESTDIR="$DESTDIR"
+)
+
+echo "bootc and ostree built and installed into \$DESTDIR"

--- a/shared/bootc/postinst/bootc-register.chroot
+++ b/shared/bootc/postinst/bootc-register.chroot
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Register the in-tree-built ostree and bootc with dpkg so the OS package
+# database reports them as installed — mirroring the old frostyard .deb install,
+# which downstream tooling (dependency checks, `apt list --installed` manifests,
+# anything querying dpkg) expects.
+#
+# The actual files are installed by the base image BuildScript
+# (shared/bootc/build/bootc.chroot) into the image's /usr. These are
+# METADATA-ONLY packages: dpkg records the package name + version (and the
+# bootc -> libostree-1-1 dependency) but does not own the files. This runs as a
+# PostInstallationScript, after the BuildScript's $DESTDIR has been merged into
+# the image, so the binaries are already present.
+set -euo pipefail
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+CHECKSUMS="$SRCDIR/shared/download/checksums.json"
+OSTREE_VER="$(jq -r '.ostree.version' "$CHECKSUMS")"
+BOOTC_VER="$(jq -r '.bootc.version' "$CHECKSUMS")"
+ARCH="$(dpkg --print-architecture)"
+
+[[ -n "$OSTREE_VER" && "$OSTREE_VER" != "null" ]] || { echo "Error: no ostree version in checksums.json" >&2; exit 1; }
+[[ -n "$BOOTC_VER" && "$BOOTC_VER" != "null" ]] || { echo "Error: no bootc version in checksums.json" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# build_stub <name> <version> <extra-control-fields>
+build_stub() {
+    local name="$1" version="$2" extra="$3"
+    local pkgdir="$WORK/$name"
+    mkdir -p "$pkgdir/DEBIAN"
+    {
+        echo "Package: $name"
+        echo "Version: $version"
+        echo "Architecture: $ARCH"
+        echo "Maintainer: Frostyard <packages@frostyard.org>"
+        echo "Section: admin"
+        echo "Priority: optional"
+        [[ -n "$extra" ]] && echo "$extra"
+        echo "Description: $name (compiled from source in snosi)"
+        echo " Files are installed by the snosi base image build script; this"
+        echo " package records the install in dpkg for package-database visibility."
+    } > "$pkgdir/DEBIAN/control"
+    dpkg-deb --build --root-owner-group "$pkgdir" "$WORK/${name}.deb"
+}
+
+build_stub "libostree-1-1" "$OSTREE_VER" ""
+build_stub "bootc" "$BOOTC_VER" "Depends: libostree-1-1"
+
+dpkg -i "$WORK/libostree-1-1.deb" "$WORK/bootc.deb"
+echo "Registered libostree-1-1 ($OSTREE_VER) and bootc ($BOOTC_VER) with dpkg"

--- a/shared/download/checksums.json
+++ b/shared/download/checksums.json
@@ -38,5 +38,20 @@
     "url": "https://codeload.github.com/frostyard/logomenu/tar.gz/ae0ea469beaa7ce0cdc1fb8be26fc50c13d4fcbf",
     "sha256": "d11cc67b6003a295d17249b9ab08ea59d5b6a4e2301d784c51b5344e561f10c0",
     "version": "ae0ea469beaa7ce0cdc1fb8be26fc50c13d4fcbf"
+  },
+  "ostree": {
+    "url": "https://github.com/ostreedev/ostree/releases/download/v2026.1/libostree-2026.1.tar.xz",
+    "sha256": "8e77c285dd6fa5ec5fb063130390977be727fe11107335ed8778a40385069e95",
+    "version": "2026.1"
+  },
+  "bootc": {
+    "url": "https://github.com/bootc-dev/bootc/releases/download/v1.16.2/bootc-1.16.2.tar.zstd",
+    "sha256": "b407aa47a61ecda39256c3e3dbeef25c31585c5644ad6d40f5397522a4d2edc7",
+    "version": "1.16.2"
+  },
+  "bootc-vendor": {
+    "url": "https://github.com/bootc-dev/bootc/releases/download/v1.16.2/bootc-1.16.2-vendor.tar.zstd",
+    "sha256": "53d759ca521144a675af67e68d23c3f5f18dca784e4e900052d0cfdc4467732b",
+    "version": "1.16.2"
   }
 }

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -49,6 +49,7 @@ mkosi.profiles/             # Desktop/server profile definitions (6 profiles)
   ...
 shared/                     # Reusable fragments composed via Include=
   download/                 # Verified download system (checksums.json + helpers)
+  bootc/                    # In-tree source build: build/bootc.chroot compiles ostree+bootc from pinned tarballs
   kernel/                   # Kernel variant configs (backports, surface, stock)
   packages/                 # Package set configs (11 sets) with postinstall relocation scripts
   scripts/                  # Shared scripts (common-postinst.sh sourced by all profiles, brew.chroot build script)
@@ -95,7 +96,7 @@ The "loaded" variants extend their base profile by adding more Include directive
 
 Scripts execute in order per image build:
 
-1. **BuildScripts** (in chroot) — Download/install items not available as packages: Homebrew, GNOME extensions, Surface secure boot cert
+1. **BuildScripts** (in chroot) — Download/install items not available as packages: Homebrew, GNOME extensions, Surface secure boot cert. The base image additionally runs `shared/bootc/build/bootc.chroot` (wired via `BuildScripts=`) to compile ostree and bootc from pinned source — build deps come from `BuildPackages=` (overlay-only, not from APT; see [build-pipeline.md](build-pipeline.md) for details).
 2. **PostInstallationScripts** (after packages) — Common logic via `shared/scripts/common-postinst.sh` (OS release branding, package list generation, cleanup, sysext infra), then profile-specific steps (GDM enablement, package relocation /opt → /usr/lib). Mount enablement and useradd home dir are handled by the base image's own postinst script.
 3. **FinalizeScripts** (pre-output) — Remove ephemeral dirs (/boot, /home), create /sysroot and /nix mountpoints, clear machine-id/SSH keys, compile GLib schemas, set file xattrs for chunkah
 4. **PostOutputScripts** (after image creation) — Manifest processing, sysext versioned renaming
@@ -200,7 +201,7 @@ Configured in `mkosi.sandbox/etc/apt/` with GPG keyrings:
 - Debian Griffo.io (debian.griffo.io) — Additional Debian packages
 - Docker (docker.com) — Docker CE packages
 - Himmelblau (packages.himmelblau-idm.org) — Entra ID authentication (nightly)
-- Frostyard (repository.frostyard.org) — Custom packages: nbc, chairlift, updex, igloo, intuneme, snow-first-setup
+- Frostyard (repository.frostyard.org) — Custom packages: nbc, chairlift, updex, igloo, intuneme, snow-first-setup. **Note:** bootc and ostree are no longer sourced from this repo (the former `frostyard/bootc-debian` packaging recipe is archived); they are compiled from pinned source in-tree instead.
 - Linux Surface (pkg.surfacelinux.com) — Surface kernel + tools
 - Microsoft Edge (packages.microsoft.com) — Edge browser
 - Microsoft VSCode (packages.microsoft.com) — VS Code editor

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -23,6 +23,28 @@ Download and install items not available as Debian packages. These run inside th
 | `bazaar.chroot` | `shared/snow/scripts/build/` | Clones Bazaar Companion GNOME extension from GitHub, patches metadata.json for shell version "48" |
 | `surface-cert.chroot` | `shared/snow/scripts/build/` | Downloads Linux Surface secure boot certificate via `verified_download()`, installs to `/usr/share/linux-surface-secureboot/` |
 
+**Base image BuildScript — in-tree ostree + bootc** (`shared/bootc/build/bootc.chroot`):
+
+Wired via `BuildScripts=` in `mkosi.images/base/mkosi.conf`. Compiles **ostree** (v2026.1) and **bootc** (v1.16.2) from pinned source tarballs. Neither is installed from APT.
+
+**Rationale:** The former `frostyard/bootc-debian` private packaging recipe is archived. Debian Trixie ships no bootc package and only ostree 2025.2, which is too old for current bootc. Compiling in-tree makes the build fully self-contained. The image rootfs has no `apt` (mkosi manages packages externally), so build deps cannot be apt-installed from inside a postinstall chroot — hence this is a BuildScript.
+
+**Build deps:** Declared in `BuildPackages=` in `mkosi.images/base/mkosi.conf` (build-essential, autoconf, libglib2.0-dev, `rustup`, etc.). mkosi installs them into the build overlay only; the overlay is discarded after the build script completes, so no build tools ever ship in the image. There is no `apt` call and no purge logic in the script.
+
+**Rust toolchain:** Debian Trixie's `rustc` (1.85) is too old to *build* bootc 1.16.2 — its xtask/build dependencies (`cargo_metadata`, `cargo-platform`) require rustc >= 1.91, even though bootc's library crate declares MSRV 1.85. So the script installs a pinned toolchain (`RUST_VERSION`, currently `1.96.0`) via `rustup` (the `rustup` package, from `BuildPackages=`) and runs `make` under `rustup run "$RUST_VERSION"`. Bump `RUST_VERSION` when bumping bootc if a newer toolchain is required.
+
+**Mechanics:**
+
+1. Install the pinned Rust toolchain via `rustup toolchain install "$RUST_VERSION"` (into the discarded overlay).
+2. Download and verify three tarballs via `verified_download()` (keys `ostree`, `bootc`, `bootc-vendor` in `checksums.json`).
+3. Build ostree via autotools (`./configure --prefix=/usr ... && make -j$(nproc)`); install **twice**: `make install DESTDIR="$DESTDIR"` (so libostree/ostree ship in the image — mkosi copies `$DESTDIR` into the rootfs) and `make install DESTDIR=` (explicitly empty, to override the `DESTDIR` mkosi exports into the build env) into the overlay's real `/usr`, so the bootc build finds `ostree-1.pc` via pkg-config and can load libostree when the docgen step runs the bootc binary.
+4. Build bootc via offline vendored cargo: extract vendor tarball into the source tree, copy `.cargo/vendor-config.toml` → `.cargo/config.toml`, then `make bin && make install-all DESTDIR="$DESTDIR"`.
+5. On EXIT (success or failure): remove the temporary work directory only — no apt purge needed.
+
+**Runtime lib pinning:** bootc and ostree's runtime dependencies (e.g., `libglib2.0-0t64`, `libcurl4t64`) are listed in base `Packages=` so they ship in the image and the compiled binaries link against them at runtime. Do not remove them from `Packages=`.
+
+**dpkg registration (PostInstallationScript):** `shared/bootc/postinst/bootc-register.chroot` runs after the BuildScript's `$DESTDIR` is merged into the image. It builds metadata-only stub `.deb`s for `libostree-1-1` (version from `.ostree.version`) and `bootc` (version from `.bootc.version`, `Depends: libostree-1-1`) and `dpkg -i`s them, so the dpkg database reports both as installed for `dpkg -l` / `apt list --installed` / dependency checks. The packages carry no files — the binaries/libs come from the BuildScript — so dpkg records presence but does not own the files. Relies on `dpkg` being Essential and `CleanPackageMetadata=no` keeping the dpkg DB in the image.
+
 **Server profiles (cayo/cayoloaded):** Only `brew.chroot` (no desktop build scripts).
 
 ### 2. PostInstallationScripts (after packages)
@@ -35,6 +57,10 @@ Runs during the base image build (not during profile builds). Handles:
 - Sets home directory path to `/var/home` in `/etc/default/useradd`
 - Enables systemd mount units (home, root, srv, mnt, media, opt, usr-local)
 - Removes bls-garbage-collect service
+
+**Version pins:** `shared/download/checksums.json` keys `ostree`, `bootc`, `bootc-vendor`. Updated weekly by `check-dependencies.yml` via PR.
+
+**Build time impact:** every clean build now compiles ostree + bootc; expect several extra minutes per image build.
 
 **Kernel postinstall (all profiles):**
 - `shared/kernel/scripts/postinst/mkosi.postinst.chroot` — Builds initramfs via dracut, detects kernel version, generates `/usr/lib/modules/$VERSION/initramfs.img`, copies vmlinuz


### PR DESCRIPTION
## Summary

Moves the **bootc** and **ostree** build in-tree instead of installing them as APT packages from the now-archived `frostyard/bootc-debian` repo. Debian Trixie ships no `bootc` package and only ostree `2025.2` (too old for current bootc), so the base image build is now fully self-contained.

## What changed

- **Pin sources** (`shared/download/checksums.json`): ostree `v2026.1`, bootc `v1.16.2`, and bootc's vendored crate set — SHA256-verified through the existing `verified_download` helper. Weekly update checks added to `check-dependencies.yml` (bootc + bootc-vendor bumped together; reminder to re-check the Rust toolchain on a bootc bump).
- **BuildScript** (`shared/bootc/build/bootc.chroot`): compiles ostree (autotools) and bootc (offline, vendored cargo) into the image. Build deps come from `BuildPackages=` — they live only in the build overlay mkosi discards, so nothing leaks into the image.
  - Installs a **pinned Rust toolchain via `rustup`** (`RUST_VERSION=1.96.0`). Debian's `rustc 1.85` satisfies bootc's *declared* MSRV but is too old to actually **build** 1.16.2 — its xtask/build deps (`cargo_metadata`, `cargo-platform`) need rustc ≥ 1.91.
  - ostree is installed twice: `make install DESTDIR="$DESTDIR"` (ships in the image) and `make install DESTDIR=` (explicit empty — overrides the `DESTDIR` mkosi exports into the build env — so it lands in the overlay's real `/usr`, where the bootc build finds `ostree-1.pc` and can run the bootc binary for docgen).
- **Base config** (`mkosi.images/base/mkosi.conf`): drops `bootc` + `libostree-1-1` from `Packages=`, adds their runtime libraries, and wires `BuildScripts=` / `BuildPackages=` / the registration script.
- **dpkg registration** (`shared/bootc/postinst/bootc-register.chroot`): a PostInstallationScript that registers `bootc` + `libostree-1-1` in the dpkg database via metadata-only stub `.deb`s, so `dpkg -l` / `apt list --installed` / dependency checks see them as installed (files come from the BuildScript; dpkg records presence, not ownership).
- **Docs**: `CLAUDE.md`, `yeti/OVERVIEW.md`, `yeti/build-pipeline.md`, plus design + plan under `docs/superpowers/`.

## Verification

Clean `just snow` build passes:

- `bootc --version` → `1.16.2`; `ostree --version` → `2026.1` (built with libcurl, libsoup3, gpgme, libarchive, selinux, systemd, …)
- `dpkg -l bootc libostree-1-1` → both `ii` (1.16.2 / 2026.1)
- `rustc`/`cargo` **not** present in the image (no build-dep leak)
- base mount units still enabled (implicit base postinst still runs alongside the new scripts)

shellcheck (`-S error -s bash -x`), `checksums.json` JSON validity, and `check-dependencies.yml` YAML validity all pass.

## Notes

- `RUST_VERSION` is pinned in the script but not auto-bumped by `check-dependencies` — the `pull_request` matrix build in `build-images.yml` compiles bootc, so a toolchain mismatch fails the PR visibly rather than breaking `main`.
- The dpkg stubs are metadata-only (fileless); switching to file-owning packages is a possible follow-up if anything needs `dpkg -V`/`dpkg -L` accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)