### PR TITLE
fix: record rygel user service as deliberately disabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ ln -sf /usr/lib/systemd/user/<service> /etc/systemd/user/<target>.wants/<service
 
 The target (e.g. `gnome-session.target`) comes from the service's `WantedBy=` in its `[Install]` section.
 
-**Known issue:** `deb-systemd-helper` creates `.dsh-also` tracking files in `/var/lib/systemd/deb-systemd-user-helper-enabled/` during the build but may not create the actual enablement symlinks in `/etc/systemd/user/`. If a user service isn't auto-starting after reboot, check whether its symlink is missing from `/etc/systemd/user/<target>.wants/` and compare against its `.dsh-also` file. There may be other services with this same gap that haven't been noticed yet.
+**Known issue:** `deb-systemd-helper` creates `.dsh-also` tracking files in `/var/lib/systemd/deb-systemd-user-helper-enabled/` during the build but may not create the actual enablement symlinks in `/etc/systemd/user/`. If a user service isn't auto-starting after reboot, check whether its symlink is missing from `/etc/systemd/user/<target>.wants/` and compare against its `.dsh-also` file. A full sweep on 2026-07-01 found only two affected units, both resolved deliberately: `gnome-remote-desktop-headless` (removed — conflicts with the non-headless variant) and `rygel` (kept off — tracking removed in `snow.postinst.chroot`). Re-run the comparison when adding packages that ship user services.
 
 ## CI/CD
 

--- a/shared/snow/scripts/postinstall/snow.postinst.chroot
+++ b/shared/snow/scripts/postinstall/snow.postinst.chroot
@@ -26,6 +26,15 @@ ln -sf /usr/lib/systemd/user/gnome-remote-desktop.service /etc/systemd/user/gnom
 ln -sf /usr/lib/systemd/user/gnome-remote-desktop-handover.service /etc/systemd/user/gnome-session.target.wants/gnome-remote-desktop-handover.service
 rm -f /etc/systemd/user/gnome-session.target.wants/gnome-remote-desktop-headless.service
 
+# rygel (UPnP/DLNA media server) is deliberately NOT autostarted: an always-on
+# media server is a surprising desktop default. deb-systemd-helper records it
+# as enabled in its tracking dir even though the enablement symlink is never
+# created (the known dsh gap), leaving inconsistent state — remove the
+# tracking and any symlink so "disabled" is recorded consistently.
+rm -f /etc/systemd/user/default.target.wants/rygel.service
+rm -rf /var/lib/systemd/deb-systemd-user-helper-enabled/rygel.service.dsh-also \
+       /var/lib/systemd/deb-systemd-user-helper-enabled/default.target.wants/rygel.service
+
 # Compile dconf databases to avoid "expect degraded performance" warnings in GNOME services
 dconf update
 


### PR DESCRIPTION
## Summary

Fixes #294. The audit compared every `.dsh-also` tracking file against `/etc/systemd/user/` on a live snowloaded host and found two user services tracked as enabled with no enablement symlink:

- `gnome-remote-desktop-headless` — turns out to be **intentional**: `snow.postinst.chroot` explicitly removes it because it `Conflicts=` the non-headless variant (documented in yeti). No change.
- `rygel` — genuinely inconsistent state from the deb-systemd-helper gap. Decision (per discussion): an always-on UPnP/DLNA media server is a surprising desktop default, so it stays **off** — but now deliberately: the postinst removes the stale tracking files and any symlink, so recorded state matches intent.

Also updates CLAUDE.md's known-issue paragraph: the full sweep found only these two units affected (both now deliberate), with a note to re-run the comparison when adding packages that ship user services.

## Verification

- shellcheck clean (only the pre-existing SC1091 sourcing info)
- Exercised by the four desktop-profile CI builds; the `rm -f`/`rm -rf` are safe no-ops if the paths don't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
