### PR TITLE
feat: ship virtiofsd in the base image

### DIFF
--- a/mkosi.images/base/mkosi.conf
+++ b/mkosi.images/base/mkosi.conf
@@ -89,6 +89,10 @@ Packages=vim
          dpkg-dev
          procps
 
+# virtiofs host daemon: shares host directories with VMs; required by bcvk
+# (bootc VM test tool), which only finds it at standard system paths
+Packages=virtiofsd
+
 # Microcode
 Packages=amd64-microcode
          intel-microcode


### PR DESCRIPTION
## Summary

Add `virtiofsd` (virtio-fs host daemon, Debian trixie 1.13.2) to the base image package set.

Motivation: [bcvk](https://github.com/bootc-dev/bcvk) — the purpose-built bootc VM test tool, verified working on snosi/Debian — requires virtiofsd and only searches fixed system paths (`/usr/libexec`, `/usr/bin`, `/usr/local/bin`, `/usr/lib`; `$PATH` is not consulted, and out-of-tree `VIRTIOFSD_BIN` paths aren't visible inside its podman container). On an immutable install nothing can be apt-installed into `/usr`, so the daemon has to ship in the image. It's also generally useful for qemu/incus virtiofs shares.

## Test plan

- [x] `./check-duplicate-packages.sh` passes (virtiofsd appears in no other package set)
- [x] `mkosi summary` validates with the CI-pinned mkosi
- [x] Package exists in trixie (`1.13.2-1+deb13u1`); the same binary version was manually verified working with bcvk against `ghcr.io/frostyard/snow:latest` on a snowloaded host

🤖 Generated with [Claude Code](https://claude.com/claude-code)