### PR TITLE
fix: boot noise batch — alternatives symlinks, dconf DBs, emdash wiring

### DIFF
--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/emdash.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/emdash.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=Emdash dashboard
+Documentation=https://frostyard.org
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/emdash.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/emdash.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=emdash
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/emdash/
+MatchPattern=emdash_@v_%w_%a.raw.zst \
+             emdash_@v_%w_%a.raw.xz \
+             emdash_@v_%w_%a.raw.gz \
+             emdash_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=emdash_@v_%w_%a.raw.zst \
+             emdash_@v_%w_%a.raw.xz \
+             emdash_@v_%w_%a.raw.gz \
+             emdash_@v_%w_%a.raw
+CurrentSymlink=emdash.raw

--- a/mkosi.images/debdev/mkosi.postinst.chroot
+++ b/mkosi.images/debdev/mkosi.postinst.chroot
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+# Sysexts can only ship /usr, so update-alternatives symlinks created while
+# installing this sysext's packages would dangle at runtime — their
+# /etc/alternatives targets never leave the build (frostyard/snosi#309;
+# observed live: /usr/bin/automake -> /etc/alternatives/automake, missing).
+# Repoint any /usr/bin and /usr/sbin symlink that routes through
+# /etc/alternatives to its fully resolved target instead.
+for dir in /usr/bin /usr/sbin; do
+    [ -d "$dir" ] || continue
+    find "$dir" -maxdepth 1 -type l | while read -r link; do
+        target=$(readlink "$link")
+        case "$target" in
+            /etc/alternatives/*) ;;
+            *) continue ;;
+        esac
+        resolved=$(readlink -f "$link" || true)
+        if [ -n "$resolved" ] && [ -e "$resolved" ]; then
+            ln -sf "$resolved" "$link"
+            echo "repointed $link -> $resolved (was $target)"
+        else
+            echo "WARNING: $link -> $target does not resolve; leaving as-is" >&2
+        fi
+    done
+done

--- a/mkosi.images/dev/mkosi.postinst.chroot
+++ b/mkosi.images/dev/mkosi.postinst.chroot
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+# Sysexts can only ship /usr, so update-alternatives symlinks created while
+# installing this sysext's packages would dangle at runtime — their
+# /etc/alternatives targets never leave the build (frostyard/snosi#309;
+# observed live: /usr/bin/automake -> /etc/alternatives/automake, missing).
+# Repoint any /usr/bin and /usr/sbin symlink that routes through
+# /etc/alternatives to its fully resolved target instead.
+for dir in /usr/bin /usr/sbin; do
+    [ -d "$dir" ] || continue
+    find "$dir" -maxdepth 1 -type l | while read -r link; do
+        target=$(readlink "$link")
+        case "$target" in
+            /etc/alternatives/*) ;;
+            *) continue ;;
+        esac
+        resolved=$(readlink -f "$link" || true)
+        if [ -n "$resolved" ] && [ -e "$resolved" ]; then
+            ln -sf "$resolved" "$link"
+            echo "repointed $link -> $resolved (was $target)"
+        else
+            echo "WARNING: $link -> $target does not resolve; leaving as-is" >&2
+        fi
+    done
+done

--- a/shared/snow/scripts/postinstall/snow.postinst.chroot
+++ b/shared/snow/scripts/postinstall/snow.postinst.chroot
@@ -35,7 +35,14 @@ rm -f /etc/systemd/user/default.target.wants/rygel.service
 rm -rf /var/lib/systemd/deb-systemd-user-helper-enabled/rygel.service.dsh-also \
        /var/lib/systemd/deb-systemd-user-helper-enabled/default.target.wants/rygel.service
 
-# Compile dconf databases to avoid "expect degraded performance" warnings in GNOME services
+# Compile dconf databases to avoid "expect degraded performance" warnings in GNOME services.
+# The shipped profile (shared/snow/tree/etc/dconf/profile/user) references
+# system-db:local and system-db:site; without compiled databases every
+# flatpak/gnome-session/portal start logs "unable to open file
+# '/etc/dconf/db/local'" (24+ warnings per boot). Empty keyfile dirs make
+# dconf update produce valid empty databases, and admins can drop overrides
+# into them later.
+mkdir -p /etc/dconf/db/local.d /etc/dconf/db/site.d
 dconf update
 
 # Remove fish desktop entry

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -67,6 +67,9 @@ Some sysexts include extra files via `mkosi.extra/`:
 ### code-server
 - `mkosi.postinst.chroot` — Downloads code-server .deb via `verified_download()`, installs with `dpkg -i`. Upstream package targets `/usr/lib/code-server` with `/usr/bin/code-server` symlink and systemd units under `/usr/lib/systemd/`, so no relocation is required.
 
+### debdev / dev
+- `mkosi.postinst.chroot` — Repoints `/usr/bin`+`/usr/sbin` symlinks that route through `/etc/alternatives` to their resolved targets. Sysexts cannot ship `/etc`, so alternatives symlinks created while installing these sysexts' packages would dangle at runtime (observed live: `/usr/bin/automake -> /etc/alternatives/automake`, missing).
+
 ### docker
 - `usr/lib/systemd/system-preset/20-docker.preset` — Enable docker.socket + containerd (numbered below 30 so it beats the base image's `30-docker.preset` disable; presets are first-match-wins in lexical order)
 - `usr/lib/systemd/system/multi-user.target.d/10-docker.conf` — `Upholds=docker.socket containerd.service` drop-in for reliable boot activation (the socket, not docker.service — dockerd runs `-H fd://` and fails without socket-passed FDs)
@@ -117,6 +120,11 @@ The shared postoutput script (`shared/sysext/postoutput/sysext-postoutput.sh`) h
 ## Sysupdate Registration
 
 Each sysext needs two files in the base image at `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/`:
+
+> Note: `emdash.transfer`/`emdash.feature` are also registered here even though
+> the emdash sysext is built and published from a separate repository — every
+> sysext distributed via repository.frostyard.org needs its sysupdate wiring in
+> the base image regardless of where it is built.
 
 ### Transfer file (`<name>.transfer`)
 


### PR DESCRIPTION
## Summary

Addresses #309 (three of four items; see below for the deferred one).

- **Dangling alternatives symlinks (L1):** new `mkosi.postinst.chroot` in the **dev** and **debdev** sysexts repoints `/usr/bin`+`/usr/sbin` symlinks that route through `/etc/alternatives` to their resolved targets — sysexts can't ship `/etc`, so alternatives registered by their packages dangle at runtime. Verified in the built images: `usr/bin/automake -> /usr/bin/automake-1.17`, `aclocal -> /usr/bin/aclocal-1.17` (the exact links found broken on a live host). 94 links repointed across both sysexts; base-inherited ones (awk, pager, …) get harmlessly re-shipped resolved — at runtime base's `/etc/alternatives` still exists and resolves identically.
- **dconf boot warnings (L24):** the shipped profile references `system-db:local`/`site` but no databases existed → 24+ `unable to open file '/etc/dconf/db/local'` warnings per boot. `snow.postinst.chroot` now creates empty `local.d`/`site.d` keyfile dirs before its existing `dconf update`, yielding valid empty databases while keeping the admin-override hook points. (`dconf compile` verified to accept empty dirs.)
- **emdash sysupdate wiring (LM3):** `repository.frostyard.org/ext/emdash/` is live and updex ships an `Enabled=true` drop-in for it, but the base image had no `emdash.transfer`/`.feature`, so `systemd-sysupdate features` didn't know it existed (orphaned drop-in observed live). Registered both following the standard pattern; yeti notes that externally-built sysexts still register here.

## Deferred: tss initrd noise (L23)

The `Failed to resolve user 'tss'` initrd messages are cosmetic (post-switch-root, `/dev/tpm0` ends up correctly `tss root`). The candidate fixes — omitting the tpm2-tss dracut module or injecting passwd entries into the initrd — risk breaking TPM-based unlock flows and can't be validated without booting a built image. Left on #309 with a note rather than shipping an unverifiable change.

## Verification

Full sysext build (exit 0): build log shows the 94 repointed links; `systemd-dissect` mtree confirms the resolved `automake`/`aclocal` targets in `dev.raw`; `emdash.transfer`/`.feature` present in the built base tree; dconf behavior proven via `dconf compile` on an empty keyfile dir (valid GVariant DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
