### PR TITLE
fix: don't delete /opt itself in bitwarden postinst

### DIFF
--- a/shared/packages/bitwarden/mkosi.postinst.d/bitwarden.chroot
+++ b/shared/packages/bitwarden/mkosi.postinst.d/bitwarden.chroot
@@ -21,7 +21,8 @@ dpkg -i debs/bitwarden.deb
 rm -rf debs
 
 ${SUDO} mv /opt/Bitwarden /usr/lib/Bitwarden
-${SUDO} rm -rf /opt/{Bitwarden,}
+# /opt itself must stay: it is the mountpoint for opt.mount (bind to /var/opt)
+${SUDO} rm -rf /opt/Bitwarden
 ${SUDO} mkdir -p /usr/bin
 ${SUDO} ln -sf /usr/lib/Bitwarden/bitwarden /usr/bin/bitwarden
 ${SUDO} ln -sf /usr/lib/Bitwarden/bitwarden-app /usr/bin/bitwarden-app


### PR DESCRIPTION
## Summary

Fixes #285 — `shared/packages/bitwarden/mkosi.postinst.d/bitwarden.chroot:24` ran `rm -rf /opt/{Bitwarden,}`, which brace-expands to `/opt/Bitwarden /opt/` and deletes the `/opt` mountpoint from the image. Today this is masked by accidental ordering: `edge.chroot` runs after it in the loaded profiles (lexicographic drop-in order) and its `dpkg -i` recreates `/opt`. Any profile composing bitwarden without edge — or a rename reordering the drop-ins — would ship an image where `opt.mount` (bind to `/var/opt`) fails at boot because it can't create its mountpoint on the read-only root.

## Change

The preceding `mv` has already relocated `/opt/Bitwarden` to `/usr/lib/Bitwarden`, so the `rm` is only cleanup of leftovers. Scope it to `rm -rf /opt/Bitwarden` and add a comment explaining why `/opt` must survive.

## Verification

shellcheck clean; brace-expansion behavior demonstrated (`/opt/{Bitwarden,}` → `/opt/Bitwarden /opt/`). The change is exercised by the snowloaded/snowfieldloaded CI builds, whose SUID smoke test also depends on this script's Bitwarden relocation completing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
