### PR TITLE
fix: gate live-setup on /var marker instead of runtime systemctl disable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ Scripts execute in order: **BuildScripts** (in chroot) -> **PostInstallationScri
 
 **Critical pattern:** Packages installing to `/opt` must be relocated to `/usr/lib/<package>` at build time with symlinks in `/usr/bin`. This applies to both desktop images and sysexts.
 
+**Runtime service enablement changes are forbidden:** units must never run `systemctl disable`/`enable` at runtime (e.g. via `ExecStartPost`) — it deletes/creates `.wants`/`.requires` symlinks in `/etc`, and any path removed from the live `/etc` relative to the booted image makes bootc's `/etc` merge fail at update finalize with "a path led outside of the filesystem" (bootc ≤ 1.16.3 follows the corresponding symlink in the new deployment's `/etc` out of its sandbox). For run-once behavior, gate on a `/var` marker file instead (see `snow-linux-live-setup.service`).
+
 **First-boot semantics:** the image ships `/etc/machine-id` as an empty file, which systemd treats as "initialize a machine ID, but not first boot" — `ConditionFirstBoot=yes` never fires on installed systems (only a missing machine-id or one containing `uninitialized` triggers it). Any unit that must run once on a fresh install needs a different condition (e.g. `ConditionPathExists=!<marker>`); see the `sshd-keygen.service.d` drop-in in base `mkosi.extra`, which regenerates SSH host keys whenever they are missing. When writing such a drop-in, remember an empty `Condition*=` assignment resets ALL conditions on the unit, so restate the stock unit's other conditions.
 
 ### Base Image: In-Tree bootc + ostree Build

--- a/shared/snow/tree/usr/lib/systemd/system/snow-linux-live-setup.service
+++ b/shared/snow/tree/usr/lib/systemd/system/snow-linux-live-setup.service
@@ -7,10 +7,18 @@ Requires=systemd-logind.service
 Before=display-manager.service
 After=systemd-logind.service systemd-homed.service
 ConditionPathExists=/usr/bin/_snow-linux-live-setup
+# Run-once via marker file instead of `systemctl disable`: the disable
+# removed this unit's .wants/.requires symlinks from /etc at runtime, and
+# any path deleted from the live /etc makes bootc's /etc merge fail at
+# update finalize (bootc <= 1.16.3 follows the corresponding symlink in the
+# new deployment's /etc and aborts: "a path led outside of the filesystem").
+# Live sessions are unaffected: their state is ephemeral, so the marker
+# resets every live boot exactly like the old runtime disable did.
+ConditionPathExists=!/var/lib/snow-linux-live-setup.done
 
 [Service]
 ExecStart=/usr/bin/_snow-linux-live-setup
-ExecStartPost=/usr/bin/systemctl disable %n
+ExecStartPost=/usr/bin/touch /var/lib/snow-linux-live-setup.done
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

First live update-sequence testing (per `docs/plans/2026-07-03-bootc-update-validation-plan.md`) found that **staged bootc updates never apply on snosi installs**. The chain:

1. `snow-linux-live-setup.service` runs on installed systems' first boot and self-disables via `ExecStartPost=/usr/bin/systemctl disable %n`
2. That deletes `multi-user.target.wants/snow-linux-live-setup.service`, `multi-user.target.requires/`, and `display-manager.service.requires/` from the live `/etc`
3. At update finalize, bootc's `/etc` merge computes those as "removed" and calls `metadata_optional()` on the corresponding paths in the **new** deployment's `/etc` — where the `.wants` symlink still exists, pointing at `/usr/lib/systemd/...`
4. cap-std follows the symlink out of its sandbox → `error: Merging: a path led outside of the filesystem` → `bootc-finalize-staged.service` fails at every shutdown → the old deployment boots again

(Empirically bisected in a live VM: `bootc config-diff` showed exactly those three removed paths; restoring them made `composefs-finalize-staged` succeed and the staged deployment boot, with SSH host keys, machine-id, and all `/var`+`/etc` persistence markers intact. The `metadata_optional` symlink-follow is also a bootc bug — still present on upstream `main` — being reported separately, but snosi shouldn't mutate `/etc` enablement at runtime regardless.)

## Fix

Replace the runtime disable with the image-friendly run-once pattern: `ConditionPathExists=!/var/lib/snow-linux-live-setup.done` + `ExecStartPost=touch`. Installed systems run setup once and `/etc` stays pristine; live sessions keep per-boot behavior because their state is ephemeral. Adds the general "no runtime `systemctl disable/enable` in units" rule to CLAUDE.md.

## Test plan

- [x] Root cause verified live: restoring the three deleted `/etc` paths in the guest made finalize succeed and the update apply (first successful snosi bootc update hop)
- [ ] After merge + publish: update hop from a pre-fix image will still need the same one-time workaround (the pre-fix deployment already mutated `/etc`), but hops between post-fix images should finalize cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)