### PR TITLE
fix: unmount and detach loop device in bootc-install-test cleanup

### DIFF
--- a/test/bootc-install-test.sh
+++ b/test/bootc-install-test.sh
@@ -44,6 +44,15 @@ cleanup() {
     echo ""
     echo "=== Cleanup ==="
 
+    # Unmount and detach first — before vm_cleanup removes the backing disk
+    # file and before we attempt to rm -rf WORK_DIR through a live mountpoint.
+    if [[ -n "$WORK_DIR" ]] && mountpoint -q "$WORK_DIR/mnt" 2>/dev/null; then
+        umount "$WORK_DIR/mnt" || true
+    fi
+    if [[ -n "${loop:-}" ]]; then
+        losetup -d "$loop" 2>/dev/null || true
+    fi
+
     # Stop VM and remove disk
     vm_cleanup
 
@@ -53,21 +62,16 @@ cleanup() {
         podman rmi -f "$IMAGE_LOADED" 2>/dev/null || true
     fi
 
-    # If a failure happened between mount and losetup -d in the SSH-key
-    # injection step, unmount and detach before removing WORK_DIR —
-    # otherwise the rm -rf below deletes the installed disk's contents
-    # through the live mountpoint and leaks the loop device.
-    if [[ -n "$WORK_DIR" ]] && mountpoint -q "$WORK_DIR/mnt" 2>/dev/null; then
-        umount "$WORK_DIR/mnt" || true
-    fi
-    if [[ -n "${loop:-}" ]]; then
-        losetup -d "$loop" 2>/dev/null || true
-    fi
-
-    # Remove temp directory
+    # Only remove WORK_DIR once the mountpoint is confirmed gone; if the
+    # umount above failed the directory could still be mounted and an
+    # unconditional rm -rf would delete the installed disk's contents.
     if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
-        rm -rf "$WORK_DIR"
-        echo "Removed temp directory: $WORK_DIR"
+        if ! mountpoint -q "$WORK_DIR/mnt" 2>/dev/null; then
+            rm -rf "$WORK_DIR"
+            echo "Removed temp directory: $WORK_DIR"
+        else
+            echo "WARNING: $WORK_DIR/mnt is still mounted; skipping removal to avoid data loss" >&2
+        fi
     fi
 }
 

--- a/test/bootc-install-test.sh
+++ b/test/bootc-install-test.sh
@@ -53,6 +53,17 @@ cleanup() {
         podman rmi -f "$IMAGE_LOADED" 2>/dev/null || true
     fi
 
+    # If a failure happened between mount and losetup -d in the SSH-key
+    # injection step, unmount and detach before removing WORK_DIR —
+    # otherwise the rm -rf below deletes the installed disk's contents
+    # through the live mountpoint and leaks the loop device.
+    if [[ -n "$WORK_DIR" ]] && mountpoint -q "$WORK_DIR/mnt" 2>/dev/null; then
+        umount "$WORK_DIR/mnt" || true
+    fi
+    if [[ -n "${loop:-}" ]]; then
+        losetup -d "$loop" 2>/dev/null || true
+    fi
+
     # Remove temp directory
     if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
         rm -rf "$WORK_DIR"


### PR DESCRIPTION
## Summary

Fixes #300 — the EXIT trap in `test/bootc-install-test.sh` didn't unmount `$WORK_DIR/mnt` or detach the loop device. A failure between `mount "${loop}p3"` and `losetup -d "$loop"` in the SSH-key injection step meant cleanup ran `rm -rf "$WORK_DIR"` through a live mountpoint (deleting the installed disk's contents) and leaked the loop device.

## Change

`cleanup()` now, before the `rm -rf`:
- `umount "$WORK_DIR/mnt"` guarded by `mountpoint -q` (no-op when nothing is mounted)
- `losetup -d "$loop"` guarded by `[[ -n "${loop:-}" ]]` and tolerant of an already-detached device (the success path detaches in the main flow)

## Verification

shellcheck clean. The happy path is unchanged (both guards no-op after the main flow's own umount/detach); the failure path is only reachable with a mid-injection error, which CI's manual `test-install.yml` run would exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
