### PR TITLE
fix: replace invalid 'mask' preset verb with disable + /etc mask symlinks

### DIFF
--- a/shared/cayo/tree/etc/systemd/system/apt-daily-upgrade.timer
+++ b/shared/cayo/tree/etc/systemd/system/apt-daily-upgrade.timer
@@ -1,0 +1,1 @@
+/dev/null

--- a/shared/cayo/tree/etc/systemd/system/apt-daily.timer
+++ b/shared/cayo/tree/etc/systemd/system/apt-daily.timer
@@ -1,0 +1,1 @@
+/dev/null

--- a/shared/cayo/tree/etc/systemd/system/dpkg-db-backup.timer
+++ b/shared/cayo/tree/etc/systemd/system/dpkg-db-backup.timer
@@ -1,0 +1,1 @@
+/dev/null

--- a/shared/cayo/tree/etc/systemd/system/systemd-boot-update.service
+++ b/shared/cayo/tree/etc/systemd/system/systemd-boot-update.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/shared/cayo/tree/usr/lib/systemd/system-preset/99-disable-unwanted-services.preset
+++ b/shared/cayo/tree/usr/lib/systemd/system-preset/99-disable-unwanted-services.preset
@@ -1,4 +1,4 @@
-mask systemd-boot-update.service
-mask apt-daily-upgrade.timer
-mask apt-daily.timer
-mask dpkg-db-backup.timer
+disable systemd-boot-update.service
+disable apt-daily-upgrade.timer
+disable apt-daily.timer
+disable dpkg-db-backup.timer

--- a/shared/snow/tree/etc/systemd/system/apt-daily-upgrade.timer
+++ b/shared/snow/tree/etc/systemd/system/apt-daily-upgrade.timer
@@ -1,0 +1,1 @@
+/dev/null

--- a/shared/snow/tree/etc/systemd/system/apt-daily.timer
+++ b/shared/snow/tree/etc/systemd/system/apt-daily.timer
@@ -1,0 +1,1 @@
+/dev/null

--- a/shared/snow/tree/etc/systemd/system/dpkg-db-backup.timer
+++ b/shared/snow/tree/etc/systemd/system/dpkg-db-backup.timer
@@ -1,0 +1,1 @@
+/dev/null

--- a/shared/snow/tree/etc/systemd/system/systemd-boot-update.service
+++ b/shared/snow/tree/etc/systemd/system/systemd-boot-update.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/shared/snow/tree/usr/lib/systemd/system-preset/99-disable-unwanted-services.preset
+++ b/shared/snow/tree/usr/lib/systemd/system-preset/99-disable-unwanted-services.preset
@@ -1,4 +1,4 @@
-mask systemd-boot-update.service
-mask apt-daily-upgrade.timer
-mask apt-daily.timer
-mask dpkg-db-backup.timer
+disable systemd-boot-update.service
+disable apt-daily-upgrade.timer
+disable apt-daily.timer
+disable dpkg-db-backup.timer


### PR DESCRIPTION
## Summary

Fixes #284 — `mask` is not a valid systemd preset verb, so all four lines of `99-disable-unwanted-services.preset` were silently ignored (`Couldn't parse line 'mask systemd-boot-update.service'. Ignoring.` — confirmed in the journal on a live snowloaded host). Two of the four "masked" units were actually running: `systemd-boot-update.service` (bootloader auto-rewrite on an immutable image) and `dpkg-db-backup.timer`.

## Changes

- Both preset files (`shared/snow/tree/...` and `shared/cayo/tree/...`) now use the valid `disable` verb, so preset application produces the intended enabled-state.
- True masking is provided by `etc/systemd/system/<unit> → /dev/null` symlinks shipped in both trees (`/etc` base configs come from the image; user overrides persist via the overlay). This matches the original intent of the `mask` verb and follows the existing precedent of `systemd-networkd-wait-online.service` masking in the base image finalize.

## Behavior change (intended, but worth reviewing)

These four units will now actually stop running on new images: `systemd-boot-update.service`, `apt-daily.timer`, `apt-daily-upgrade.timer`, `dpkg-db-backup.timer`. In particular, masking `systemd-boot-update.service` means systemd-boot will no longer self-update the bootloader from the running system — which is what the preset has claimed to do all along. If bootloader updates are supposed to happen through another path (e.g. bootctl during image update flows), nothing changes there.

## Verification

Static tree files only (preset text + symlinks) — verified the preset now uses only valid verbs and the symlinks resolve to `/dev/null`; existing units on a running host confirm the mask-symlink mechanism (`systemd-networkd-wait-online.service` is masked exactly this way). The PR CI image build exercises the tree copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
