### PR TITLE
fix: make kernel version detection deterministic in kernel postinst

### DIFF
--- a/shared/kernel/scripts/postinst/mkosi.postinst.chroot
+++ b/shared/kernel/scripts/postinst/mkosi.postinst.chroot
@@ -5,8 +5,14 @@ set -euo pipefail
 # It performs final customizations
 
 echo "Running post-installation customizations..."
-# Build Initramfs
-KERNEL_VERSION="$(basename "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v -E "*.img" | tail -n 1)")"
+# Build Initramfs for the newest installed kernel. -mindepth 1 keeps
+# /usr/lib/modules itself out of the list; sort -V picks the highest version
+# deterministically when more than one kernel package is installed.
+KERNEL_VERSION="$(find /usr/lib/modules -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -V | tail -n 1)"
+if [[ -z "$KERNEL_VERSION" ]]; then
+  echo "ERROR: no kernel found under /usr/lib/modules" >&2
+  exit 1
+fi
 
 dracut --force --no-hostonly --reproducible --zstd --verbose --add etc-overlay \
   --kver "$KERNEL_VERSION" "/usr/lib/modules/$KERNEL_VERSION/initramfs.img"

--- a/shared/kernel/scripts/postinst/mkosi.postinst.chroot
+++ b/shared/kernel/scripts/postinst/mkosi.postinst.chroot
@@ -8,6 +8,10 @@ echo "Running post-installation customizations..."
 # Build Initramfs for the newest installed kernel. -mindepth 1 keeps
 # /usr/lib/modules itself out of the list; sort -V picks the highest version
 # deterministically when more than one kernel package is installed.
+if [[ ! -d /usr/lib/modules ]]; then
+  echo "ERROR: /usr/lib/modules does not exist" >&2
+  exit 1
+fi
 KERNEL_VERSION="$(find /usr/lib/modules -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -V | tail -n 1)"
 if [[ -z "$KERNEL_VERSION" ]]; then
   echo "ERROR: no kernel found under /usr/lib/modules" >&2


### PR DESCRIPTION
## Summary

Fixes #296 — `KERNEL_VERSION` detection in `shared/kernel/scripts/postinst/mkosi.postinst.chroot` was triple-broken: `grep -v -E "*.img"` is an invalid ERE (GNU grep: warning + no-op filter; non-GNU greps: exit 2), `find` included `/usr/lib/modules` itself (empty dir → `KERNEL_VERSION=modules`), and `tail -n1` picked from unsorted readdir order (wrong kernel with two packages installed).

## Change

```
find /usr/lib/modules -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -V | tail -n 1
```
plus a loud failure when no kernel is found.

## Verification

- shellcheck clean
- Simulated against a fake modules tree with three kernels: old pipeline returned **empty** on this machine (its grep is ugrep, which hard-errors on the invalid ERE — the audit's non-GNU failure mode reproduced for real); new logic picks `6.16.4+deb13-amd64` over `6.9.1-surface` (correct `sort -V` semantics) and the empty-dir guard fires
- Exercised for all six profiles by the PR CI image builds (every profile runs this postinst)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
