### PR TITLE
ci: hardening leftovers from audit batch (#306)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,6 +22,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # A hung mkosi/apt otherwise burns the 6-hour default per matrix leg.
+    timeout-minutes: 180
     permissions:
       contents: read
       packages: write
@@ -124,9 +126,13 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
           MAX_LAYERS: 128
         run: |
+          # head_commit.timestamp is empty on workflow_dispatch/repository_dispatch
+          # and GNU 'date -d ""' silently yields today-midnight; derive the epoch
+          # from the checked-out commit instead (correct for every trigger).
+          SOURCE_EPOCH=$(git log -1 --format=%ct)
           sudo TMPDIR="$TMPDIR" ./shared/outformat/image/chunkah-package.sh \
           "$IMAGE:${{ steps.version.outputs.tag }}" \
-          $(date -d '${{ github.event.head_commit.timestamp }}' +%s)
+          "$SOURCE_EPOCH"
 
       - name: Smoke test - verify SUID bit on sudo
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # A hung mkosi/apt otherwise burns the 6-hour default.
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write
@@ -69,6 +71,16 @@ jobs:
           docker system prune -af || true
           docker builder prune -af || true
           df -h
+
+      - name: Redirect temp to /mnt
+        # Same disk-exhaustion class as build-images.yml: mkosi's workspace
+        # defaults to TMPDIR on /, which is the tighter volume on hosted
+        # runners; /mnt has the headroom. sudo -E preserves TMPDIR below.
+        run: |
+          sudo mkdir -p /mnt/tmp
+          sudo chmod 1777 /mnt/tmp
+          echo "TMPDIR=/mnt/tmp" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Free disk space
         run: |
@@ -49,9 +51,13 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Pull image
+        env:
+          TAG: ${{ inputs.image_tag || 'latest' }}
         run: |
-          podman pull ${{ env.IMAGE }}:${{ inputs.image_tag || 'latest' }}
+          podman pull "${IMAGE}:${TAG}"
 
       - name: Run installation tests
+        env:
+          TAG: ${{ inputs.image_tag || 'latest' }}
         run: |
-          ./test/bootc-install-test.sh ${{ env.IMAGE }}:${{ inputs.image_tag || 'latest' }}
+          ./test/bootc-install-test.sh "${IMAGE}:${TAG}"


### PR DESCRIPTION
## Summary

Picks up the #306 items that were deferred until the earlier CI PRs merged (same files):

- **`build-images.yml`:** `SOURCE_DATE_EPOCH` for chunked layers now comes from `git log -1 --format=%ct` — `github.event.head_commit.timestamp` is empty on `workflow_dispatch`/`repository_dispatch`, and `date -d ''` silently yields today-midnight instead of failing. Also `timeout-minutes: 180` on the matrix job.
- **`build.yml`:** `timeout-minutes: 120`, plus the TMPDIR-on-/mnt redirect that `build-images.yml` already has (`sudo -E mkosi build` preserves it) — same disk-exhaustion class as the documented runner issue.
- **`test-install.yml`:** `image_tag` input passed via `env:` instead of inline `run:` interpolation; `persist-credentials: false` on checkout.

**Not closing #306:** the remaining items there are update automation for `RUST_VERSION`, the chunkah image digest, and the syft/cosign version inputs (Dependabot bumps action SHAs but not `with:` version inputs). I'll comment the remaining scope on the issue.

## Verification

All three workflows parse (PyYAML); `git log -1 --format=%ct` verified to work post-checkout for all trigger types (it reads the checked-out commit, not event payload). The touched steps are exercised on the next main push / manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
