### PR TITLE
build: bootstrap mkosi locally at the CI-pinned commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ mkosi.tools.manifest
 mkosi.key
 mkosi.crt
 .mkosi-private
+.mkosi/
 .envrc
 mkosi.images/base/mkosi.extra/usr/share/homebrew.tar.zst
 mkosi.profiles/snow/mkosi.extra/usr/share/homebrew.tar.zst

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ snosi is a bootable container image build system using [mkosi](https://github.co
 
 ## Build Commands
 
-Requires: mkosi v24+, just, root/sudo access.
+Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrapped: the Justfile fetches systemd/mkosi into a repo-local, gitignored `.mkosi/` checkout at the exact commit pinned by the `systemd/mkosi@<sha>` action in `.github/workflows/build.yml` (read at runtime — no drift between local and CI), and runs `.mkosi/bin/mkosi` from there. Delete `.mkosi/` to discard it; override with `just mkosi=/usr/bin/mkosi <target>` to use a system install.
 
 ```bash
 just                    # List targets

--- a/Justfile
+++ b/Justfile
@@ -1,33 +1,40 @@
 set dotenv-load := true
 
 just := `which just`
-mkosi := `which mkosi`
+
+# mkosi runs from a repo-local checkout pinned to the same commit as the
+# systemd/mkosi action in CI (single source of truth: build.yml, which the
+# other workflows mirror). Delete .mkosi/ to discard it, or override with
+# `just mkosi=/usr/bin/mkosi <target>` to use a system install.
+mkosi_commit := `grep -m1 -oE 'systemd/mkosi@[0-9a-f]+' .github/workflows/build.yml | cut -d@ -f2`
+mkosi_dir := justfile_directory() / ".mkosi"
+mkosi := mkosi_dir / "bin" / "mkosi"
 
 default:
     {{just}} --list --unsorted
 
-clean:
+clean: ensure-mkosi
     sudo PATH="$PATH" {{just}} _clean
 
-sysexts:
+sysexts: ensure-mkosi
     sudo PATH="$PATH" {{just}} _sysexts
 
-snow:
+snow: ensure-mkosi
     sudo PATH="$PATH" {{just}} _snow
 
-snowloaded:
+snowloaded: ensure-mkosi
     sudo PATH="$PATH" {{just}} _snowloaded
 
-snowfield:
+snowfield: ensure-mkosi
     sudo PATH="$PATH" {{just}} _snowfield
 
-snowfieldloaded:
+snowfieldloaded: ensure-mkosi
     sudo PATH="$PATH" {{just}} _snowfieldloaded
 
-cayo:
+cayo: ensure-mkosi
     sudo PATH="$PATH" {{just}} _cayo
 
-cayoloaded:
+cayoloaded: ensure-mkosi
     sudo PATH="$PATH" {{just}} _cayoloaded
 
 test-install image="output/snow":
@@ -35,6 +42,25 @@ test-install image="output/snow":
 
 run-qemu image="output/snow":
     sudo PATH="$PATH" DISK_SIZE=50G {{just}} _run-qemu {{image}}
+
+# Fetch mkosi into .mkosi/ when missing or not at the CI-pinned commit.
+# Runs as the invoking user (before sudo) so the checkout is not root-owned.
+[private]
+ensure-mkosi:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "{{mkosi}}" != "{{mkosi_dir}}/bin/mkosi" ]; then
+        exit 0  # mkosi was overridden on the command line; use it as-is
+    fi
+    if [ -x "{{mkosi}}" ] && [ "$(git -C "{{mkosi_dir}}" rev-parse HEAD 2>/dev/null)" = "{{mkosi_commit}}" ]; then
+        exit 0
+    fi
+    command -v python3 >/dev/null || { echo "error: python3 is required to run mkosi" >&2; exit 1; }
+    echo "Installing mkosi @ {{mkosi_commit}} (CI pin) into {{mkosi_dir}}"
+    rm -rf "{{mkosi_dir}}"
+    git init -q "{{mkosi_dir}}"
+    git -C "{{mkosi_dir}}" fetch -q --depth=1 https://github.com/systemd/mkosi.git "{{mkosi_commit}}"
+    git -C "{{mkosi_dir}}" checkout -q --detach FETCH_HEAD
 
 # Private targets (run as root via sudo)
 

--- a/README.md
+++ b/README.md
@@ -198,9 +198,15 @@ Include=%D/shared/outformat/image/mkosi.conf    # OCI output format
 
 ### Prerequisites
 
-- [mkosi](https://github.com/systemd/mkosi) (v24+)
 - [just](https://github.com/casey/just) task runner
+- git and python3
 - Root/sudo access (mkosi requires privileges for chroot operations)
+
+[mkosi](https://github.com/systemd/mkosi) does not need to be installed: the
+Justfile automatically fetches it into a repo-local `.mkosi/` checkout at the
+same commit pinned in the CI workflows, so local builds always match CI.
+Delete `.mkosi/` to remove it, or run `just mkosi=/usr/bin/mkosi <target>` to
+use a system-installed mkosi instead.
 
 ### Build Commands
 

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -166,7 +166,8 @@ CI sets `TMPDIR=/mnt/tmp` before mkosi/buildah/chunkah work because hosted runne
 
 ### Build Requirements
 
-- mkosi v24+, just, root/sudo access
+- just, git, python3, root/sudo access
+- mkosi is auto-bootstrapped by the Justfile into a gitignored `.mkosi/` checkout at the commit pinned by the `systemd/mkosi@<sha>` action in `.github/workflows/build.yml` (parsed at runtime, so local always matches CI); override with `just mkosi=/usr/bin/mkosi <target>`
 - For CI: buildah, skopeo, podman, cosign, syft, oras
 
 ### Build Commands


### PR DESCRIPTION
## Summary

Hosts without mkosi installed (e.g. throwaway incus test instances) couldn't run *any* `just` target — the old `mkosi := `which mkosi`` backtick fails at Justfile parse time and aborts even `just --list`.

- Replace the `which mkosi` lookup with a repo-local bootstrap: a private `ensure-mkosi` recipe shallow-fetches systemd/mkosi into a gitignored `.mkosi/` checkout and runs `.mkosi/bin/mkosi` (stdlib-only Python, no pip install)
- The pin is parsed at runtime from the `systemd/mkosi@<sha>` action ref in `.github/workflows/build.yml`, so local builds always use the exact mkosi commit CI uses — when the dependency bot bumps the action, local follows automatically with a re-fetch
- The bootstrap runs before the `sudo` hop (checkout stays user-owned), no-ops when `.mkosi` is already at the pin, and is bypassable with `just mkosi=/usr/bin/mkosi <target>`
- Docs updated in CLAUDE.md, README.md, and yeti/OVERVIEW.md

## Test plan

- [x] `just --list` succeeds with no mkosi on PATH
- [x] `just ensure-mkosi` fetches the pin; `.mkosi/bin/mkosi --version` → `mkosi 27~devel` at `3c3a08fb`
- [x] Second run is a no-op; `just mkosi=/usr/bin/true ensure-mkosi` skips the bootstrap
- [x] `.mkosi/` is git-ignored; `.mkosi/bin/mkosi summary` parses the repo config cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)