### PR TITLE
feat: add bootc-update-stage timer (nbc-parity update staging)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ Scripts execute in order: **BuildScripts** (in chroot) -> **PostInstallationScri
 
 **First-boot semantics:** the image ships `/etc/machine-id` as an empty file, which systemd treats as "initialize a machine ID, but not first boot" — `ConditionFirstBoot=yes` never fires on installed systems (only a missing machine-id or one containing `uninitialized` triggers it). Any unit that must run once on a fresh install needs a different condition (e.g. `ConditionPathExists=!<marker>`); see the `sshd-keygen.service.d` drop-in in base `mkosi.extra`, which regenerates SSH host keys whenever they are missing. When writing such a drop-in, remember an empty `Condition*=` assignment resets ALL conditions on the unit, so restate the stock unit's other conditions.
 
+### OS Update Staging (bootc)
+
+On bootc-installed systems, updates are staged by `bootc-update-stage.timer` (hourly; base `mkosi.extra`): `/usr/libexec/bootc-update-stage` pulls the followed image via **podman** and stages it with `bootc switch --transport containers-storage`; the update applies at the next natural reboot via `bootc-finalize-staged.service`. podman does the transfer because bootc's registry-transport composefs pull currently fails on snosi images (known upstream bug) — and podman enforces `containers-policy.json` at pull time. The script no-ops when: not a bootc-managed system (nbc installs — `spec.image` is null), already running or already staged the pulled digest, or the pulled digest equals the **rollback** deployment (never auto-flip-flop back to a version the admin rolled away from; bootc refuses that switch anyway). Upstream's `bootc-fetch-apply-updates.timer` is preset-disabled: it force-reboots on update and is gated on `/run/ostree-booted`, which does not exist on composefs deployments. During the transition, `nbc-update-download.timer` still ships for nbc-installed hosts; each mechanism no-ops on the other's install type.
+
 ### Base Image: In-Tree bootc + ostree Build
 
 bootc and ostree are **not** installed from APT; they are compiled from pinned source during the base image build.

--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/system-preset/04-bootc-update.preset
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/system-preset/04-bootc-update.preset
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Stage-only update timer: downloads + stages, applies at next natural reboot.
+enable bootc-update-stage.timer
+# Upstream bootc timer does fetch + apply + IMMEDIATE REBOOT. It is currently
+# inert on composefs deployments (gated on /run/ostree-booted, which does not
+# exist there), but systemctl preset-all enables it by default — disable it
+# explicitly so a future upstream fix cannot start force-rebooting desktops.
+disable bootc-fetch-apply-updates.timer

--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/bootc-update-stage.service
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/bootc-update-stage.service
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Unit]
+Description=Stage bootc update (download only; applies at next reboot)
+Documentation=man:bootc(8)
+After=network-online.target
+Wants=network-online.target
+# Cheap gate: composefs deployments boot with a composefs= kernel argument.
+# Do NOT use ConditionPathExists=/run/ostree-booted here — that path does not
+# exist on composefs-booted systems (it is why the upstream
+# bootc-fetch-apply-updates.timer never fires). The script additionally exits
+# cleanly when the system is not bootc-managed (e.g. nbc A/B installs).
+ConditionKernelCommandLine=composefs
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/bootc-update-stage

--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/bootc-update-stage.timer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/bootc-update-stage.timer
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Unit]
+Description=Stage bootc update timer
+
+[Timer]
+# Mirrors nbc-update-download.timer's cadence during the transition.
+OnCalendar=hourly
+RandomizedDelaySec=15m
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/mkosi.images/base/mkosi.extra/usr/libexec/bootc-update-stage
+++ b/mkosi.images/base/mkosi.extra/usr/libexec/bootc-update-stage
@@ -1,0 +1,57 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Stage a bootc update: pull the followed image via podman, then stage it
+# with `bootc switch --transport containers-storage`. The staged deployment
+# applies at the next natural reboot (bootc-finalize-staged.service), which
+# mirrors nbc's download-only semantics — no forced reboot.
+#
+# podman does the transfer because bootc's registry-transport composefs pull
+# currently fails on snosi images (known upstream bug; see the findings log
+# in docs/plans/2026-07-03-bootc-update-validation-plan.md). podman also
+# enforces containers-policy.json at pull time.
+set -euo pipefail
+
+status=$(bootc status --format json)
+
+image=$(jq -r '.spec.image.image // empty' <<<"$status")
+if [[ -z "$image" ]]; then
+    # Not a bootc-managed system (e.g. an nbc A/B install): nothing to do.
+    echo "No bootc image spec; not a bootc-managed system. Nothing to do."
+    exit 0
+fi
+
+booted=$(jq -r '.status.booted.image.imageDigest // empty' <<<"$status")
+staged=$(jq -r '.status.staged.image.imageDigest // empty' <<<"$status")
+rollback=$(jq -r '.status.rollback.image.imageDigest // empty' <<<"$status")
+
+podman pull --quiet "$image" >/dev/null
+pulled=$(podman image inspect --format '{{.Id}}' "$image")
+pulled="sha256:${pulled#sha256:}"
+
+# For containers-storage deployments, bootc's imageDigest is the storage
+# image ID (config digest), which is exactly what podman reports as .Id.
+if [[ "$pulled" == "$booted" ]]; then
+    echo "Already running $image ($pulled); nothing to stage."
+    exit 0
+fi
+if [[ "$pulled" == "$staged" ]]; then
+    echo "$image ($pulled) is already staged; will apply at next reboot."
+    exit 0
+fi
+if [[ -n "$rollback" && "$pulled" == "$rollback" ]]; then
+    # The published image is the deployment the admin rolled back FROM.
+    # Do not flip-flop back to it automatically (bootc would refuse anyway:
+    # "Target image has the same fs-verity digest as the existing rollback
+    # deployment"). Use `bootc rollback` deliberately if that is intended.
+    echo "$image ($pulled) equals the rollback deployment; not re-staging automatically."
+    exit 0
+fi
+
+echo "Staging update: $image ($pulled)"
+bootc switch --quiet --transport containers-storage "$image"
+
+# The image content is copied into the composefs repository at switch time;
+# prune dangling transfer images to keep podman storage bounded.
+podman image prune -f >/dev/null || true
+
+echo "Update staged; it will apply at the next reboot."


### PR DESCRIPTION
## Summary

Implements Phase 5 of `docs/plans/2026-07-03-bootc-update-validation-plan.md`: automated, desktop-safe update staging for bootc installs.

- **`bootc-update-stage.timer`** (hourly, `Persistent=true`, mirroring `nbc-update-download.timer`'s cadence) → **`/usr/libexec/bootc-update-stage`**: podman-pull the followed image, then `bootc switch --transport containers-storage`. Staged updates apply at the next natural reboot via `bootc-finalize-staged.service` — nbc's download-only semantics, no forced reboot.
- **Transfer via podman** because bootc's registry-transport composefs pull fails deterministically on snosi images (known upstream bug; confirmed unfixed in 1.16.3 during validation runs). Bonus: podman enforces `containers-policy.json` at pull time, giving a hook for the signature-enforcement open question.
- **Safety no-ops**, each live-tested: not bootc-managed (nbc installs — `spec.image` null; verified on an nbc host), pulled digest already running (verified in VM), already staged, or **equal to the rollback deployment** — discovered during testing that bootc refuses such a switch (`same fs-verity digest as rollback deployment`), and an hourly updater must not flip-flop back to a version the admin deliberately rolled away from (nor error hourly about it).
- **Gate:** `ConditionKernelCommandLine=composefs` — deliberately *not* `/run/ostree-booted`, which does not exist on composefs deployments (verified; it's why upstream's timer never fires).
- **`bootc-fetch-apply-updates.timer` preset-disabled**: it does fetch + apply + *immediate reboot*, and `systemctl preset-all` was enabling it in shipped images. Inert today only because of its dead gate; a future upstream fix would have started force-rebooting desktops.
- `nbc-update-download.timer` continues to ship during the transition; each updater no-ops on the other's install type.

## Test plan

- [x] shellcheck clean
- [x] Script live-tested in a QEMU bootc deployment: kernel-cmdline gate present (`composefs=<digest>`), "already running" no-op with correct digest comparison (bootc's containers-storage `imageDigest` == podman image ID — verified equality), rollback-equality refusal reproduced and handled
- [x] Not-bootc-managed guard tested on a real nbc-installed host
- [ ] After merge + publish: VM soak per plan Phase 5 (timer fires → stages → natural reboot applies → persistence matrix green), using `test/bootc-update-test.sh` images

🤖 Generated with [Claude Code](https://claude.com/claude-code)