### PR TITLE
ci: fix broken YAML in check-dependencies gh_api fallback

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -27,17 +27,19 @@ jobs:
           CHECKSUMS="shared/download/checksums.json"
           UPDATES=""
 
-          # Authenticated, retried GitHub API fetch. On persistent failure the
-          # pipeline yields an empty string, which every branch below guards
-          # against — a failed check skips that dependency instead of
-          # proposing a bogus "null" update.
-gh_api() {
-  curl -fsSL --retry 3 --retry-delay 2 \
-    -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer ${GH_TOKEN}" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    "$1" 2>/dev/null || echo '[]'
-}
+          # Authenticated, retried GitHub API fetch. On persistent failure it
+          # yields an empty string (|| true — explicit, so the graceful-skip
+          # behavior doesn't depend on the shell's -e/pipefail settings, and
+          # curl's error stays visible in the log). Every branch below guards
+          # against the empty value: a failed check skips that dependency
+          # instead of proposing a bogus "null" update or aborting the run.
+          gh_api() {
+            curl -fsSL --retry 3 --retry-delay 2 \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$1" || true
+          }
 
           # Check Bitwarden (skip drafts/prereleases)
           CURRENT_BW=$(jq -r '.bitwarden.version' "$CHECKSUMS")


### PR DESCRIPTION
## Summary

**main's `check-dependencies.yml` is currently unparseable** — the autofix accepted on #314 (ed173e4) de-indented the `gh_api` function to column 0 inside the `run: |` literal block, which is a YAML scanner error (`could not find expected ':'`, line 34). The next scheduled or manual run of the workflow will fail immediately with a workflow-file error.

## Changes

- Re-indent `gh_api` into the literal block (restoring valid YAML).
- Keep the autofix's intent but as `|| true` instead of `2>/dev/null || echo '[]'`:
  - graceful-skip no longer depends on the shell's `-e`/pipefail settings (the concern Copilot raised — default `run:` has `-e` but *not* pipefail, so the original piped calls were already safe, but explicit is better than folklore)
  - curl's error message stays visible in the log for debugging (no `2>/dev/null`)
  - `echo '[]'` fed an empty *array* to object endpoints, so `.tag_name`/`.sha` lookups errored on the failure path; empty input makes jq exit quietly for both shapes

## Verification

- YAML parses (PyYAML)
- Extracted check step executed live under `bash -e` (Actions default): detected the two genuine upstream updates currently pending (brew-install, ostree 2026.2)
- Executed under `bash -eo pipefail` (worst case) with an invalid token: every call 401s, all guards skip, "All dependencies up to date", exit 0, zero null outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
