### PR TITLE
fix: add Upholds drop-ins to himmelblau, incus, and nix sysexts

### DIFF
--- a/mkosi.images/himmelblau/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-himmelblau.conf
+++ b/mkosi.images/himmelblau/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-himmelblau.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=himmelblau-sysext-setup.service himmelblaud.service

--- a/mkosi.images/incus/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-incus.conf
+++ b/mkosi.images/incus/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-incus.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=incus-sysext-setup.service incus.socket incus-user.socket incus-lxcfs.service incus-startup.service

--- a/mkosi.images/nix/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-nix.conf
+++ b/mkosi.images/nix/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-nix.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=nix.mount nix-daemon.socket nix-daemon.service

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -77,17 +77,20 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `usr/lib/himmelblau/himmelblau-sysext-setup` — Runtime PAM/NSS injection script (idempotent, runs at boot): adds `himmelblau` to nsswitch.conf passwd/group/shadow, runs `pam-auth-update --enable himmelblau`
 - `usr/lib/systemd/system/himmelblau-sysext-setup.service` — Oneshot service to run setup script (conditioned on `/run/himmelblau-sysext-setup.done`)
 - `usr/lib/systemd/system-preset/40-himmelblau.preset` — Enable himmelblaud and himmelblau-sysext-setup services
+- `usr/lib/systemd/system/multi-user.target.d/10-himmelblau.conf` — `Upholds=` drop-in for reliable boot activation (himmelblaud upholds himmelblaud-tasks itself)
 - `usr/lib/tmpfiles.d/himmelblau.conf` — Config injection from `/usr/share/factory/etc/`
 
 ### incus
 - `usr/lib/systemd/system/incus.service.d/override.conf` — Service override
 - `usr/lib/systemd/system-preset/40-incus.preset` — Enable incus services
+- `usr/lib/systemd/system/multi-user.target.d/10-incus.conf` — `Upholds=` drop-in for reliable boot activation (sockets + lxcfs + startup + sysext-setup; incus.service itself is socket-activated)
 - `usr/lib/sysusers.d/incus-sysext.conf` — User/group definitions
 - `usr/lib/tmpfiles.d/incus-sysext.conf` — Runtime directory setup
 - `usr/bin/incus-sysext-setup` — Custom setup script
 
 ### nix
 - `usr/lib/systemd/` — Mount unit and preset for `/nix` bind mount
+- `usr/lib/systemd/system/multi-user.target.d/10-nix.conf` — `Upholds=nix.mount nix-daemon.socket nix-daemon.service` drop-in for reliable boot activation
 - `usr/lib/sysusers.d/nix.conf` — Nix user/group
 - `usr/lib/tmpfiles.d/nix-sysext.conf` — Runtime setup
 


### PR DESCRIPTION
## Summary

Fixes #283 — himmelblau, incus, and nix relied on `WantedBy=multi-user.target` + preset alone, which the project's own docs (CLAUDE.md "Service activation in sysexts") identify as broken: the sysext is not yet merged when PID 1 scans units, so the preset-created `.wants` symlinks are dangling and silently dropped. After a reboot, himmelblaud (Entra ID login), the incus sockets/instance autostart, and the `/nix` bind mount never came up.

## Changes

One `usr/lib/systemd/system/multi-user.target.d/10-<name>.conf` drop-in per sysext, mirroring the working docker/tailscale pattern:

| Sysext | Upholds | Rationale |
|--------|---------|-----------|
| himmelblau | `himmelblau-sysext-setup.service himmelblaud.service` | Upstream `himmelblaud.service` already carries `Upholds=himmelblaud-tasks.service`, so the tasks daemon (the audit's open question) is covered transitively |
| incus | `incus-sysext-setup.service incus.socket incus-user.socket incus-lxcfs.service incus-startup.service` | `incus.service` is socket-activated (`Requires=incus.socket`, no `WantedBy` — only `Also=`), so the drop-in upholds the **sockets**, avoiding the socket-activation race that bites docker's drop-in (#289) |
| nix | `nix.mount nix-daemon.socket nix-daemon.service` | Mirrors `40-nix.preset`; `Upholds=` works for mount and socket units |

Both oneshot setup services set `RemainAfterExit=yes`, so upholding them cannot retrigger after their first run. The `40-<name>.preset` files are unchanged — they still provide enabled state; the drop-ins fix the activation timing.

Also updated the `yeti/sysexts.md` per-sysext file listings.

## Verification

Rebuilt base + all sysexts (`just sysexts`, exit 0) and inspected the three `.raw` images with `systemd-dissect`:

- each image ships `usr/lib/systemd/system/multi-user.target.d/10-<name>.conf` with exactly the intended `Upholds=` line
- every upheld unit exists in its image (unit files extracted and reviewed: activation type, `RemainAfterExit`, `Condition*`, and upstream `Upholds=`/`Requires=` relationships checked before choosing targets)

Runtime behavior matches the docker/tailscale drop-ins, which are confirmed firing on a live snowloaded host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
