### PR TITLE
fix: pin bazaar.chroot to a verified download (no more unpinned git clone)

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -79,6 +79,15 @@ jobs:
             echo "logomenu_commit=$LATEST_LM" >> $GITHUB_OUTPUT
           fi
 
+          # Check bazaar (Bazaar Companion GNOME extension)
+          CURRENT_BZ=$(jq -r '.bazaar.version' "$CHECKSUMS")
+          LATEST_BZ=$(curl -s https://api.github.com/repos/AlexanderVanhee/bazaar-companion/commits/HEAD | jq -r '.sha')
+          if [[ -n "$LATEST_BZ" && "$LATEST_BZ" != "null" && "$LATEST_BZ" != "$CURRENT_BZ" ]]; then
+            UPDATES="${UPDATES}bazaar: ${CURRENT_BZ:0:12} -> ${LATEST_BZ:0:12}\n"
+            echo "bazaar_update=true" >> $GITHUB_OUTPUT
+            echo "bazaar_commit=$LATEST_BZ" >> $GITHUB_OUTPUT
+          fi
+
           # Check Microsoft Azure VPN Client
           CURRENT_AZ=$(jq -r '.["microsoft-azurevpnclient"].version' "$CHECKSUMS")
           LATEST_AZ=$(curl -s https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/ | grep -oP 'microsoft-azurevpnclient_\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
@@ -178,6 +187,18 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$COMMIT" \
               '.logomenu.url=$u | .logomenu.sha256=$s | .logomenu.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "${{ steps.check.outputs.bazaar_update }}" == "true" ]]; then
+            COMMIT="${{ steps.check.outputs.bazaar_commit }}"
+            URL="https://codeload.github.com/AlexanderVanhee/bazaar-companion/tar.gz/${COMMIT}"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$COMMIT" \
+              '.bazaar.url=$u | .bazaar.sha256=$s | .bazaar.version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/shared/download/checksums.json
+++ b/shared/download/checksums.json
@@ -38,5 +38,10 @@
     "url": "https://codeload.github.com/frostyard/logomenu/tar.gz/ae0ea469beaa7ce0cdc1fb8be26fc50c13d4fcbf",
     "sha256": "d11cc67b6003a295d17249b9ab08ea59d5b6a4e2301d784c51b5344e561f10c0",
     "version": "ae0ea469beaa7ce0cdc1fb8be26fc50c13d4fcbf"
+  },
+  "bazaar": {
+    "url": "https://codeload.github.com/AlexanderVanhee/bazaar-companion/tar.gz/3bb9134985343ffd1993520eb37c90e113bfb09b",
+    "sha256": "b779610b06e1ac58af6193f515f637d3846eae67d3fb36f4af71b2e05fb05869",
+    "version": "3bb9134985343ffd1993520eb37c90e113bfb09b"
   }
 }

--- a/shared/snow/scripts/build/bazaar.chroot
+++ b/shared/snow/scripts/build/bazaar.chroot
@@ -1,25 +1,34 @@
 #!/bin/bash
 set -euo pipefail
 
-# this script clones the Bazaar Companion repository into the appropriate location
-# in the build tree so that it can be included in the final image.
-# Bazaar Compansion is a GNOME Shell extension that adds Bazaar to locations previously occupied by GNOME Software
+# this script downloads a pinned Bazaar Companion source archive into the
+# appropriate location in the build tree so that it can be included in the
+# final image.
+# Bazaar Companion is a GNOME Shell extension that adds Bazaar to locations
+# previously occupied by GNOME Software.
 
-
-REPOSITORY=https://github.com/AlexanderVanhee/bazaar-companion.git
 DESTINATION="$SRCDIR/shared/snow/tree/usr/share/gnome-shell/extensions/bazaar-integration@kolunmi.github.io"
+source "$SRCDIR/shared/download/verified-download.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+ARCHIVE="$TMP/bazaar.tar.gz"
 
 # remove any existing bazaar-companion directory
 rm -rf "$DESTINATION"
-# clone the bazaar-companion repository
-rm -rf /tmp/bazaar-companion
-git clone --depth 1 "$REPOSITORY" "/tmp/bazaar-companion"
+verified_download "bazaar" "$ARCHIVE"
+tar -xzf "$ARCHIVE" -C "$TMP"
 
-# Move subdirectory into the extension folder
+SOURCE_DIR=$(find "$TMP" -maxdepth 1 -type d -name 'bazaar-companion-*' | head -n 1)
+if [[ -z "$SOURCE_DIR" ]]; then
+    echo "Error: failed to locate extracted bazaar-companion source directory" >&2
+    exit 1
+fi
+
+# Move the extension sources (src/) into the extension folder
 mkdir -p "$DESTINATION"
-mv /tmp/bazaar-companion/src/* "$DESTINATION/"
+cp -a "$SOURCE_DIR"/src/. "$DESTINATION"/
 
-# set the permissions: 755 for directories and 644 for files in the hotedge directory
+# set the permissions: 755 for directories and 644 for files in the extension directory
 find "$DESTINATION" -type d -exec chmod 755 {} +
 find "$DESTINATION" -type f -exec chmod 644 {} +
 

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -20,7 +20,7 @@ Download and install items not available as Debian packages. These run inside th
 |--------|----------|---------|
 | `hotedge.chroot` | `shared/snow/scripts/build/` | Downloads Hotedge GNOME extension (hot corners) from GitHub via `verified_download()`, installs to `/usr/share/gnome-shell/extensions/` |
 | `logomenu.chroot` | `shared/snow/scripts/build/` | Downloads Logomenu GNOME extension from GitHub via `verified_download()`, installs extension + GLib schema |
-| `bazaar.chroot` | `shared/snow/scripts/build/` | Clones Bazaar Companion GNOME extension from GitHub, patches metadata.json for shell version "48" |
+| `bazaar.chroot` | `shared/snow/scripts/build/` | Downloads pinned Bazaar Companion GNOME extension tarball from GitHub via `verified_download()`, installs its `src/`, patches metadata.json for shell version "48" |
 | `surface-cert.chroot` | `shared/snow/scripts/build/` | Downloads Linux Surface secure boot certificate via `verified_download()`, installs to `/usr/share/linux-surface-secureboot/` |
 
 **Server profiles (cayo/cayoloaded):** Only `brew.chroot` (no desktop build scripts).


### PR DESCRIPTION
## Problem

`shared/snow/scripts/build/bazaar.chroot` did:

```bash
git clone --depth 1 https://github.com/AlexanderVanhee/bazaar-companion.git ...
```

This is **unpinned** — every build pulls the latest `main` of an upstream repo, which:
- violates the repo convention ("Pin external URLs to specific versions/commits, never `latest` or branch names")
- is non-reproducible (the extension can change between builds without any change in snosi)
- rewrites the tracked extension files under `shared/snow/tree/.../bazaar-integration@.../` on every `just snow`, dirtying the working tree

## Fix

Convert it to the repo's standard verified-download pattern (same as `hotedge.chroot` / `logomenu.chroot`):

- **`shared/download/checksums.json`**: new `bazaar` entry pinning commit `3bb9134` of `AlexanderVanhee/bazaar-companion` (codeload tarball + SHA256).
- **`shared/snow/scripts/build/bazaar.chroot`**: `verified_download "bazaar"` → extract → install `src/` → patch `metadata.json`. No `git clone`, no writes outside the extension dir.
- **`.github/workflows/check-dependencies.yml`**: weekly check that bumps the pin via PR when upstream advances (mirrors hotedge/logomenu).
- **`yeti/build-pipeline.md`**: updated the bazaar row.

## Verification

- `shellcheck -S error -s bash -x` passes.
- `verified_download "bazaar"` succeeds end-to-end (download + checksum match).
- `checksums.json` valid JSON; `check-dependencies.yml` valid YAML.
- Functional test: extracting the pinned tarball and installing `src/` yields the same files as the old `mv src/*`, and the `metadata.json` shell-version `"48"` patch applies identically. **No behavior change** — only the source is now pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)