### PR TITLE
docs: audit accuracy batch — sysext templates, tree layout, CI coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ The shared sysext postoutput script (`shared/sysext/postoutput/sysext-postoutput
 - `shared/bootc/` - In-tree source build of bootc (v1.16.2) and ostree (v2026.1); `build/bootc.chroot` is a base image **BuildScript** (wired via `BuildScripts=`); build deps come from `BuildPackages=` (overlay-only, discarded after build); compiles both tools (autotools for ostree, offline vendored cargo for bootc) and installs into `$DESTDIR`, which mkosi copies into the image
 - `shared/kernel/` - Kernel configs (backports, surface, stock) and dracut scripts
 - `shared/packages/` - Package set definitions, some with postinstall scripts for relocation
-- `shared/outformat/image/` - Image output format config (directory), finalize scripts, and `buildah-package.sh` for OCI packaging
+- `shared/outformat/image/` - Image output format config (directory), finalize scripts, `buildah-package.sh` (OCI packaging), and `chunkah-package.sh` (CI re-chunks the OCI image for efficient delta updates)
 - `shared/sysext/postoutput/` - Shared sysext postoutput logic
 - `mkosi.sandbox/etc/apt/` - External APT repo configs (Docker, Incus, linux-surface, Frostyard)
 

--- a/README.md
+++ b/README.md
@@ -519,9 +519,27 @@ set -euo pipefail
 # in the published sysext.
 FACTORY="$BUILDROOT/usr/share/factory/etc"
 mkdir -p "$FACTORY"
+
+# Paths relative to /etc, matching the C directives in usr/lib/tmpfiles.d/incus.conf
+FACTORY_PATHS=(
+    libnl-3
+    default/incus
+    logrotate.d/incus
+    needrestart/conf.d/incus.conf
+    libvirt
+    profile.d/vte-2.91.sh
+    profile.d/vte.csh
+    qemu-ifdown
+    qemu-ifup
+)
+
 cd "$BUILDROOT/etc"
-for path in default/incus logrotate.d/incus libvirt ...; do
-    [ -e "$path" ] && cp --archive --parents --update=none "$path" "$FACTORY/"
+for path in "${FACTORY_PATHS[@]}"; do
+    if [ -e "$path" ]; then
+        cp --archive --parents --update=none "$path" "$FACTORY/"
+    else
+        echo "incus finalize: /etc/$path not present in buildroot; factory capture skipped" >&2
+    fi
 done
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The project produces:
 
 | Image               | Description                                                     | Output Format |
 | ------------------- | --------------------------------------------------------------- | ------------- |
-| **snow**            | GNOME desktop with backports kernel                             | OCI archive   |
-| **snowloaded**      | snow + Edge + VSCode + Bitwarden + Incus + Azure VPN            | OCI archive   |
-| **snowfield**       | snow with linux-surface kernel for Surface devices              | OCI archive   |
-| **snowfieldloaded** | snowfield + Edge + VSCode + Bitwarden + Incus + Azure VPN       | OCI archive   |
-| **cayo**            | Headless server with podman + backports kernel                  | OCI archive   |
-| **cayoloaded**      | cayo + Docker + Incus (baked in)                                | OCI archive   |
+| **snow**            | GNOME desktop with backports kernel                             | directory → OCI (buildah/chunkah) |
+| **snowloaded**      | snow + Edge + VSCode + Bitwarden + Incus + Azure VPN            | directory → OCI (buildah/chunkah) |
+| **snowfield**       | snow with linux-surface kernel for Surface devices              | directory → OCI (buildah/chunkah) |
+| **snowfieldloaded** | snowfield + Edge + VSCode + Bitwarden + Incus + Azure VPN       | directory → OCI (buildah/chunkah) |
+| **cayo**            | Headless server with podman + backports kernel                  | directory → OCI (buildah/chunkah) |
+| **cayoloaded**      | cayo + Docker + Incus (baked in)                                | directory → OCI (buildah/chunkah) |
 | **1password-cli**   | 1Password CLI tool                                              | sysext        |
 | **code-server**     | code-server (VS Code in the browser)                            | sysext        |
 | **debdev**          | Debian development tools (debootstrap, distro-info)             | sysext        |
@@ -100,32 +100,49 @@ shared/
 │   ├── backports/mkosi.conf   ← Trixie backports kernel + firmware
 │   ├── surface/mkosi.conf     ← linux-surface kernel + iptsd
 │   └── scripts/               ← dracut postinst scripts
+├── bootc/                     ← In-tree source build of bootc + ostree
+│   ├── build/bootc.chroot     ← Base image BuildScript
+│   └── postinst/              ← dpkg stub registration
+├── download/
+│   ├── checksums.json         ← Pinned URLs + SHA256s for all external downloads
+│   └── verified-download.sh   ← verified_download() helper
+├── kernel/
+│   ├── backports/mkosi.conf   ← Trixie backports kernel + firmware
+│   ├── surface/mkosi.conf     ← linux-surface kernel + iptsd
+│   ├── stock/mkosi.conf       ← Stock Trixie kernel
+│   └── scripts/               ← dracut postinst scripts
+├── manifest/postoutput/       ← Manifest annotation postoutput script
 ├── outformat/
-│   └── oci/
+│   └── image/
 │       ├── mkosi.conf         ← Sets Format=directory
-│       ├── finalize/          ← OCI finalization scripts
-│       └── postoutput/        ← OCI tagging scripts
+│       ├── finalize/          ← Image finalization scripts
+│       ├── buildah-package.sh ← Packages rootfs dir into an OCI image
+│       └── chunkah-package.sh ← Re-chunks the OCI image for efficient updates
 ├── packages/
-│   ├── cayo/mkosi.conf        ← Server packages + podman (~155 lines)
-│   ├── snow/mkosi.conf        ← GNOME desktop packages (~490 lines)
+│   ├── cayo/mkosi.conf        ← Server packages + podman
+│   ├── snow/mkosi.conf        ← GNOME desktop packages
 │   ├── edge/mkosi.conf        ← Microsoft Edge browser
 │   ├── azurevpn/mkosi.conf    ← Azure VPN Client
 │   ├── vscode/mkosi.conf      ← Visual Studio Code
 │   ├── bitwarden/mkosi.conf   ← Bitwarden password manager
+│   ├── entra-sso/mkosi.conf   ← linux-entra-sso browser SSO
 │   ├── docker-onimage/        ← Docker CE for baked-in images
 │   ├── virt-base/mkosi.conf   ← Headless Incus virtualization
 │   └── virt/mkosi.conf        ← Incus virtualization
 ├── scripts/
-│   └── build/               ← Shared build-time scripts (brew.chroot)
+│   ├── build/                 ← Shared build-time scripts (brew.chroot)
+│   └── common-postinst.sh     ← Shared postinstall logic (os-release, manifest)
+├── sysext/postoutput/         ← Shared sysext versioning/naming postoutput
 ├── cayo/
 │   ├── tree/                  ← Extra files overlaid into cayo image
 │   └── scripts/
 │       └── postinstall/       ← Post-installation customizations
-└── snow/
-    ├── tree/                  ← Extra files overlaid into image
-    └── scripts/
-        ├── build/             ← Build-time scripts (brew, surface-cert, etc.)
-        └── postinstall/       ← Post-installation customizations
+├── snow/
+│   ├── tree/                  ← Extra files overlaid into image
+│   └── scripts/
+│       ├── build/             ← Build-time scripts (hotedge, logomenu, bazaar, surface-cert)
+│       └── postinstall/       ← Post-installation customizations
+└── snowloaded/                ← Loaded-variant tree overlay
 ```
 
 ### Example: snow Profile
@@ -212,6 +229,12 @@ just cayoloaded
 
 # Clean build artifacts
 just clean
+
+# Run the bootc installation test in QEMU/KVM
+just test-install
+
+# Boot a built image in QEMU
+just run-qemu
 ```
 
 ### Build Process
@@ -288,6 +311,16 @@ gh attestation verify oci://ghcr.io/frostyard/snowloaded:latest --owner frostyar
 ```
 
 The `test-install.yml` workflow verifies the signature before every installation test.
+
+### Other workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `check-dependencies.yml` | Weekly | Checks pinned external downloads (checksums.json) for updates, opens PRs |
+| `check-packages.yml` | Daily | Checks external APT package versions, opens PRs |
+| `validate.yml` | PR/push | shellcheck (all shebang-discovered scripts, `-S warning`) + `mkosi summary` validation for every profile |
+| `test-install.yml` | Manual | Signature-verified bootc installation test in QEMU/KVM |
+| `scorecard.yml` | Weekly | OpenSSF supply-chain security analysis |
 
 ## Frostyard Custom Packages
 
@@ -464,8 +497,8 @@ Sysexts can **only** provide files under `/usr`. They cannot:
 | Script                  | When It Runs               | Purpose                            |
 | ----------------------- | -------------------------- | ---------------------------------- |
 | `mkosi.postinst.chroot` | Build time, in chroot      | Relocate files, fix paths          |
-| `mkosi.finalize`        | Build time, outside chroot | Capture `/etc` to factory defaults |
-| `mkosi.postoutput`      | After image creation       | Rename output, update manifests    |
+| `mkosi.finalize`        | Build time, outside chroot | Capture needed `/etc` paths to factory defaults |
+| shared postoutput (`PostOutputScripts=`) | After image creation | Versioned naming + manifest processing — every sysext points at `shared/sysext/postoutput/sysext-postoutput.sh` and sets `Environment=KEYPACKAGE=`; there is no per-sysext postoutput script |
 
 #### Example: Incus Sysext
 
@@ -474,33 +507,27 @@ The [incus sysext](mkosi.images/incus/) needs special handling because:
 1. **Incus packages install configs to `/etc`** - but sysexts can't modify `/etc` at runtime
 2. **The sysext needs versioned filenames** - for update management
 
-**[mkosi.finalize](mkosi.images/incus/mkosi.finalize):** (captures `/etc` for tmpfiles.d)
+**[mkosi.finalize](mkosi.images/incus/mkosi.finalize):** (captures the needed `/etc` paths for tmpfiles.d)
 
 ```bash
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Copy /etc to /usr/share/factory/etc so systemd-tmpfiles
-# can symlink configs into /etc at boot time
-mkdir -p "$BUILDROOT/usr/share/factory/"
-cp --archive --no-target-directory --update=none \
-   "$BUILDROOT/etc" "$BUILDROOT/usr/share/factory/etc"
+# Capture ONLY the /etc paths referenced by tmpfiles.d C directives.
+# Never capture all of /etc: the buildroot /etc is the merged base view,
+# so a full capture ships the base image's /etc/shadow and SSH host keys
+# in the published sysext.
+FACTORY="$BUILDROOT/usr/share/factory/etc"
+mkdir -p "$FACTORY"
+cd "$BUILDROOT/etc"
+for path in default/incus logrotate.d/incus libvirt ...; do
+    [ -e "$path" ] && cp --archive --parents --update=none "$path" "$FACTORY/"
+done
 ```
 
 This pattern allows configs to be "injected" into `/etc` via systemd-tmpfiles rules when the sysext is activated.
 
-**[mkosi.postoutput](mkosi.images/incus/mkosi.postoutput):** (versioned naming)
-
-```bash
-#!/bin/bash
-# Extract version from manifest and rename output file
-KEYVERSION=$(jq -r '.packages[] | select(.name == "incus") | .version' "$MANIFEST_FILE")
-ARCH=$(jq -r '.packages[] | select(.name == "incus") | .architecture' "$MANIFEST_FILE")
-
-# Rename: incus.raw → incus_6.20-debian13_amd64.raw
-cp "$OUTPUTDIR/incus.raw" "$OUTPUTDIR/incus_${KEYVERSION}_${ARCH}.raw"
-ln -s "incus_${KEYVERSION}_${ARCH}.raw" "$OUTPUTDIR/incus"
-```
+**Versioned naming** is handled by the shared postoutput script — the sysext's `mkosi.conf` wires `PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh` and sets `Environment=KEYPACKAGE=incus`; the script reads the key package's version from the manifest and renames the output to `incus_<version>_<os>_<arch>.raw`. Do not create per-sysext postoutput scripts.
 
 #### Sysext Checklist
 
@@ -519,16 +546,28 @@ When creating a new sysext, verify:
 
 ```ini
 # mkosi.images/mysysext/mkosi.conf
+[Config]
+Dependencies=base
+
 [Output]
 ImageId=mysysext
+Output=mysysext
 Overlay=yes
+ManifestFormat=json
 Format=sysext
 
 [Content]
 Bootable=no
 BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+
 Packages=mypackage
+
+[Build]
+Environment=KEYPACKAGE=mypackage
 ```
+
+Then register it: add `mysysext` to the root `mkosi.conf` `Dependencies=` list, and create `mysysext.transfer` + `mysysext.feature` in `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/` (copy an existing pair).
 
 If the package needs relocation, add:
 

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -1,6 +1,5 @@
 {
   "himmelblau": "4.0.0-debian13~20260701",
-  "microsoft-edge-stable": "147.0.3912.60-1",
   "code": "1.126.0-1782208079",
   "docker-ce": "5:29.6.1-1~debian.13~trixie",
   "1password-cli": "2.34.1-1"

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -208,6 +208,13 @@ Configured in `mkosi.sandbox/etc/apt/` with GPG keyrings:
 - Microsoft VSCode (packages.microsoft.com) — VS Code editor
 - Tailscale (pkgs.tailscale.com) — VPN client
 
+## Developer Utilities (repo root)
+
+- `compare-images.sh` — diffoscope-style comparison of two OCI images (extracts layers, handles whiteouts, reports file-level differences); dev tool, not used by CI
+- `packagediff.sh` — diffs the build manifest against the running system's package list (`/usr/share/frostyard/<id>.packages.txt`)
+- `check-duplicate-packages.sh` / `check-profile-dependencies.sh` — config sanity checks, run by CI
+- `mkosi.tools` + `mkosi.tools.manifest` — mkosi `ToolsTree=default` support: the build runs its tooling from a separate tools tree so host tool versions don't leak into image builds
+
 ## CI/CD
 
 | Workflow | Trigger | Purpose |

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -229,7 +229,7 @@ Provides `verified_download(key, output_path)`:
 
 ### package-versions.json
 
-Tracks APT-based external package versions (Edge, VSCode, Docker, 1Password, Himmelblau) separately from download checksums. Updated daily by `check-packages.yml`.
+Tracks APT-based external package versions (VSCode `code`, `docker-ce`, `1password-cli`, `himmelblau`) separately from download checksums. Updated daily by `check-packages.yml`. Edge is NOT tracked here — it is pinned via `checksums.json` and updated by `check-dependencies.yml`.
 
 ### update-checksums.sh
 

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -56,9 +56,13 @@ Checks for updates to resources managed by the verified download system:
 
 - Bitwarden desktop .deb
 - Homebrew install script
+- code-server .deb
+- ostree source tarball
+- bootc + bootc-vendor source tarballs (bumped together; re-check RUST_VERSION on bootc bumps)
 - Surface secure boot certificate
 - Hotedge GNOME extension
 - Logomenu GNOME extension
+- Bazaar Companion GNOME extension
 - Microsoft Azure VPN Client
 - Microsoft Edge Stable .deb
 

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -33,24 +33,25 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 Every sysext mkosi.conf follows the same structure:
 
 ```ini
-[Distribution]
-Distribution=debian
-Release=trixie
+[Config]
+Dependencies=base
 
 [Output]
-Dependencies=base
+ImageId=<sysext-name>
+Output=<sysext-name>
 Overlay=yes
 ManifestFormat=json
-ImageId=<sysext-name>
 Format=sysext
 
 [Content]
+Bootable=no
 BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+
 Packages=<package-list>
 
-[Output]
+[Build]
 Environment=KEYPACKAGE=<package-name>
-PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
 ```
 
 Key settings:
@@ -70,8 +71,9 @@ Some sysexts include extra files via `mkosi.extra/`:
 ### docker
 - `usr/lib/systemd/system-preset/20-docker.preset` — Enable docker.socket + containerd (numbered below 30 so it beats the base image's `30-docker.preset` disable; presets are first-match-wins in lexical order)
 - `usr/lib/systemd/system/multi-user.target.d/10-docker.conf` — `Upholds=docker.socket containerd.service` drop-in for reliable boot activation (the socket, not docker.service — dockerd runs `-H fd://` and fails without socket-passed FDs)
-- `usr/lib/sysusers.d/docker-sysext.conf` — Docker user/group definitions
-- `usr/lib/tmpfiles.d/docker-sysext.conf` — Runtime directory setup
+- `mkosi.finalize` — Captures `/etc/default/docker`, `/etc/docker`, `/etc/containerd` to factory defaults
+- `usr/lib/sysusers.d/docker.conf` — Docker user/group definitions
+- `usr/lib/tmpfiles.d/docker.conf` — Factory config injection
 
 ### himmelblau
 - `mkosi.postinst.chroot` — Post-install customization hook (currently minimal)
@@ -83,23 +85,27 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `usr/lib/tmpfiles.d/himmelblau.conf` — Config injection from `/usr/share/factory/etc/`
 
 ### incus
-- `usr/lib/systemd/system/incus.service.d/override.conf` — Service override
+- `mkosi.finalize` — Captures the tmpfiles-referenced `/etc` paths to factory defaults
 - `usr/lib/systemd/system-preset/40-incus.preset` — Enable incus services
 - `usr/lib/systemd/system/multi-user.target.d/10-incus.conf` — `Upholds=` drop-in for reliable boot activation (sockets + lxcfs + startup + sysext-setup; incus.service itself is socket-activated)
-- `usr/lib/sysusers.d/incus-sysext.conf` — User/group definitions
-- `usr/lib/tmpfiles.d/incus-sysext.conf` — Runtime directory setup
-- `usr/bin/incus-sysext-setup` — Custom setup script
+- `usr/lib/systemd/system/incus-sysext-setup.service` — Oneshot post-merge setup (subuid/subgid)
+- `usr/lib/incus/incus-sysext-setup` — The setup script the service runs
+- `usr/lib/sysusers.d/{dnsmasq,rdma}.conf` — User/group definitions
+- `usr/lib/tmpfiles.d/incus.conf` — Factory config injection + runtime dirs + xz alternatives links
 
 ### nix
-- `usr/lib/systemd/` — Mount unit and preset for `/nix` bind mount
+- `mkosi.finalize` — Captures `/etc/nix` to factory defaults
+- `usr/lib/systemd/system/nix.mount` + `nix-daemon.service.d/mount-binding.conf` — `/nix` bind mount wiring
+- `usr/lib/systemd/system-preset/40-nix.preset` — Enable nix.mount + nix-daemon
 - `usr/lib/systemd/system/multi-user.target.d/10-nix.conf` — `Upholds=nix.mount nix-daemon.socket nix-daemon.service` drop-in for reliable boot activation
 - `usr/lib/sysusers.d/nix.conf` — Nix user/group
-- `usr/lib/tmpfiles.d/nix-sysext.conf` — Runtime setup
+- `usr/lib/tmpfiles.d/nix.conf` — `/nix` hierarchy + factory config injection
 
 ### tailscale
+- `mkosi.finalize` — Captures `/etc/default/tailscaled` to factory defaults (tailscaled requires the EnvironmentFile)
 - `usr/lib/systemd/system-preset/40-tailscale.preset` — Enable tailscaled
 - `usr/lib/systemd/system/multi-user.target.d/10-tailscale.conf` — `Upholds=tailscaled.service` drop-in for reliable boot activation
-- `usr/lib/tmpfiles.d/tailscale-sysext.conf` — Runtime directory setup
+- `usr/lib/tmpfiles.d/tailscale.conf` — Factory config injection
 
 ## Version Extraction and Naming
 
@@ -124,17 +130,25 @@ Defines how systemd-sysupdate downloads the sysext:
 
 ```ini
 [Transfer]
-ProtectVersion=%A
+Features=<name>
+Verify=false
 
 [Source]
 Type=url-file
 Path=https://repository.frostyard.org/ext/<name>/
-MatchPattern=<name>_@v_@o_@a.raw
+MatchPattern=<name>_@v_%w_%a.raw.zst \
+             <name>_@v_%w_%a.raw.xz \
+             <name>_@v_%w_%a.raw.gz \
+             <name>_@v_%w_%a.raw
 
 [Target]
 Type=regular-file
 Path=/var/lib/extensions.d/
-MatchPattern=<name>_@v_@o_@a.raw
+MatchPattern=<name>_@v_%w_%a.raw.zst \
+             <name>_@v_%w_%a.raw.xz \
+             <name>_@v_%w_%a.raw.gz \
+             <name>_@v_%w_%a.raw
+CurrentSymlink=<name>.raw
 ```
 
 ### Feature file (`<name>.feature`)
@@ -142,7 +156,7 @@ MatchPattern=<name>_@v_@o_@a.raw
 Provides metadata and defaults:
 
 ```ini
-[SysUpdate]
+[Feature]
 Description=<description>
 Documentation=<url>
 Enabled=false
@@ -191,4 +205,4 @@ The setup script must be idempotent — safe to run on every boot without accumu
 5. Create `<name>.transfer` and `<name>.feature` in `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/`
 6. **If the sysext ships a systemd service:** add `usr/lib/systemd/system/multi-user.target.d/10-<name>.conf` with `Upholds=<name>.service` (see [Service Activation Pattern](#service-activation-pattern-upholds) above)
 7. Add the sysext name to root `mkosi.conf` Dependencies list
-7. Add a corresponding update check to `.github/workflows/check-dependencies.yml` if it has external downloads
+8. Add a corresponding update check to `.github/workflows/check-dependencies.yml` if it has external downloads


### PR DESCRIPTION
## Summary

Fixes #305 — the documentation-accuracy batch. The dangerous ones first: the README's incus example still taught the **full-`/etc` factory capture** (the exact pattern that shipped `/etc/shadow` in #282) and a **per-sysext `mkosi.postoutput`** that doesn't exist; yeti/sysexts.md's templates used INI sections (`[Distribution]`, `Dependencies` under `[Output]`, `[SysUpdate]`) and transfer patterns (`ProtectVersion=%A`, `@o`) matching no shipped file. Anyone — human or agent — following these verbatim would produce broken or leaky sysexts.

## Changes

- **README:** sysext template rewritten to the real structure (incl. `[Build] Environment=KEYPACKAGE=` matching #334 — **merge #334 before or with this PR**, otherwise the template is briefly ahead of the confs) with the registration steps (root `Dependencies=`, sysupdate.d pair); incus example shows the targeted capture with the never-all-of-`/etc` warning; script-types table points at the shared postoutput; `shared/` tree diagram matches disk (`outformat/image`, `bootc/`, `download/`, `manifest/`, `sysext/`, `snowloaded/`, entra-sso, stock kernel — stale line counts dropped); image table: `directory → OCI (buildah/chunkah)`; `just test-install`/`run-qemu` documented; CI section gains the five undocumented workflows
- **yeti/sysexts.md:** config + `.transfer`/`.feature` templates now byte-match the shipped-file patterns; per-sysext listings corrected against `find` output (docker/incus/nix/tailscale — wrong filenames, missing finalize scripts and setup service); duplicate step "7" renumbered
- **yeti/ci-cd.md:** check-dependencies resource list completed (12, was 7)
- **package-versions.json + yeti/build-pipeline.md:** dead `microsoft-edge-stable` entry removed — Edge is pinned in `checksums.json`/updated by check-dependencies; `check-packages.yml` never checked it, so the entry could only rot
- **yeti/OVERVIEW.md:** new "Developer Utilities" section covering `compare-images.sh`, `packagediff.sh`, the sanity-check scripts, and `mkosi.tools`/`ToolsTree` (all previously undocumented)
- **CLAUDE.md:** `chunkah-package.sh` added to the outformat description

## Verification

- Every template/listing was written from the current files on disk (`mkosi.images/docker/mkosi.conf` post-#334, `dev.transfer`/`dev.feature`, `find` over each sysext's `mkosi.extra`)
- Stale-claim sweep across README/yeti/CLAUDE.md: zero hits for the old patterns (`OCI archive`, `docker-sysext.conf`, `[SysUpdate]`, `ProtectVersion`, `@o` patterns, per-sysext postoutput, line counts)
- `package-versions.json` parses; nothing in the repo consumes the removed key (`check-packages.yml` checks only code/docker-ce/1password-cli/himmelblau); `ToolsTree=default` confirmed in root `mkosi.conf` before documenting it

🤖 Generated with [Claude Code](https://claude.com/claude-code)