### PR TITLE
feat: bootc update-sequence test harness (plan Phases 1-3)

### DIFF
--- a/docs/plans/2026-07-03-bootc-update-validation-plan.md
+++ b/docs/plans/2026-07-03-bootc-update-validation-plan.md
@@ -149,7 +149,13 @@ First runs of `test/bootc-update-test.sh` against real published tags:
 3. **Full green run achieved** on the first all-fixes image (`20260703174338`, containing #343/#345/#347/#348): install → SSH with no injection → hop to `20260703151145` via containers-storage → finalize on natural shutdown → staged→booted→rollback digests exact → **13/13 persistence checks pass** (incl. SSH host key + machine-id stability, deleted-file persistence) → `is-system-running=running`.
 4. **Answered:** `/run/ostree-booted` is **absent** on composefs-booted systems — upstream `bootc-fetch-apply-updates.timer` would never fire; the Phase 5 timer must not copy that condition. Also: bootc records the containers-storage digest (not registry manifest digest) for podman-run installs — never compare `bootc status` digests to `skopeo inspect` for that transport; double-finalize is safe (second run fails loudly on the BLS exchange rather than double-swapping).
 
-Still open for Phase 2 completeness: the "both-changed" `/etc` merge case (needs two tags whose `/etc` genuinely differs) and the ascending multi-hop chain (needs ≥2 post-fix tags; downgrade-direction hop is validated).
+Later the same day (post-fix tags `20260703174338` → `20260703184744`):
+
+5. **Ascending hop green** (13/13, digests exact) — Phases 1–2 validated in both directions on production images.
+6. **Phase 4 (rollback) green** via the harness's `ROLLBACK=1` phase: previous deployment boots, booted/rollback slots swap exactly, `/var` written on the rolled-back-from deployment persists, persistence matrix passes post-rollback. Two facts for update tooling: **after `bootc rollback`, `spec.image` reverts to the rolled-back-to deployment's ref**, and **bootc refuses to `switch` to an image whose fs-verity digest equals the current rollback deployment** ("Target image has the same fs-verity digest…") — auto-updaters must treat that as a no-op, never flip-flopping back to a version the admin rolled away from.
+7. **Phase 5 implemented** (separate PR): `bootc-update-stage.timer/.service` + `/usr/libexec/bootc-update-stage` in base `mkosi.extra` — hourly, stage-only, applies at next natural reboot; podman transfer per finding 1; gated on `ConditionKernelCommandLine=composefs`; no-op guards (non-bootc system, already running/staged, rollback flip-flop) live-tested in a VM and on an nbc host. `bootc-fetch-apply-updates.timer` preset-disabled (force-reboots on update; `systemctl preset-all` had been enabling it despite its dead `/run/ostree-booted` gate).
+
+Still open for Phase 2 completeness: the "both-changed" `/etc` merge case (needs two tags whose `/etc` genuinely differs).
 
 ## Open questions
 

--- a/docs/plans/2026-07-03-bootc-update-validation-plan.md
+++ b/docs/plans/2026-07-03-bootc-update-validation-plan.md
@@ -140,9 +140,19 @@ Then the removal PR: drop `frostyard-nbc` from base `Packages=` (`mkosi.images/b
 - Phase 5 timer units (new PR) and, at GO, the nbc-removal PR
 - Migration runbook for nbc-installed machines
 
+## Findings log (2026-07-03, Phases 1–2 executed)
+
+First runs of `test/bootc-update-test.sh` against real published tags:
+
+1. **Registry-transport pull broken (bootc 1.16.2 AND 1.16.3):** `bootc switch docker://<ref>` fails deterministically on published snosi images with `Failed to pull config … unexpected EOF reading tar entry`. The blob is intact (host fetch OK), `podman pull` of the same tag inside the same guest succeeds, and `bootc switch --transport containers-storage` works. Known upstream issue; NOT fixed by the composefs bump in 1.16.3. **Until fixed upstream, the production update path must be `podman pull` + `bootc switch --transport containers-storage` — the Phase 5 timer must use this mechanism** (harness: `HOP_TRANSPORT=containers-storage`).
+2. **`/etc` merge finalize bug (fixed for snosi, reported upstream):** any path removed from live `/etc` that exists as an escaping symlink in the new deployment's `/etc` aborts finalize with "a path led outside of the filesystem" (`metadata_optional` follows symlinks; [bootc#2278](https://github.com/bootc-dev/bootc/issues/2278)). snosi's trigger — `snow-linux-live-setup.service` self-disabling at runtime — removed in PR #347; CLAUDE.md now forbids runtime `systemctl disable/enable` in units.
+3. **Full green run achieved** on the first all-fixes image (`20260703174338`, containing #343/#345/#347/#348): install → SSH with no injection → hop to `20260703151145` via containers-storage → finalize on natural shutdown → staged→booted→rollback digests exact → **13/13 persistence checks pass** (incl. SSH host key + machine-id stability, deleted-file persistence) → `is-system-running=running`.
+4. **Answered:** `/run/ostree-booted` is **absent** on composefs-booted systems — upstream `bootc-fetch-apply-updates.timer` would never fire; the Phase 5 timer must not copy that condition. Also: bootc records the containers-storage digest (not registry manifest digest) for podman-run installs — never compare `bootc status` digests to `skopeo inspect` for that transport; double-finalize is safe (second run fails loudly on the BLS exchange rather than double-swapping).
+
+Still open for Phase 2 completeness: the "both-changed" `/etc` merge case (needs two tags whose `/etc` genuinely differs) and the ascending multi-hop chain (needs ≥2 post-fix tags; downgrade-direction hop is validated).
+
 ## Open questions
 
 - `/etc` both-changed merge semantics under the composefs backend (Phase 2 answers empirically).
-- `/run/ostree-booted` presence on composefs-booted systems (Phase 5; possible upstream issue/drop-in).
 - Old-deployment GC policy and knobs for the composefs backend (Phase 3).
-- Signature enforcement on update pulls: installs currently use `--skip-fetch-check`; decide a containers-policy.json / sigstore policy so `bootc upgrade` verifies the same cosign signatures CI produces, and add a Phase 5 test that an unsigned/tampered image is rejected.
+- Signature enforcement on update pulls: installs currently use `--skip-fetch-check`; decide a containers-policy.json / sigstore policy so update pulls verify the same cosign signatures CI produces, and add a Phase 5 test that an unsigned/tampered image is rejected. (With the containers-storage interim path, podman enforces `containers-policy.json` at pull time — configure it there.)

--- a/test/bootc-update-test.sh
+++ b/test/bootc-update-test.sh
@@ -160,12 +160,17 @@ echo "=== Step 3: Boot and baseline ==="
 vm_start "$DISK_IMAGE"
 wait_for_ssh
 
-install_digest=$(digest_of "$INSTALL_REF")
+# NOTE: bootc installed from local containers-storage (the podman run path)
+# records the STORAGE image digest, not the registry manifest digest, so the
+# baseline asserts the image NAME. Digest continuity is asserted per hop:
+# staged digest (recorded before reboot) must become the booted digest, and
+# the previously booted digest must land in the rollback slot.
+booted_name=$(vm_ssh "bootc status --format json" | jq -r '.status.booted.image.image.image // "null"')
 booted=$(guest_status_digest booted)
 echo "Installed: $INSTALL_REF"
-echo "  expected digest: $install_digest"
-echo "  booted digest:   $booted"
-[[ "$booted" == "$install_digest" ]] || { echo "FATAL: booted digest does not match installed ref" >&2; exit 1; }
+echo "  booted image:  $booted_name"
+echo "  booted digest: $booted (storage digest; registry manifest: $(digest_of "$INSTALL_REF"))"
+[[ "$booted_name" == "$INSTALL_REF" ]] || { echo "FATAL: booted image name does not match installed ref" >&2; exit 1; }
 
 echo ""
 echo "=== Step 4: Write persistence markers ==="
@@ -174,7 +179,7 @@ run_guest_script "$SCRIPT_DIR/update-tests/persistence-write.sh"
 # ---------------------------------------------------------------
 declare -a hop_names=()
 declare -a hop_results=()
-prev_digest="$install_digest"
+prev_booted="$booted"
 overall=0
 
 hop_num=0
@@ -182,28 +187,32 @@ for ref in "${HOP_REFS[@]}"; do
     hop_num=$((hop_num + 1))
     echo ""
     echo "=== Hop $hop_num: bootc switch $ref ==="
-    expected=$(digest_of "$ref")
-    echo "Expected digest: $expected"
+    registry_digest=$(digest_of "$ref")
+    echo "Registry manifest digest: $registry_digest"
 
     vm_ssh "bootc switch --quiet $ref"
 
     staged=$(guest_status_digest staged)
-    echo "Staged digest:   $staged"
-    if [[ "$staged" != "$expected" ]]; then
-        echo "FATAL: staged digest does not match $ref" >&2
+    staged_name=$(vm_ssh "bootc status --format json" | jq -r '.status.staged.image.image.image // "null"')
+    echo "Staged: $staged_name @ $staged"
+    if [[ "$staged_name" != "$ref" || "$staged" == "null" ]]; then
+        echo "FATAL: staged deployment does not match $ref" >&2
         exit 1
+    fi
+    if [[ "$staged" != "$registry_digest" ]]; then
+        echo "note: staged digest differs from registry manifest digest (transport-dependent; continuity is asserted via staged->booted instead)"
     fi
 
     reboot_guest
 
     booted=$(guest_status_digest booted)
     rollback=$(guest_status_digest rollback)
-    echo "Booted digest:   $booted (expected $expected)"
-    echo "Rollback digest: $rollback (expected $prev_digest)"
+    echo "Booted digest:   $booted (expected staged $staged)"
+    echo "Rollback digest: $rollback (expected previous booted $prev_booted)"
 
     hop_rc=0
-    [[ "$booted" == "$expected" ]] || { echo "not ok - booted deployment is $ref"; hop_rc=1; }
-    [[ "$rollback" == "$prev_digest" ]] || { echo "not ok - rollback slot holds previous deployment"; hop_rc=1; }
+    [[ "$booted" == "$staged" ]] || { echo "not ok - booted deployment is the one that was staged"; hop_rc=1; }
+    [[ "$rollback" == "$prev_booted" ]] || { echo "not ok - rollback slot holds previous deployment"; hop_rc=1; }
 
     echo ""
     echo "--- Persistence verification after hop $hop_num ---"
@@ -227,7 +236,7 @@ for ref in "${HOP_REFS[@]}"; do
     hop_names+=("hop-$hop_num -> $ref")
     hop_results+=("$hop_rc")
     [[ $hop_rc -eq 0 ]] || overall=1
-    prev_digest="$expected"
+    prev_booted="$booted"
 done
 
 # ---------------------------------------------------------------

--- a/test/bootc-update-test.sh
+++ b/test/bootc-update-test.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Orchestrator for bootc update-sequence integration tests
+# (docs/plans/2026-07-03-bootc-update-validation-plan.md, Phases 1-3).
+#
+# Installs <install-ref> to a virtual disk via bootc, boots it in QEMU,
+# writes persistence markers, then for each <hop-ref> runs `bootc switch`
+# in the guest, reboots, and verifies deployment digests plus the full
+# persistence matrix.
+#
+# Usage: ./test/bootc-update-test.sh <install-ref> <hop-ref> [<hop-ref>...]
+#
+# Example:
+#   sudo ./test/bootc-update-test.sh \
+#       ghcr.io/frostyard/snow:20260702011235 \
+#       ghcr.io/frostyard/snow:20260703151145
+#
+# Environment:
+#   DISK_SIZE (default 20G — multiple deployments need headroom)
+#   INJECT_HOSTKEYS=1  Pre-generate SSH host keys on the installed disk.
+#                      Workaround for images published before the
+#                      sshd-keygen fix (#343); harmless but unnecessary after.
+#   KEEP_VM=1          Skip cleanup (leave VM running for inspection).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Defaults must be set BEFORE sourcing lib/vm.sh — it snapshots DISK_SIZE
+# with a 10G fallback at source time. Updates pull whole images into the
+# guest's /var, so the default install-test size is far too small here.
+: "${DISK_SIZE:=20G}"
+: "${INJECT_HOSTKEYS:=0}"
+: "${KEEP_VM:=0}"
+
+# shellcheck source=test/lib/ssh.sh
+source "$SCRIPT_DIR/lib/ssh.sh"
+# shellcheck source=test/lib/vm.sh
+source "$SCRIPT_DIR/lib/vm.sh"
+
+WORK_DIR=""
+
+usage() {
+    echo "Usage: $0 <install-ref> <hop-ref> [<hop-ref>...]" >&2
+    echo "  Refs are registry references (e.g. ghcr.io/frostyard/snow:<tag>)." >&2
+    exit 1
+}
+
+# shellcheck disable=SC2329
+cleanup() {
+    if [[ "$KEEP_VM" == "1" ]]; then
+        echo "KEEP_VM=1: leaving VM (PID ${QEMU_PID:-?}) and $WORK_DIR in place"
+        return
+    fi
+    echo ""
+    echo "=== Cleanup ==="
+    if [[ -n "$WORK_DIR" ]] && mountpoint -q "$WORK_DIR/mnt" 2>/dev/null; then
+        umount "$WORK_DIR/mnt" || true
+    fi
+    if [[ -n "${loop:-}" ]]; then
+        losetup -d "$loop" 2>/dev/null || true
+    fi
+    vm_cleanup
+    if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]] && ! mountpoint -q "$WORK_DIR/mnt" 2>/dev/null; then
+        rm -rf "$WORK_DIR"
+        echo "Removed temp directory: $WORK_DIR"
+    fi
+}
+
+# digest_of <registry-ref> - resolve a ref to its manifest digest (host-side,
+# independent of the guest, so guest-reported digests are cross-checked).
+digest_of() {
+    skopeo inspect --format '{{.Digest}}' "docker://$1"
+}
+
+# guest_status_digest <staged|booted|rollback> - image digest of a deployment
+# slot as reported by bootc inside the guest ("null" if the slot is empty).
+guest_status_digest() {
+    vm_ssh "bootc status --format json" | jq -r ".status.$1.image.imageDigest // \"null\""
+}
+
+# run_guest_script <local-path> - copy a script plus helpers into the guest
+# and execute it. Returns the script's exit code.
+run_guest_script() {
+    local script="$1"
+    local name
+    name="$(basename "$script")"
+    vm_ssh "mkdir -p /tmp/test-lib"
+    scp "${SSH_OPTS[@]}" -i "$SSH_KEY" -P "$SSH_PORT" \
+        "$SCRIPT_DIR/lib/helpers.sh" root@localhost:/tmp/test-lib/helpers.sh
+    scp "${SSH_OPTS[@]}" -i "$SSH_KEY" -P "$SSH_PORT" \
+        "$script" root@localhost:"/tmp/$name"
+    vm_ssh "TEST_LIB_DIR=/tmp/test-lib bash /tmp/$name"
+}
+
+# reboot_guest - reboot the VM and wait for SSH to drop and come back.
+# QEMU stays up across a guest reboot; only sshd goes away.
+reboot_guest() {
+    echo "Rebooting guest..."
+    vm_ssh "systemctl reboot" || true
+    # Wait for the old system to actually go down before polling for the new
+    # one, otherwise wait_for_ssh can succeed against the pre-reboot sshd.
+    local down_deadline=$((SECONDS + 120))
+    while (( SECONDS < down_deadline )); do
+        vm_ssh -o ConnectTimeout=2 true 2>/dev/null || break
+        sleep 2
+    done
+    wait_for_ssh
+}
+
+# --- Argument parsing ---
+[[ $# -ge 2 ]] || usage
+INSTALL_REF="$1"
+shift
+HOP_REFS=("$@")
+
+[[ $EUID -eq 0 ]] || { echo "Error: must run as root (bootc install needs the root user namespace)" >&2; exit 1; }
+
+trap cleanup EXIT
+
+# Real disk, not tmpfs: hop images are pulled into the guest's /var.
+WORK_DIR=$(mktemp -d /var/tmp/bootc-update-test.XXXXXX)
+echo "Temp directory: $WORK_DIR"
+
+# ---------------------------------------------------------------
+echo ""
+echo "=== Step 1: Pull and install $INSTALL_REF ==="
+load_image "$INSTALL_REF"
+ssh_keygen "$WORK_DIR"
+create_disk "$WORK_DIR/disk.raw"
+install_to_disk "$WORK_DIR/disk.raw"
+
+# ---------------------------------------------------------------
+echo ""
+echo "=== Step 2: Inject SSH access ==="
+loop=$(losetup --find --show --partscan "$WORK_DIR/disk.raw")
+mkdir -p "$WORK_DIR/mnt"
+mount "${loop}p3" "$WORK_DIR/mnt"
+
+ssh_dir="$WORK_DIR/mnt/state/os/default/var/roothome/.ssh"
+mkdir -p "$ssh_dir"
+cp "${SSH_KEY}.pub" "$ssh_dir/authorized_keys"
+chmod 700 "$ssh_dir"
+chmod 600 "$ssh_dir/authorized_keys"
+
+if [[ "$INJECT_HOSTKEYS" == "1" ]]; then
+    # Pre-#343 images never generate host keys (sshd-keygen is gated on
+    # ConditionFirstBoot, which empty machine-id never satisfies).
+    deploy_dir=$(find "$WORK_DIR/mnt/state/deploy" -mindepth 1 -maxdepth 1 -type d | head -1)
+    ssh-keygen -A -f "$deploy_dir"
+    echo "Injected SSH host keys into $deploy_dir/etc/ssh"
+fi
+
+umount "$WORK_DIR/mnt"
+losetup -d "$loop"
+loop=""
+
+# ---------------------------------------------------------------
+echo ""
+echo "=== Step 3: Boot and baseline ==="
+vm_start "$DISK_IMAGE"
+wait_for_ssh
+
+install_digest=$(digest_of "$INSTALL_REF")
+booted=$(guest_status_digest booted)
+echo "Installed: $INSTALL_REF"
+echo "  expected digest: $install_digest"
+echo "  booted digest:   $booted"
+[[ "$booted" == "$install_digest" ]] || { echo "FATAL: booted digest does not match installed ref" >&2; exit 1; }
+
+echo ""
+echo "=== Step 4: Write persistence markers ==="
+run_guest_script "$SCRIPT_DIR/update-tests/persistence-write.sh"
+
+# ---------------------------------------------------------------
+declare -a hop_names=()
+declare -a hop_results=()
+prev_digest="$install_digest"
+overall=0
+
+hop_num=0
+for ref in "${HOP_REFS[@]}"; do
+    hop_num=$((hop_num + 1))
+    echo ""
+    echo "=== Hop $hop_num: bootc switch $ref ==="
+    expected=$(digest_of "$ref")
+    echo "Expected digest: $expected"
+
+    vm_ssh "bootc switch --quiet $ref"
+
+    staged=$(guest_status_digest staged)
+    echo "Staged digest:   $staged"
+    if [[ "$staged" != "$expected" ]]; then
+        echo "FATAL: staged digest does not match $ref" >&2
+        exit 1
+    fi
+
+    reboot_guest
+
+    booted=$(guest_status_digest booted)
+    rollback=$(guest_status_digest rollback)
+    echo "Booted digest:   $booted (expected $expected)"
+    echo "Rollback digest: $rollback (expected $prev_digest)"
+
+    hop_rc=0
+    [[ "$booted" == "$expected" ]] || { echo "not ok - booted deployment is $ref"; hop_rc=1; }
+    [[ "$rollback" == "$prev_digest" ]] || { echo "not ok - rollback slot holds previous deployment"; hop_rc=1; }
+
+    echo ""
+    echo "--- Persistence verification after hop $hop_num ---"
+    set +e
+    run_guest_script "$SCRIPT_DIR/update-tests/persistence-verify.sh"
+    verify_rc=$?
+    set -e
+    hop_rc=$((hop_rc + verify_rc))
+
+    echo "--- System health after hop $hop_num ---"
+    set +e
+    vm_ssh "systemctl is-system-running --wait"
+    health_rc=$?
+    vm_ssh "systemctl --failed --no-legend"
+    set -e
+    if [[ $health_rc -ne 0 ]]; then
+        echo "not ok - system is not in 'running' state after hop"
+        hop_rc=$((hop_rc + 1))
+    fi
+
+    hop_names+=("hop-$hop_num -> $ref")
+    hop_results+=("$hop_rc")
+    [[ $hop_rc -eq 0 ]] || overall=1
+    prev_digest="$expected"
+done
+
+# ---------------------------------------------------------------
+echo ""
+echo "========================================"
+echo "        UPDATE TEST SUMMARY"
+echo "========================================"
+echo "  install: $INSTALL_REF"
+for i in "${!hop_names[@]}"; do
+    if [[ "${hop_results[$i]}" -eq 0 ]]; then
+        printf "  %-60s PASS\n" "${hop_names[$i]}"
+    else
+        printf "  %-60s FAIL (%s)\n" "${hop_names[$i]}" "${hop_results[$i]}"
+    fi
+done
+echo "========================================"
+exit "$overall"

--- a/test/bootc-update-test.sh
+++ b/test/bootc-update-test.sh
@@ -121,6 +121,13 @@ HOP_REFS=("$@")
 
 [[ $EUID -eq 0 ]] || { echo "Error: must run as root (bootc install needs the root user namespace)" >&2; exit 1; }
 
+# Fail fast if the SSH forward port is taken (e.g. a leftover KEEP_VM guest);
+# otherwise QEMU errors only after a full image pull + install.
+if ss -tln 2>/dev/null | awk '{print $4}' | grep -q ":${SSH_PORT}$"; then
+    echo "Error: port ${SSH_PORT} is already in use (stale VM? set SSH_PORT to override)" >&2
+    exit 1
+fi
+
 trap cleanup EXIT
 
 # Real disk, not tmpfs: hop images are pulled into the guest's /var.

--- a/test/bootc-update-test.sh
+++ b/test/bootc-update-test.sh
@@ -21,6 +21,11 @@
 #                      Workaround for images published before the
 #                      sshd-keygen fix (#343); harmless but unnecessary after.
 #   KEEP_VM=1          Skip cleanup (leave VM running for inspection).
+#   HOP_TRANSPORT=containers-storage
+#                      Pull hop images via podman in the guest and switch
+#                      from local storage. Workaround for the bootc 1.16.2
+#                      registry-transport pull failure ("unexpected EOF
+#                      reading tar entry"); default is registry.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -31,6 +36,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${DISK_SIZE:=20G}"
 : "${INJECT_HOSTKEYS:=0}"
 : "${KEEP_VM:=0}"
+: "${HOP_TRANSPORT:=registry}"
 
 # shellcheck source=test/lib/ssh.sh
 source "$SCRIPT_DIR/lib/ssh.sh"
@@ -190,7 +196,16 @@ for ref in "${HOP_REFS[@]}"; do
     registry_digest=$(digest_of "$ref")
     echo "Registry manifest digest: $registry_digest"
 
-    vm_ssh "bootc switch --quiet $ref"
+    if [[ "$HOP_TRANSPORT" == "containers-storage" ]]; then
+        # Workaround for the bootc 1.16.2 registry-transport pull failure
+        # ("unexpected EOF reading tar entry"): pull via podman in the guest,
+        # then switch from local storage. Same staging/finalize machinery;
+        # only the transfer path differs.
+        vm_ssh "podman pull --quiet $ref >/dev/null"
+        vm_ssh "bootc switch --quiet --transport containers-storage $ref"
+    else
+        vm_ssh "bootc switch --quiet $ref"
+    fi
 
     staged=$(guest_status_digest staged)
     staged_name=$(vm_ssh "bootc status --format json" | jq -r '.status.staged.image.image.image // "null"')

--- a/test/bootc-update-test.sh
+++ b/test/bootc-update-test.sh
@@ -26,6 +26,9 @@
 #                      from local storage. Workaround for the bootc 1.16.2
 #                      registry-transport pull failure ("unexpected EOF
 #                      reading tar entry"); default is registry.
+#   ROLLBACK=1         After the final hop, run the rollback phase: bootc
+#                      rollback, reboot, verify slots swapped and /var+/etc
+#                      persistence held.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -37,6 +40,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${INJECT_HOSTKEYS:=0}"
 : "${KEEP_VM:=0}"
 : "${HOP_TRANSPORT:=registry}"
+: "${ROLLBACK:=0}"
 
 # shellcheck source=test/lib/ssh.sh
 source "$SCRIPT_DIR/lib/ssh.sh"
@@ -260,6 +264,66 @@ for ref in "${HOP_REFS[@]}"; do
     [[ $hop_rc -eq 0 ]] || overall=1
     prev_booted="$booted"
 done
+
+# ---------------------------------------------------------------
+# Rollback phase (plan Phase 4): roll back from the final hop, verify the
+# previous deployment boots, that the slots swapped, that /var data written
+# on the rolled-back-from deployment persists, and the persistence matrix.
+if [[ "$ROLLBACK" == "1" ]]; then
+    echo ""
+    echo "=== Rollback phase ==="
+    vm_ssh "echo rollback-marker > /var/persist-test/written-on-final.txt"
+
+    pre_rb_booted=$(guest_status_digest booted)
+    pre_rb_rollback=$(guest_status_digest rollback)
+    echo "Rolling back from $pre_rb_booted to $pre_rb_rollback"
+
+    vm_ssh "bootc rollback"
+    reboot_guest
+
+    booted=$(guest_status_digest booted)
+    rollback=$(guest_status_digest rollback)
+    echo "Booted digest:   $booted (expected $pre_rb_rollback)"
+    echo "Rollback digest: $rollback (expected $pre_rb_booted)"
+
+    rb_rc=0
+    if [[ "$booted" == "$pre_rb_rollback" ]]; then
+        echo "ok - rollback booted the previous deployment"
+    else
+        echo "not ok - rollback booted the previous deployment"
+        rb_rc=$((rb_rc + 1))
+    fi
+    if [[ "$rollback" == "$pre_rb_booted" ]]; then
+        echo "ok - rollback slot holds the rolled-back-from deployment"
+    else
+        echo "not ok - rollback slot holds the rolled-back-from deployment"
+        rb_rc=$((rb_rc + 1))
+    fi
+    if vm_ssh "grep -qx rollback-marker /var/persist-test/written-on-final.txt"; then
+        echo "ok - /var data written on rolled-back-from deployment persists"
+    else
+        echo "not ok - /var data written on rolled-back-from deployment persists"
+        rb_rc=$((rb_rc + 1))
+    fi
+
+    echo ""
+    echo "--- Persistence verification after rollback ---"
+    set +e
+    run_guest_script "$SCRIPT_DIR/update-tests/persistence-verify.sh"
+    verify_rc=$?
+    vm_ssh "systemctl is-system-running --wait"
+    health_rc=$?
+    set -e
+    rb_rc=$((rb_rc + verify_rc))
+    if [[ $health_rc -ne 0 ]]; then
+        echo "not ok - system is not in 'running' state after rollback"
+        rb_rc=$((rb_rc + 1))
+    fi
+
+    hop_names+=("rollback -> $pre_rb_rollback")
+    hop_results+=("$rb_rc")
+    [[ $rb_rc -eq 0 ]] || overall=1
+fi
 
 # ---------------------------------------------------------------
 echo ""

--- a/test/update-tests/persistence-verify.sh
+++ b/test/update-tests/persistence-verify.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Verify persistence markers after a bootc update hop (or reboot).
+# This script runs INSIDE the booted VM via SSH, as root, after every
+# hop performed by bootc-update-test.sh. Counterpart of
+# persistence-write.sh. Output: TAP-like, exit code = failures.
+set -euo pipefail
+
+HELPERS="${TEST_LIB_DIR:-$(dirname "$0")/../lib}/helpers.sh"
+# shellcheck source=test/lib/helpers.sh
+source "$HELPERS"
+
+STATE=/var/persist-test
+
+echo "# Persistence verification"
+
+# --- /var ---
+check "/var marker file content intact" \
+    grep -qx "var-marker-v1" "$STATE/data.txt"
+
+check "persisttest user still resolves" \
+    id persisttest
+
+check "persisttest home marker intact" \
+    grep -qx "home-marker" /var/home/persisttest/marker.txt
+
+check "podman image survives in /var/lib/containers" \
+    podman image exists localhost/persist-test:1
+
+check "/opt bind still shows /var/opt content" \
+    grep -qx "opt-marker" /opt/persist-test/marker
+
+# shellcheck disable=SC2016
+check "journal retains previous boots (boot count grew)" \
+    bash -c '[[ $(journalctl --list-boots --quiet 2>/dev/null | wc -l) -gt $(cat /var/persist-test/boot-count) ]]'
+
+# --- /etc ---
+check "new local /etc file survives" \
+    grep -qx "etc-new-marker" /etc/persist-test.conf
+
+check "local modification to shipped /etc file survives" \
+    grep -q "persist-test-motd-marker" /etc/motd
+
+if [[ -f "$STATE/issue.net-was-deleted" ]]; then
+    check "locally deleted shipped /etc file stays deleted" \
+        bash -c '[[ ! -e /etc/issue.net ]]'
+fi
+
+check "hostname survives" \
+    bash -c '[[ $(hostname) == persist-test-vm ]]'
+
+check "NetworkManager profile survives" \
+    test -f /etc/NetworkManager/system-connections/persist-test.nmconnection
+
+# --- Identity stability (guards regressions found 2026-07: host keys and
+# machine-id must never change across reboots or updates) ---
+check "SSH host keys unchanged" \
+    sha256sum --check --quiet "$STATE/hostkeys.sha256"
+
+# shellcheck disable=SC2016
+check "machine-id unchanged" \
+    bash -c 'diff -q <(cat /etc/machine-id) /var/persist-test/machine-id'
+
+# --- Informational (answers plan open questions; not pass/fail) ---
+if [[ -e /run/ostree-booted ]]; then
+    echo "# info: /run/ostree-booted EXISTS on this composefs deployment"
+else
+    echo "# info: /run/ostree-booted ABSENT on this composefs deployment"
+fi
+
+print_summary

--- a/test/update-tests/persistence-write.sh
+++ b/test/update-tests/persistence-write.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Write persistence markers before a bootc update hop.
+# This script runs INSIDE the booted VM via SSH, as root, exactly once
+# (on the freshly installed system). persistence-verify.sh asserts the
+# markers after every subsequent reboot/hop.
+# Baselines are recorded under /var/persist-test/ (itself a /var marker).
+set -euo pipefail
+
+STATE=/var/persist-test
+mkdir -p "$STATE"
+
+echo "# Writing persistence markers"
+
+# --- /var markers (shared state/os/default/var; must always persist) ---
+echo "var-marker-v1" > "$STATE/data.txt"
+
+# User account: crosses /etc (passwd/shadow) and /var (home on /var/home)
+if ! id persisttest >/dev/null 2>&1; then
+    useradd -m -s /bin/bash persisttest
+fi
+echo "home-marker" > /var/home/persisttest/marker.txt
+chown persisttest:persisttest /var/home/persisttest/marker.txt
+
+# Container image in /var/lib/containers, built offline (no registry pull)
+tmpf=$(mktemp -d)
+echo "container-marker" > "$tmpf/marker"
+tar -C "$tmpf" -cf - marker | podman import --quiet - localhost/persist-test:1 >/dev/null
+rm -rf "$tmpf"
+
+# /opt is a bind to /var/opt
+mkdir -p /var/opt/persist-test
+echo "opt-marker" > /var/opt/persist-test/marker
+
+# --- /etc markers (per-deployment copy; must carry into new deployments) ---
+# New local file
+echo "etc-new-marker" > /etc/persist-test.conf
+
+# Locally modified shipped file
+echo "# persist-test-motd-marker" >> /etc/motd
+
+# Locally deleted shipped file (issue.net is shipped by base-files and inert)
+if [[ -f /etc/issue.net ]]; then
+    rm /etc/issue.net
+    touch "$STATE/issue.net-was-deleted"
+fi
+
+# Identity
+hostnamectl set-hostname persist-test-vm
+
+# NetworkManager connection profile (never activated; loopback-ish dummy)
+cat > /etc/NetworkManager/system-connections/persist-test.nmconnection <<'EOF'
+[connection]
+id=persist-test
+uuid=8db7a1f0-5aa5-4e8b-9e52-persisttest0
+type=dummy
+interface-name=persist0
+autoconnect=false
+EOF
+chmod 600 /etc/NetworkManager/system-connections/persist-test.nmconnection
+
+# --- Baselines for identity-stability checks ---
+sha256sum /etc/ssh/ssh_host_*_key.pub > "$STATE/hostkeys.sha256"
+cat /etc/machine-id > "$STATE/machine-id"
+journalctl --list-boots --quiet 2>/dev/null | wc -l > "$STATE/boot-count"
+
+echo "# Markers written; baselines recorded in $STATE"


### PR DESCRIPTION
## Summary

Implements the update-sequence harness from `docs/plans/2026-07-03-bootc-update-validation-plan.md`: `test/bootc-update-test.sh` installs a published tag, boots it, writes a persistence marker matrix (`test/update-tests/persistence-write.sh`), then per hop runs `bootc switch` in the guest, reboots, asserts staged→booted→rollback digest continuity, and re-verifies the matrix plus system health (`persistence-verify.sh`).

Running it immediately paid for itself — it found **three real bugs** (all now addressed or reported):

1. **Registry-transport pull is broken in bootc 1.16.2** (`bootc switch docker://…` → `unexpected EOF reading tar entry`; same tag pulls fine via podman in the same guest). Candidate fix: composefs bump in bootc 1.16.3 (#348). Harness workaround: `HOP_TRANSPORT=containers-storage`.
2. **Staged updates never finalized on snosi installs**: `snow-linux-live-setup.service` self-disabled via runtime `systemctl disable`, deleting `/etc` symlinks; bootc's merge follows the corresponding symlink in the new deployment's `/etc` out of its cap-std sandbox (`a path led outside of the filesystem`). Fixed snosi-side in #347; bootc-side bug (`metadata_optional` should be `symlink_metadata`, still present on upstream `main`) to be reported upstream.
3. Digest semantics: containers-storage installs record the storage digest, not the registry manifest digest — the harness asserts name at baseline and staged→booted continuity per hop.

With the three `/etc` paths restored in a live guest, the full flow was verified end-to-end on real published tags (`20260702011235` → `20260703151145`): update applied, rollback slot correct, system `running` with zero failed units, and **12/13 persistence checks passed** — including SSH host keys and machine-id stability; the 13th (deleted-file persistence) was contaminated by debugging in that guest, not a merge failure. Also answered a plan open question: `/run/ostree-booted` is **absent** on composefs deployments, so upstream's update timer would never fire as-is.

`INJECT_HOSTKEYS=1` supports images published before #343.

## Test plan

- [x] shellcheck (CI settings) clean
- [x] Executed live against real published tags through install → markers → switch → finalize → reboot → verify (with documented workarounds for the two pre-fix bugs)
- [ ] Green end-to-end run without workarounds once #347/#348 images publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)