### PR TITLE
ci: run bootc install test as root

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -47,8 +47,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-x86 qemu-utils ovmf podman skopeo
 
+      # Everything that touches podman storage runs as root: bootc install
+      # requires the root user namespace ("/proc/1 is owned by 65534" abort
+      # under rootless podman), and the image must be pulled into root's
+      # storage for the install container to see it.
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | sudo podman login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
@@ -70,8 +74,8 @@ jobs:
 
       - name: Pull image
         run: |
-          podman pull "${IMAGE_REF}"
+          sudo podman pull "${IMAGE_REF}"
 
       - name: Run installation tests
         run: |
-          ./test/bootc-install-test.sh "${IMAGE_REF}"
+          sudo ./test/bootc-install-test.sh "${IMAGE_REF}"

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -106,8 +106,8 @@ Tests full bootc installation and boot cycle:
 1. Frees disk space on runner (removes large toolchains)
 2. Enables KVM on GitHub Actions runner
 3. Installs QEMU, OVMF, podman, skopeo
-4. Resolves the requested mutable tag to a digest, verifies that immutable ref with `cosign verify --key cosign.pub`, then pulls the verified ref
-5. Runs `test/bootc-install-test.sh` — installs to virtual disk, boots in QEMU, runs test suite via SSH
+4. Resolves the requested mutable tag to a digest, verifies that immutable ref with `cosign verify --key cosign.pub`, then pulls the verified ref (into root's podman storage)
+5. Runs `sudo test/bootc-install-test.sh` — installs to virtual disk, boots in QEMU, runs test suite via SSH. Root is required: `bootc install` refuses to run under rootless podman (`/proc/1 is owned by 65534`); this was why every run of this workflow failed before 2026-07
 
 ### scorecard.yml — Supply-Chain Security
 

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -38,8 +38,10 @@ Boots an image in a QEMU graphical window (GTK display). Loads the image, instal
 
 **Usage:**
 ```bash
-./test/bootc-install-test.sh [image-ref]
+sudo ./test/bootc-install-test.sh [image-ref]
 ```
+
+Must run as root: `bootc install` requires the root user namespace (it aborts under rootless podman with "/proc/1 is owned by 65534"), and the script also uses losetup/mount. When passing a registry ref, the image is pulled into root's podman storage.
 
 **Flow:**
 1. Loads OCI image (from local directory or registry reference via skopeo/podman)


### PR DESCRIPTION
## Summary

Every run of `test-install.yml` to date failed at the same spot, before the image was ever exercised:

```
error: Installing to disk: /proc/1 is owned by 65534, not zero; this command must be run in the root user namespace (e.g. not rootless podman)
```

The workflow ran `podman login`, `podman pull`, and `./test/bootc-install-test.sh` rootless. The Justfile's local `test-install` target has always used sudo — CI simply didn't. This PR runs those three steps under sudo, so the verified image lands in root's podman storage and `bootc install to-disk` gets the root user namespace it requires. Cosign verification is unchanged (skopeo/cosign don't need root). Docs updated (`yeti/testing.md`, `yeti/ci-cd.md`).

## Test plan

- [x] Ran the exact script as root locally against `ghcr.io/frostyard/snow:latest`: install completes (GPT + btrfs + ESP + systemd-boot), VM boots to a login prompt — i.e. the failure mode this PR fixes is gone
- [x] Workflow YAML parses
- [ ] After the sshd-keygen image fix (#343) merges and images publish, a `workflow_dispatch` run should pass end-to-end; until then it will proceed past install/boot and fail only at the SSH wait (missing host keys in the published image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)