### PR TITLE
docs: update documentation for snosi

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -134,7 +134,9 @@ See [sysexts.md](sysexts.md) for details.
 
 External resources are pinned in `shared/download/checksums.json` with URL + SHA256. Scripts use `verified_download(key, output_path)` from `shared/download/verified-download.sh`. CI workflow `check-dependencies.yml` detects updates weekly and creates PRs.
 
-Package versions for APT-based externals (Edge, VSCode, Docker, 1Password, Himmelblau) are tracked separately in `shared/download/package-versions.json`, checked daily by `check-packages.yml`.
+Package versions for selected APT-based externals (VSCode, Docker, 1Password, Himmelblau) are tracked separately in `shared/download/package-versions.json`, checked daily by `check-packages.yml`.
+
+Current checksum-managed downloads are Bitwarden, Homebrew install script, code-server, ostree, bootc, bootc-vendor, Surface secure boot certificate, Hotedge, Logomenu, Bazaar Companion, Azure VPN, and Microsoft Edge. Current APT version tracking covers `code`, `docker-ce`, `1password-cli`, and `himmelblau`; Edge is checksum-managed because the build installs a patched downloaded `.deb`.
 
 ### User Service Enablement in Chroot
 
@@ -150,6 +152,8 @@ ln -sf /usr/lib/systemd/user/<service> /etc/systemd/user/<target>.wants/<service
 ### OCI Image Packaging
 
 Images are built as directories, then packaged into OCI via `buildah-package.sh` using `buildah mount` + `cp -a` + `buildah commit`. This avoids `buildah COPY` which drops SUID bits (buildah#4463). Layer optimization is done via `chunkah-package.sh`.
+
+CI sets `TMPDIR=/mnt/tmp` before mkosi/buildah/chunkah work because hosted runners have more free space on `/mnt` than on `/`; large loaded variants can exhaust `/var/tmp` if this is omitted.
 
 ### Shell Script Conventions
 
@@ -213,14 +217,13 @@ Configured in `mkosi.sandbox/etc/apt/` with GPG keyrings:
 - `compare-images.sh` — diffoscope-style comparison of two OCI images (extracts layers, handles whiteouts, reports file-level differences); dev tool, not used by CI
 - `packagediff.sh` — diffs the build manifest against the running system's package list (`/usr/share/frostyard/<id>.packages.txt`)
 - `check-duplicate-packages.sh` / `check-profile-dependencies.sh` — config sanity checks, run by CI
-- `mkosi.tools` + `mkosi.tools.manifest` — mkosi `ToolsTree=default` support: the build runs its tooling from a separate tools tree so host tool versions don't leak into image builds
 
 ## CI/CD
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `build.yml` | Push/PR/dispatch | Build base + sysexts, publish to R2 |
-| `build-images.yml` | Push/PR/dispatch | Matrix build of 6 profiles, push OCI to ghcr.io, generate SBOMs, sign with Cosign |
+| `build-images.yml` | Push/PR/repository_dispatch/dispatch | Matrix build of 6 profiles, push OCI to ghcr.io, generate SBOMs, sign with Cosign |
 | `check-dependencies.yml` | Weekly (Mon 9am UTC) | Check external download updates, create PRs |
 | `check-packages.yml` | Daily (8am UTC) | Check APT package version updates, create PRs |
 | `validate.yml` | PR/push | shellcheck + mkosi summary validation |

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -10,43 +10,45 @@ Builds the base image and all 10 sysexts, publishes to the Frostyard repository 
 
 **Steps:**
 1. Aggressive cleanup of runner (removes JDK, .NET, Android SDK, etc. to free disk space)
-2. Run `check-duplicate-packages.sh` to validate no duplicate packages across configs
-3. Build base + all sysext images via mkosi
-4. Run `sysextmv.sh` and `manifestmv.sh` to organize output into `output/sysexts/` and `output/manifests/`
-5. Upload sysext artifacts to Frostyard R2 repository via `frostyard/repogen` action
-6. Upload manifest files to R2
-7. Uses concurrent workflow cancellation (newer pushes cancel in-progress builds)
+2. Redirect `TMPDIR` to `/mnt/tmp`; mkosi workspaces can otherwise overflow the hosted runner root volume
+3. Run `check-duplicate-packages.sh` to validate no duplicate packages across configs
+4. Build base + all sysext images via mkosi
+5. Run `sysextmv.sh` and `manifestmv.sh` to organize output into `output/sysexts/` and `output/manifests/`
+6. Upload sysext artifacts to Frostyard R2 repository via `frostyard/repogen` action
+7. Upload manifest files to R2
+8. Uses concurrent workflow cancellation (newer pushes cancel in-progress builds)
 
 ### build-images.yml — Desktop/Server Image Build and Publish
 
-**Trigger:** Push/PR to main, manual dispatch
+**Trigger:** repository_dispatch type `build`, push/PR to main, manual dispatch
 
 Matrix build of all 6 profiles (snow, snowloaded, snowfield, snowfieldloaded, cayo, cayoloaded).
 
 Each matrix build resets mkosi dependencies to `base` (`--dependency= --dependency=base`). This prevents the root sysext dependency list from being appended into every profile build. The sysext publishing set is built once by `build.yml`; profile image jobs build only `base` plus the selected main image.
 
 **Steps:**
-1. Build profile image via mkosi with dependencies reset to `base` only (produces directory output)
-2. Package OCI image via `buildah-package.sh` (preserves SUID, xattrs)
-3. Optimize layers via `chunkah-package.sh`
-4. **Smoke test:** Validates SUID bit on `/usr/bin/sudo` (mode 4755) — catches metadata loss
-5. Generate SBOM via Syft (scans mkosi output directory, syft-json format)
-6. Push to ghcr.io with `latest` tag
-7. Attach SBOM to image via ORAS (`application/vnd.syft+json` artifact type)
-8. Sign SBOM artifact with Cosign
-9. Attest build provenance (GitHub Actions attestation)
-10. Sign image with Cosign
-11. Upload manifests to R2
+1. Free runner disk, mount BTRFS for container storage, and redirect `TMPDIR` to `/mnt/tmp`
+2. Build profile image via mkosi with dependencies reset to `base` only (produces directory output)
+3. Package OCI image via `buildah-package.sh` (preserves SUID, xattrs)
+4. Optimize layers via `chunkah-package.sh`
+5. **Smoke test:** Validates SUID bit on `/usr/bin/sudo` (mode 4755) — catches metadata loss
+6. Generate SBOM via Syft (scans mkosi output directory, syft-json format)
+7. Push to ghcr.io with `latest` tag
+8. Attach SBOM to image via ORAS (`application/vnd.syft+json` artifact type)
+9. Sign SBOM artifact with Cosign
+10. Attest build provenance (GitHub Actions attestation)
+11. Sign image with Cosign
+12. Upload manifests to R2
 
 #### release job — Automated GitHub Releases
 
-After the matrix completes, a self-contained `release` job runs on main-branch pushes only and creates a GitHub Release summarising what changed in the build. The job has `continue-on-error: true` at the job level, so any failure produces a warning annotation without turning the workflow red. The `build` job is untouched by this feature.
+After the matrix completes, a self-contained `release` job runs on main-branch pushes only and creates a GitHub Release summarising what changed in the build. It uses `!cancelled()` so it can still run after a matrix leg fails, but only proceeds when the `snowloaded` leg uploaded its tag artifact. Release failures are visible; the job is not `continue-on-error`.
 
-**Resolution:** The release job installs ORAS, logs into GHCR, then queries `oras repo tags ghcr.io/<owner>/snowloaded` to list all tags. It filters for the `YYYYMMDDhhmmss` timestamp format, sorts descending, and picks the newest tag as `current` (the image this run just pushed) and the second-newest as `previous` (the prior build). It then runs `frostyard/changelog-generator` with those two exact tags to produce the diff. Only `snowloaded` is diffed; the other five profiles build and push unchanged and are not referenced in the release.
+**Resolution:** The `snowloaded` matrix leg writes the just-pushed timestamp tag to a short-lived artifact. The release job reads that as `current`, then prefers the previous tag recorded in the latest GitHub Release body (`<!-- snowloaded-tag: ... -->`). If no release marker exists, it falls back to `oras repo tags ghcr.io/<owner>/snowloaded` and selects the newest other timestamp tag. It then runs `frostyard/changelog-generator` with those two exact tags to produce the diff. Only `snowloaded` is diffed; the other five profiles build and push unchanged and are not referenced in the release.
 
-**Release tag scheme:** `YYYY-MM-DD.N` (daily counter, e.g. `2026-04-09.1`). The release title is `Build YYYY-MM-DD HH:MM:SS UTC`. The body is a short header line ("Based on the `snowloaded` image."), a `podman pull ghcr.io/<owner>/snowloaded:latest` command in a fenced code block, and then the generated changelog.
+**Release tag scheme:** `YYYY-MM-DD.N` (daily counter, e.g. `2026-04-09.1`). The release title is `Build YYYY-MM-DD HH:MM:SS UTC`. The body comes from the generated changelog plus the hidden `snowloaded-tag` marker used by future releases.
 
-**Skip paths:** If the `snowloaded` repository has zero or one timestamped tags (bootstrap edge case, not applicable in practice — the repository already has many historical tags), the resolve step writes `skip=true` and all downstream steps gracefully short-circuit with a `::warning::` annotation.
+**Skip paths:** Missing/invalid snowloaded artifact, no previous tag, or `previous == current` all emit warnings and skip release creation.
 
 ### check-dependencies.yml — External Download Updates
 
@@ -93,8 +95,8 @@ Checks for version updates to external APT packages:
 **Trigger:** PR/push to main
 
 Two validation checks:
-1. **Shell linting:** Runs shellcheck on all `*.sh` and `*.chroot` files
-2. **mkosi validation:** Runs `mkosi summary` for base image and all profiles to verify configuration, plus `check-profile-dependencies.sh` to ensure profile builds do not include sysext images
+1. **Shell linting:** Runs shellcheck on tracked `*.sh`/`*.chroot` files and extensionless tracked shell scripts discovered by shebang, excluding `saved-unused/`
+2. **mkosi validation:** Runs `mkosi summary` for root config and all profiles to verify configuration, plus `check-profile-dependencies.sh` to ensure profile builds do not include sysext images
 
 ### test-install.yml — Bootc Installation Test
 
@@ -104,7 +106,7 @@ Tests full bootc installation and boot cycle:
 1. Frees disk space on runner (removes large toolchains)
 2. Enables KVM on GitHub Actions runner
 3. Installs QEMU, OVMF, podman, skopeo
-4. Pulls specified OCI image from ghcr.io
+4. Resolves the requested mutable tag to a digest, verifies that immutable ref with `cosign verify --key cosign.pub`, then pulls the verified ref
 5. Runs `test/bootc-install-test.sh` — installs to virtual disk, boots in QEMU, runs test suite via SSH
 
 ### scorecard.yml — Supply-Chain Security

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -46,10 +46,13 @@ Boots an image in a QEMU graphical window (GTK display). Loads the image, instal
 2. Generates ephemeral SSH keypair
 3. Creates sparse raw disk image
 4. Runs `bootc install to-disk --via-loopback` to install the image
-5. Boots installed disk in QEMU with KVM acceleration
-6. Waits for SSH availability (retry loop)
-7. Runs all test tiers in order via SSH
-8. Reports results, cleans up
+5. Injects the generated SSH key into the installed composefs state directory
+6. Boots installed disk in QEMU with KVM acceleration
+7. Waits for SSH availability (retry loop)
+8. Runs all test tiers in order via SSH
+9. Reports results, cleans up
+
+The explicit post-install SSH-key injection is intentional: `bootc install --root-ssh-authorized-keys` does not currently place the key where the composefs backend exposes `/root` at runtime. The test mounts partition 3 and writes `state/os/default/var/roothome/.ssh/authorized_keys` directly before booting the VM.
 
 **Configuration:** Supports custom disk size, VM memory, CPU count, and timeouts.
 
@@ -74,8 +77,9 @@ Validates critical system services:
 - systemd-resolved is active (DNS)
 - NetworkManager is active (networking)
 - SSH is active (remote access)
-- Timer and service availability checks
-- Failed units count is within acceptable range
+- `nbc-update-download.timer` is loaded
+- `frostyard-updex` is installed
+- No failed systemd units are present
 
 ### Tier 3 — Sysext Validation (03-sysexts.sh)
 
@@ -115,16 +119,18 @@ Shared test harness sourced by all four test scripts. Provides:
 ### vm.sh
 
 - `load_image(ref)` — Loads OCI image from local dir or registry (uses buildah mount + cp -a + commit pattern for local dirs)
-- `bootc_install(image, disk)` — Runs bootc install to-disk with loopback
-- `start_vm(disk)` — Launches QEMU with KVM, OVMF firmware, port forwarding for SSH
-- `stop_vm()` — Graceful shutdown
+- `install_to_disk(disk)` — Runs `bootc install to-disk` with loopback inside a privileged podman container
+- `vm_start(disk)` — Launches QEMU with KVM, OVMF firmware, port forwarding for SSH
+- `vm_stop()` / `vm_cleanup()` — Graceful shutdown and disk cleanup
+- `find_ovmf()` searches common OVMF locations, including Incus' bundled firmware path (`/usr/incus/share/qemu/`)
 
 ## CI Integration
 
 The `test-install.yml` workflow runs these tests on manual dispatch:
 1. Sets up KVM-enabled runner
 2. Installs QEMU + OVMF + podman + skopeo
-3. Pulls image from ghcr.io
-4. Runs the full test suite
+3. Resolves the selected `ghcr.io/frostyard/snow:<tag>` to a digest and verifies that immutable ref with `cosign.pub`
+4. Pulls the verified image ref
+5. Runs the full test suite
 
 Not run automatically on every PR due to infrastructure requirements (KVM, large disk, long runtime).


### PR DESCRIPTION
## Summary

Updates the documentation to match current CI, release, dependency tracking, and VM test behavior. The changes clarify which external artifacts are checksum-managed versus APT-version-tracked, explain runner disk-space handling, and document recent workflow changes around image builds, releases, validation, and install testing.

## Changes

- Documented current checksum-managed downloads and APT package version tracking coverage, including why Microsoft Edge is handled as a downloaded `.deb`.
- Added notes about setting `TMPDIR=/mnt/tmp` for mkosi/buildah/chunkah work on hosted runners.
- Updated CI workflow trigger and step descriptions for `build.yml`, `build-images.yml`, `validate.yml`, and `test-install.yml`.
- Revised automated release documentation to describe snowloaded tag artifacts, previous-tag resolution, hidden release markers, and release skip cases.
- Updated bootc install test documentation to cover digest resolution, cosign verification, and explicit SSH key injection into composefs state.
- Refreshed VM helper function names and OVMF lookup behavior in testing docs.
- Removed outdated `mkosi.tools`/`mkosi.tools.manifest` tooling-tree documentation from the overview.