### PR TITLE
fix: generate SSH host keys when missing, not only on first boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ Scripts execute in order: **BuildScripts** (in chroot) -> **PostInstallationScri
 
 **Critical pattern:** Packages installing to `/opt` must be relocated to `/usr/lib/<package>` at build time with symlinks in `/usr/bin`. This applies to both desktop images and sysexts.
 
+**First-boot semantics:** the image ships `/etc/machine-id` as an empty file, which systemd treats as "initialize a machine ID, but not first boot" — `ConditionFirstBoot=yes` never fires on installed systems (only a missing machine-id or one containing `uninitialized` triggers it). Any unit that must run once on a fresh install needs a different condition (e.g. `ConditionPathExists=!<marker>`); see the `sshd-keygen.service.d` drop-in in base `mkosi.extra`, which regenerates SSH host keys whenever they are missing. When writing such a drop-in, remember an empty `Condition*=` assignment resets ALL conditions on the unit, so restate the stock unit's other conditions.
+
 ### Base Image: In-Tree bootc + ostree Build
 
 bootc and ostree are **not** installed from APT; they are compiled from pinned source during the base image build.

--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/sshd-keygen.service.d/10-run-when-keys-missing.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/sshd-keygen.service.d/10-run-when-keys-missing.conf
@@ -1,0 +1,14 @@
+# mkosi ships /etc/machine-id as an empty file, which systemd treats as
+# "initialize a machine ID, but this is not first boot" (first-boot semantics
+# require the file to be missing or to contain "uninitialized"). The stock
+# unit's ConditionFirstBoot=yes therefore never fires on installed systems,
+# no host keys are ever generated, and sshd crash-loops.
+#
+# Run whenever host keys are missing instead. The empty ConditionFirstBoot=
+# resets ALL conditions on the unit, so the stock unit's other conditions are
+# restated below.
+[Unit]
+ConditionFirstBoot=
+ConditionPathIsReadWrite=/etc/ssh
+ConditionPathIsSymbolicLink=!/etc/ssh
+ConditionPathExists=!/etc/ssh/ssh_host_ed25519_key

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -98,7 +98,7 @@ Prepare the image for output. Run after postinstall, before the image format is 
 **Image finalize** (`shared/outformat/image/finalize/mkosi.finalize.chroot`):
 - Removes `/boot`, `/home`, `/root`, `/srv` (recreates empty)
 - Creates `/sysroot` and `/nix` mountpoints (nix sysext bind-mount)
-- Removes `/etc/machine-id` (recreates empty for first-boot) and SSH host keys
+- Removes `/etc/machine-id` (recreates empty) and SSH host keys. **Note:** an empty machine-id file means systemd initializes a machine ID at boot but does NOT treat it as first boot (`ConditionFirstBoot=` stays false; only a missing file or one containing `uninitialized` triggers first-boot semantics). Units gated on `ConditionFirstBoot` never run on installed systems — SSH host key generation relies on a `sshd-keygen.service.d` drop-in in base `mkosi.extra` that keys on missing host keys instead.
 - Compiles GLib schemas and dconf databases
 - Sets file xattrs: `user.component=<package_name>` for every installed file — used by chunkah for layer optimization
 


### PR DESCRIPTION
## Summary

Installed snosi systems have no SSH host keys and no way to ever get them:

- The image (correctly) ships no `/etc/ssh/ssh_host_*` keys
- Debian's `sshd-keygen.service` is gated on `ConditionFirstBoot=yes`
- mkosi ships `/etc/machine-id` as an **empty** file, and systemd's rule is: empty = "initialize a machine ID, but this is *not* first boot" (only a missing file or `uninitialized\n` content triggers first-boot semantics)
- Result: `sshd-keygen` is skipped forever, `sshd` crash-loops with `no hostkeys available -- exiting`, and `ssh.socket` follows via `service-start-limit-hit`

This is the image-side root cause behind the bootc install test harness never reaching the installed VM over SSH (full investigation on an installed QEMU VM's persistent journal).

The fix is a base-image drop-in for `sshd-keygen.service` that runs whenever host keys are missing instead of only on first boot. Note the empty `ConditionFirstBoot=` assignment resets **all** conditions on the unit, so the stock unit's other conditions are restated in the drop-in.

Also corrects `yeti/build-pipeline.md`, which documented the wrong assumption ("recreates empty for first-boot"), and adds the first-boot gotcha to CLAUDE.md.

## Test plan

- [x] Booted `ghcr.io/frostyard/snow:latest` as a systemd container with the drop-in bind-mounted: `sshd-keygen.service` runs (`status=0/SUCCESS`), generates ed25519/ecdsa/rsa host keys, and `ssh.service` + `ssh.socket` both reach `active`
- [x] Separately verified on a real `bootc install to-disk --composefs-backend` QEMU VM that the only thing between the current image and `is-system-running=running` + working SSH is the missing host keys (injected manually → clean boot, SSH works)
- [ ] After merge + image publish: `test-install.yml` (with the sudo fix from the companion PR) should pass end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)