### PR TITLE
chore: mkosi/APT config cleanup batch

### DIFF
--- a/mkosi.images/1password-cli/mkosi.conf
+++ b/mkosi.images/1password-cli/mkosi.conf
@@ -12,7 +12,9 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-Environment=KEYPACKAGE=1password-cli
 
 # 1password
 Packages=1password-cli
+
+[Build]
+Environment=KEYPACKAGE=1password-cli

--- a/mkosi.images/code-server/mkosi.conf
+++ b/mkosi.images/code-server/mkosi.conf
@@ -12,4 +12,10 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+
+[Build]
+# NOTE: unlike every other sysext, code-server is not in Packages= — the deb
+# is installed by mkosi.postinst.chroot via verified_download + dpkg -i. The
+# postoutput script still resolves KEYPACKAGE from the merged dpkg database,
+# so keep this in sync with the postinst if the install mechanism changes.
 Environment=KEYPACKAGE=code-server

--- a/mkosi.images/debdev/mkosi.conf
+++ b/mkosi.images/debdev/mkosi.conf
@@ -12,7 +12,6 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-Environment=KEYPACKAGE=debootstrap
 
 Packages=debootstrap
     distro-info
@@ -22,3 +21,6 @@ Packages=debootstrap
     mount
     binutils
     ubuntu-archive-keyring
+
+[Build]
+Environment=KEYPACKAGE=debootstrap

--- a/mkosi.images/dev/mkosi.conf
+++ b/mkosi.images/dev/mkosi.conf
@@ -12,7 +12,6 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-Environment=KEYPACKAGE=build-essential
 
 Packages=build-essential
     make
@@ -38,3 +37,6 @@ Packages=build-essential
     live-build
     debootstrap
 
+
+[Build]
+Environment=KEYPACKAGE=build-essential

--- a/mkosi.images/docker/mkosi.conf
+++ b/mkosi.images/docker/mkosi.conf
@@ -12,7 +12,6 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-Environment=KEYPACKAGE=docker-ce
 
 # Docker (from docker.com repo in mkosi.sandbox)
 Packages=docker-ce
@@ -22,3 +21,6 @@ Packages=docker-ce
          docker-compose-plugin
          docker-ce-rootless-extras
 
+
+[Build]
+Environment=KEYPACKAGE=docker-ce

--- a/mkosi.images/himmelblau/mkosi.conf
+++ b/mkosi.images/himmelblau/mkosi.conf
@@ -12,9 +12,11 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-Environment=KEYPACKAGE=himmelblau
 
 # Himmelblau Entra ID authentication (from himmelblau-idm.org nightly repo)
 Packages=himmelblau
          pam-himmelblau
          nss-himmelblau
+
+[Build]
+Environment=KEYPACKAGE=himmelblau

--- a/mkosi.images/incus/mkosi.conf
+++ b/mkosi.images/incus/mkosi.conf
@@ -12,7 +12,6 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-Environment=KEYPACKAGE=incus
 
 # Incus (from Debian trixie)
 Packages=incus
@@ -27,3 +26,6 @@ Packages=incus
          ipxe-qemu
          genisoimage
          virt-viewer
+
+[Build]
+Environment=KEYPACKAGE=incus

--- a/mkosi.images/incus/mkosi.extra/usr/lib/tmpfiles.d/incus.conf
+++ b/mkosi.images/incus/mkosi.extra/usr/lib/tmpfiles.d/incus.conf
@@ -2,9 +2,6 @@
 # Copies configuration files from factory defaults and creates necessary symlinks
 
 
-# libnl-3 configuration
-C /etc/libnl-3 - - - - -
-
 # incus default configuration
 C /etc/default/incus - - - - -
 

--- a/mkosi.images/incus/mkosi.finalize
+++ b/mkosi.images/incus/mkosi.finalize
@@ -12,7 +12,6 @@ mkdir -p "$FACTORY"
 
 # Paths relative to /etc, matching the C directives in tmpfiles.d/incus.conf
 FACTORY_PATHS=(
-    libnl-3
     default/incus
     logrotate.d/incus
     needrestart/conf.d/incus.conf

--- a/mkosi.images/nix/mkosi.conf
+++ b/mkosi.images/nix/mkosi.conf
@@ -12,7 +12,9 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-Environment=KEYPACKAGE=nix-setup-systemd
 
 # Nix package manager
 Packages=nix-setup-systemd
+
+[Build]
+Environment=KEYPACKAGE=nix-setup-systemd

--- a/mkosi.images/podman/mkosi.conf
+++ b/mkosi.images/podman/mkosi.conf
@@ -12,7 +12,6 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-Environment=KEYPACKAGE=podman
 
 # Podman/ Distrobox / Containers
 Packages=podman
@@ -29,3 +28,6 @@ Packages=aardvark-dns
          fuse-overlayfs
          slirp4netns
          passt
+
+[Build]
+Environment=KEYPACKAGE=podman

--- a/mkosi.images/tailscale/mkosi.conf
+++ b/mkosi.images/tailscale/mkosi.conf
@@ -12,6 +12,8 @@ Format=sysext
 Bootable=no
 BaseTrees=%O/base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-Environment=KEYPACKAGE=tailscale
 
 Packages=tailscale
+
+[Build]
+Environment=KEYPACKAGE=tailscale

--- a/mkosi.sandbox/etc/apt/sources.list.d/debian-backports.sources
+++ b/mkosi.sandbox/etc/apt/sources.list.d/debian-backports.sources
@@ -1,5 +1,5 @@
 Types: deb deb-src
-URIs: http://deb.debian.org/debian
+URIs: https://deb.debian.org/debian
 Suites: trixie-backports
 Components: main contrib non-free non-free-firmware
 Enabled: yes

--- a/mkosi.sandbox/etc/apt/sources.list.d/tailscale.list
+++ b/mkosi.sandbox/etc/apt/sources.list.d/tailscale.list
@@ -1,1 +1,0 @@
-deb [arch=amd64 signed-by=/etc/apt/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/debian trixie main

--- a/mkosi.sandbox/etc/apt/sources.list.d/tailscale.sources
+++ b/mkosi.sandbox/etc/apt/sources.list.d/tailscale.sources
@@ -1,0 +1,7 @@
+Types: deb
+URIs: https://pkgs.tailscale.com/stable/debian
+Suites: trixie
+Components: main
+Architectures: amd64
+Enabled: yes
+Signed-By: /etc/apt/keyrings/tailscale-archive-keyring.gpg

--- a/shared/cayo/tree/etc/apt/sources.list.d/debian-backports.sources
+++ b/shared/cayo/tree/etc/apt/sources.list.d/debian-backports.sources
@@ -1,5 +1,5 @@
 Types: deb deb-src
-URIs: http://deb.debian.org/debian
+URIs: https://deb.debian.org/debian
 Suites: trixie-backports
 Components: main non-free-firmware
 Enabled: yes

--- a/shared/packages/snow/mkosi.conf
+++ b/shared/packages/snow/mkosi.conf
@@ -45,7 +45,6 @@ Packages=adwaita-icon-theme
          ptyxis
          pipewire
          dbus-broker
-         mesa-va-drivers
 
 
 # nspawn
@@ -62,9 +61,9 @@ Packages=ghostty
 Packages=gnome-shell-extension-appindicator
 
 
-# Mesa/Graphics from backports
-Packages=mesa-vulkan-drivers
-
+# Mesa/graphics packages come pinned from the kernel fragments
+# (shared/kernel/{backports,surface}/mkosi.conf) — do not add unpinned
+# duplicates here; apt's explicit /trixie-backports selection must win.
 # ALSA / Audio
 Packages=alsa-topology-conf
          alsa-ucm-conf

--- a/shared/snow/tree/etc/apt/sources.list.d/debian-backports.sources
+++ b/shared/snow/tree/etc/apt/sources.list.d/debian-backports.sources
@@ -1,5 +1,5 @@
 Types: deb deb-src
-URIs: http://deb.debian.org/debian
+URIs: https://deb.debian.org/debian
 Suites: trixie-backports
 Components: main non-free-firmware
 Enabled: yes


### PR DESCRIPTION
## Summary

Fixes #308 — the low-severity mkosi/APT configuration batch.

## Changes

- **`Environment=KEYPACKAGE=` → `[Build]`** in all 10 sysext confs. mkosi 27 emitted `Setting Environment should be configured in [Build]` on every summary and build; a future release may hard-fail. `mkosi summary` now emits **zero** warnings (was 11). Profiles needed nothing — #331 already removed their only `Environment=` (BREW_TREE).
- **incus:** dead `C /etc/libnl-3` tmpfiles directive pruned, plus its entry in the finalize factory capture — the path never exists in the buildroot (verified across the #310 and this build), so it could only produce boot-time copy-failure noise.
- **code-server:** comment documenting why `KEYPACKAGE` isn't in `Packages=` (deb installed by postinst `dpkg -i`) so a refactor doesn't silently break postoutput naming.
- **mesa duplicates** dropped from the snow package set (kernel fragments pin them to `/trixie-backports`; apt's explicit selection must win). ⚠️ Reviewer note: the naive removal left an **empty `Packages=`**, which in mkosi *resets* the accumulated package list — caught during verification and replaced with a warning comment instead.
- **debian-backports** sources: `http://` → `https://` in all three copies (sandbox, snow tree, cayo tree).
- **tailscale.list** (last legacy one-line source) converted to deb822 `tailscale.sources`.

## Verification

- `mkosi summary`: zero warnings; all six profiles parse
- `mesa-va-drivers/trixie-backports` + `mesa-vulkan-drivers/trixie-backports` still resolve for snow via the kernel fragment
- **Full sysext build (exit 0):** every sysext produced correctly versioned output (`docker_5+29.6.1-…`, `code-server_4.126.0_…`, etc.) proving `[Build]` `Environment=` reaches PostOutputScripts; `tailscale_1.98.8_…` built, proving the deb822 source resolves; zero `factory capture skipped` warnings after the libnl-3 prune

🤖 Generated with [Claude Code](https://claude.com/claude-code)
