### PR TITLE
fix: capture only tmpfiles-referenced /etc paths in himmelblau/incus sysexts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ bootc and ostree are **not** installed from APT; they are compiled from pinned s
 
 Sysexts can ONLY provide files under `/usr`. They cannot modify `/etc` or `/var` at runtime. Configs needed in `/etc` must be:
 
-1. Captured to `/usr/share/factory/etc` during build (via `mkosi.finalize`)
+1. Captured to `/usr/share/factory/etc` during build (via `mkosi.finalize`) — capture ONLY the specific paths the sysext's tmpfiles rules reference, never all of `/etc` (the buildroot `/etc` is the merged base view; a full capture ships `/etc/shadow` and SSH host keys in the published sysext)
 2. Injected at boot via systemd-tmpfiles
 
 Every sysext must have matching `<name>.transfer` and `<name>.feature` files in `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/`. The `.transfer` file defines how systemd-sysupdate downloads the sysext; the `.feature` file provides metadata and defaults to `Enabled=false`. Use existing files as templates.

--- a/mkosi.images/himmelblau/mkosi.finalize
+++ b/mkosi.images/himmelblau/mkosi.finalize
@@ -2,7 +2,15 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -euo pipefail
 
-# Capture the entirety of /etc in /usr/share/factory/etc so we can use
-# systemd-tmpfiles to symlink individual directories from it to /etc.
-mkdir -p "$BUILDROOT/usr/share/factory/"
-cp --archive --no-target-directory --update=none "$BUILDROOT/etc" "$BUILDROOT/usr/share/factory/etc"
+# Capture only /etc/himmelblau (referenced by the tmpfiles.d C directive in
+# usr/lib/tmpfiles.d/himmelblau.conf) into /usr/share/factory/etc. Capturing
+# all of /etc would ship the merged base image's /etc — including /etc/shadow
+# and the SSH host keys generated during the base build — in the published
+# sysext (frostyard/snosi#282).
+mkdir -p "$BUILDROOT/usr/share/factory/etc"
+
+if [ -d "$BUILDROOT/etc/himmelblau" ]; then
+    cp --archive --update=none "$BUILDROOT/etc/himmelblau" "$BUILDROOT/usr/share/factory/etc/"
+else
+    echo "himmelblau finalize: /etc/himmelblau not present in buildroot; factory capture skipped" >&2
+fi

--- a/mkosi.images/incus/mkosi.finalize
+++ b/mkosi.images/incus/mkosi.finalize
@@ -2,8 +2,32 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -euo pipefail
 
-# Capture the entirety of /etc in /usr/share/factory/etc so we can use
-# systemd-tmpfiles to symlink individual directories from it to /etc.
-mkdir -p "$BUILDROOT/usr/share/factory/"
-cp --archive --no-target-directory --update=none "$BUILDROOT/etc" "$BUILDROOT/usr/share/factory/etc"
+# Capture only the /etc paths referenced by tmpfiles.d C directives (see
+# usr/lib/tmpfiles.d/incus.conf) into /usr/share/factory/etc. Capturing all
+# of /etc would ship the merged base image's /etc — including /etc/shadow
+# and the SSH host keys generated during the base build — in the published
+# sysext (frostyard/snosi#282).
+FACTORY="$BUILDROOT/usr/share/factory/etc"
+mkdir -p "$FACTORY"
 
+# Paths relative to /etc, matching the C directives in tmpfiles.d/incus.conf
+FACTORY_PATHS=(
+    libnl-3
+    default/incus
+    logrotate.d/incus
+    needrestart/conf.d/incus.conf
+    libvirt
+    profile.d/vte-2.91.sh
+    profile.d/vte.csh
+    qemu-ifdown
+    qemu-ifup
+)
+
+cd "$BUILDROOT/etc"
+for path in "${FACTORY_PATHS[@]}"; do
+    if [ -e "$path" ]; then
+        cp --archive --parents --update=none "$path" "$FACTORY/"
+    else
+        echo "incus finalize: /etc/$path not present in buildroot; factory capture skipped" >&2
+    fi
+done

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -113,7 +113,8 @@ Prepare the image for output. Run after postinstall, before the image format is 
 
 **Sysext finalize** (per-sysext `mkosi.finalize` scripts):
 - Captures `/etc` configs to `/usr/share/factory/etc/` for tmpfiles-based injection at boot
-- Used by: docker, himmelblau (full /etc capture), incus (full /etc capture), nix, tailscale
+- Used by: docker, himmelblau, incus, nix, tailscale
+- Capture ONLY the specific paths referenced by the sysext's tmpfiles.d `C` directives — never all of `/etc`. With `Overlay=yes` the buildroot `/etc` is the merged base view, so a full capture ships the base image's `/etc/shadow` and SSH host keys in the published sysext (frostyard/snosi#282)
 
 ### 4. PostOutputScripts (after image creation)
 

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -10,6 +10,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 2. **Config injection** — Configs needed in `/etc` must be:
    - Captured to `/usr/share/factory/etc/` during the sysext build (via mkosi.finalize)
    - Injected at boot via systemd-tmpfiles rules in `/usr/lib/tmpfiles.d/`
+   - Capture ONLY the specific paths the tmpfiles rules reference — never all of `/etc`. The buildroot `/etc` is the merged base view, so a full capture leaks `/etc/shadow` and SSH host keys into the published sysext (frostyard/snosi#282)
 3. **Overlay composition** — All sysexts overlay the same base `/usr`, so file conflicts between sysexts must be avoided.
 
 ## Current Sysexts
@@ -73,7 +74,7 @@ Some sysexts include extra files via `mkosi.extra/`:
 
 ### himmelblau
 - `mkosi.postinst.chroot` — Post-install customization hook (currently minimal)
-- `mkosi.finalize` — Captures `/etc` to `/usr/share/factory/etc/` for tmpfiles injection at boot
+- `mkosi.finalize` — Captures `/etc/himmelblau` to `/usr/share/factory/etc/` for tmpfiles injection at boot
 - `usr/lib/himmelblau/himmelblau-sysext-setup` — Runtime PAM/NSS injection script (idempotent, runs at boot): adds `himmelblau` to nsswitch.conf passwd/group/shadow, runs `pam-auth-update --enable himmelblau`
 - `usr/lib/systemd/system/himmelblau-sysext-setup.service` — Oneshot service to run setup script (conditioned on `/run/himmelblau-sysext-setup.done`)
 - `usr/lib/systemd/system-preset/40-himmelblau.preset` — Enable himmelblaud and himmelblau-sysext-setup services
@@ -182,7 +183,7 @@ The setup script must be idempotent — safe to run on every boot without accumu
 1. Create `mkosi.images/<name>/mkosi.conf` following the pattern above
 2. Set `KEYPACKAGE` to the primary package name
 3. Add any extra files in `mkosi.images/<name>/mkosi.extra/`
-4. If configs needed in `/etc`: create `mkosi.finalize` to capture to `/usr/share/factory/etc/`, add tmpfiles.d rules
+4. If configs needed in `/etc`: create `mkosi.finalize` to capture ONLY the needed paths to `/usr/share/factory/etc/` (never all of `/etc` — see Constraints), add tmpfiles.d rules
 5. Create `<name>.transfer` and `<name>.feature` in `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/`
 6. **If the sysext ships a systemd service:** add `usr/lib/systemd/system/multi-user.target.d/10-<name>.conf` with `Upholds=<name>.service` (see [Service Activation Pattern](#service-activation-pattern-upholds) above)
 7. Add the sysext name to root `mkosi.conf` Dependencies list


### PR DESCRIPTION
## Summary

Fixes #282 — the himmelblau and incus sysext finalize scripts archived the **entire merged** `$BUILDROOT/etc` into `/usr/share/factory/etc`. With `Overlay=yes` + `BaseTrees=%O/base`, that view includes the base image's `/etc`, so the publicly distributed `himmelblau.raw`/`incus.raw` shipped `/etc/shadow` and the SSH host private keys generated by openssh-server's postinst during the base build (the profile-level key cleanup in `shared/outformat/image/finalize/mkosi.finalize.chroot` never runs for sysexts).

## Changes

- `mkosi.images/himmelblau/mkosi.finalize` — captures only `/etc/himmelblau` (the sole path its tmpfiles `C` directive references), guarded, warns if absent
- `mkosi.images/incus/mkosi.finalize` — captures only the nine `/etc` paths referenced by `tmpfiles.d/incus.conf`, using `cp --archive --parents` to preserve subpaths, per-path guards with warnings
- Both now match the existing docker/tailscale/nix targeted-capture pattern; shellcheck clean
- Docs updated to forbid full-`/etc` capture: CLAUDE.md sysext constraints, `yeti/sysexts.md` (constraints, himmelblau listing, new-sysext checklist), `yeti/build-pipeline.md`

## Verification

Built base + all sysexts locally (`just sysexts`, exit 0) and listed both images with `systemd-dissect --list`:

- **himmelblau.raw** factory tree: only `usr/share/factory/etc/himmelblau/himmelblau.conf`; `grep -cE 'shadow|ssh_host'` → 0
- **incus.raw** factory tree: exactly the eight targeted paths that exist at build time (`default/incus`, `libvirt/`, `logrotate.d/incus`, `needrestart/conf.d/incus.conf`, `profile.d/vte-2.91.sh`, `profile.d/vte.csh`, `qemu-ifdown`, `qemu-ifup`); `grep -cE 'shadow|ssh_host'` → 0
- `/etc/libnl-3` was absent in the buildroot (finalize warned and skipped) — no regression: the old full-copy couldn't have shipped it either, and its likely-dead tmpfiles directive is tracked in #308

## Follow-up (not in this PR)

Already-published `himmelblau.raw`/`incus.raw` artifacts on repository.frostyard.org contain the leaked files and should be replaced once this merges; hosts deployed from affected images regenerate their own SSH keys, so exposure is limited to the build-time-generated keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
