### PR TITLE
feat: add Microsoft Edge sysext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 4 OCI desktop images (snow, snowloaded, snowfield, snowfieldloaded), 2 OCI server images (cayo, cayoloaded), and 11 sysext overlay images (1password-cli, code-server, debdev, dev, docker, himmelblau, incus, nix, podman, tailscale, vscode).
+**Outputs:** 4 OCI desktop images (snow, snowloaded, snowfield, snowfieldloaded), 2 OCI server images (cayo, cayoloaded), and 12 sysext overlay images (1password-cli, code-server, debdev, dev, docker, edge, himmelblau, incus, nix, podman, tailscale, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 11 sysexts
+just sysexts            # Build base + all 12 sysexts
 just snow               # Build snow desktop image
 just snowloaded         # Build snowloaded variant
 just snowfield          # Build snowfield (Surface kernel)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The project produces:
 | **debdev**          | Debian development tools (debootstrap, distro-info)             | sysext        |
 | **dev**             | Build essentials, Python, cmake, valgrind, gdb                  | sysext        |
 | **docker**          | Docker CE container runtime                                     | sysext        |
+| **edge**            | Microsoft Edge browser                                          | sysext        |
 | **himmelblau**      | Himmelblau Entra ID authentication                              | sysext        |
 | **incus**           | Incus container/VM manager                                      | sysext        |
 | **nix**             | Nix package manager                                             | sysext        |

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -6,6 +6,7 @@ Dependencies=base
              debdev
              dev
              docker
+             edge
              himmelblau
              incus
              nix

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/edge.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/edge.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=Microsoft Edge browser
+Documentation=https://www.microsoft.com/edge
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/edge.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/edge.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=edge
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/edge/
+MatchPattern=edge_@v_%w_%a.raw.zst \
+             edge_@v_%w_%a.raw.xz \
+             edge_@v_%w_%a.raw.gz \
+             edge_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=edge_@v_%w_%a.raw.zst \
+             edge_@v_%w_%a.raw.xz \
+             edge_@v_%w_%a.raw.gz \
+             edge_@v_%w_%a.raw
+CurrentSymlink=edge.raw

--- a/mkosi.images/edge/mkosi.conf
+++ b/mkosi.images/edge/mkosi.conf
@@ -1,0 +1,25 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=edge
+Output=edge
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+# Downloads the pinned Edge .deb via verified_download, relocates
+# /opt/microsoft/msedge -> /usr/lib/microsoft-edge, and symlinks the product
+# logos into hicolor (same script the loaded profiles run)
+PostInstallationScripts=%D/shared/packages/edge/mkosi.postinst.d/edge.chroot
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+
+[Include]
+# Runtime deps + BaseTrees for the Edge .deb (shared with the loaded profiles)
+Include=%D/shared/packages/edge/mkosi.conf
+
+[Build]
+Environment=KEYPACKAGE=microsoft-edge-stable

--- a/mkosi.images/edge/required-paths.txt
+++ b/mkosi.images/edge/required-paths.txt
@@ -1,0 +1,7 @@
+# edge sysext: Microsoft Edge browser, relocated from /opt to /usr/lib
+/usr/lib/microsoft-edge/microsoft-edge
+/usr/bin/microsoft-edge-stable
+# Desktop integration: launcher entry and hicolor icon symlink (see
+# yeti/sysexts.md "Desktop Applications in Sysexts")
+/usr/share/applications/microsoft-edge.desktop
+/usr/share/icons/hicolor/256x256/apps/microsoft-edge.png

--- a/shared/packages/edge/mkosi.postinst.d/edge.chroot
+++ b/shared/packages/edge/mkosi.postinst.d/edge.chroot
@@ -17,10 +17,19 @@ DEBS=$(mktemp -d)
 trap 'rm -rf "$DEBS"' EXIT
 verified_download "microsoft-edge-stable" "$DEBS/microsoft-edge-stable.deb"
 
-# Strip the postinst calls that add Edge's APT repo — they invoke apt-config,
-# which fails inside the mkosi chroot and breaks the build.
+# Strip the postinst's APT repo management (add repo/key, remove legacy
+# repo/key) — irrelevant in an image build. This must ALSO neutralize the
+# top-level `APT_CONFIG="$(command -v apt-config ...)"` assignment: the base
+# tree used for sysext overlay builds ships no apt, the postinst runs under
+# dash with `set -e`, and dash's `command -v` returns 127 on a miss, so the
+# bare assignment alone kills the install with exit 127 before MAIN even
+# runs (and remove_legacy_* would later exec the empty "$APT_CONFIG").
+# Profile chroots have apt, which is why only sysext builds ever hit this.
 dpkg-deb -R "$DEBS/microsoft-edge-stable.deb" "$DEBS/edge-unpacked"
-sed -i -e '/^install_key$/d' -e '/^install_deb822_sources$/d' "$DEBS/edge-unpacked/DEBIAN/postinst"
+sed -i -e '/^install_key$/d' -e '/^install_deb822_sources$/d' \
+       -e '/^remove_legacy_list$/d' -e '/^remove_legacy_key$/d' \
+       -e 's/^APT_CONFIG=.*/APT_CONFIG=/' \
+       "$DEBS/edge-unpacked/DEBIAN/postinst"
 dpkg-deb -b "$DEBS/edge-unpacked" "$DEBS/microsoft-edge-stable-fixed.deb"
 
 ${SUDO} dpkg -i "$DEBS/microsoft-edge-stable-fixed.deb"

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -34,7 +34,7 @@ snosi is a bootable container image build system that uses [mkosi](https://githu
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 11 sysexts)
+mkosi.images/               # Image definitions (base + 12 sysexts)
   base/                     # Foundation image: systemd, bootc/ostree (frostyard debs), firmware, core utils
     mkosi.extra/            # Base filesystem overlay (dracut, systemd units/timers, sysupdate, tmpfiles, sysusers)
       usr/lib/sysupdate.d/  # .transfer + .feature files for all sysexts
@@ -186,7 +186,7 @@ Use build-time enablement/presets for desired service state. For run-once runtim
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 11 sysexts
+just sysexts            # Build base + all 12 sysexts
 just snow               # Build snow desktop
 just snowloaded         # Build snowloaded variant
 just snowfield          # Build snowfield (Surface)

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -6,7 +6,7 @@
 
 **Trigger:** Push/PR to main, manual dispatch
 
-Builds the base image and all 11 sysexts, publishes to the Frostyard repository on Cloudflare R2.
+Builds the base image and all 12 sysexts, publishes to the Frostyard repository on Cloudflare R2.
 
 **Steps:**
 1. Aggressive cleanup of runner (removes JDK, .NET, Android SDK, etc. to free disk space)

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -22,6 +22,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **debdev** | debootstrap | Debian development tools (debootstrap, distro-info, arch-test, archive keyrings) |
 | **dev** | build-essential | Build essentials, cmake, Python3, valgrind, gdb, strace |
 | **docker** | docker-ce | Docker CE, containerd, buildx, compose |
+| **edge** | microsoft-edge-stable | Microsoft Edge browser (pinned .deb via verified_download, relocated from /opt) |
 | **himmelblau** | himmelblau | Entra ID authentication (himmelblau, pam-himmelblau, nss-himmelblau) |
 | **incus** | incus | Incus container/VM manager, QEMU/KVM, dnsmasq, OVMF, virt-viewer |
 | **nix** | nix-setup-systemd | Nix package manager with systemd integration |
@@ -84,7 +85,7 @@ installed" at build time, contributes nothing to the delta, and its paths will
 always fail the check even though they exist at runtime — caught live when
 `wget` in debdev's list failed CI on the first run.
 
-`code-server` is the current exception to the `Packages=` line: it downloads a pinned upstream `.deb` in `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` and installs it with `dpkg -i`. It still sets `KEYPACKAGE=code-server`, and the shared postoutput script resolves that version from the merged dpkg database.
+`code-server` and `edge` are the current exceptions to the `Packages=` line: it downloads a pinned upstream `.deb` in `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` and installs it with `dpkg -i`. It still sets `KEYPACKAGE=code-server`, and the shared postoutput script resolves that version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift.
 
 ## Sysext-Specific Extra Files
 
@@ -102,6 +103,11 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `mkosi.finalize` — Captures `/etc/default/docker`, `/etc/docker`, `/etc/containerd` to factory defaults
 - `usr/lib/sysusers.d/docker.conf` — Docker user/group definitions
 - `usr/lib/tmpfiles.d/docker.conf` — Factory config injection
+
+### edge
+- No `mkosi.extra/` — everything comes from the shared package fragment and postinst script (`shared/packages/edge/`), reused verbatim from the loaded profiles
+- Desktop app with no systemd service: no preset, no `Upholds=` drop-in
+- Its icons are hicolor symlinks created by the relocation script — visibility depends on the no-icon-cache pattern (see Desktop Applications in Sysexts below), so on images that still ship `icon-theme.cache` the Edge icon renders generic
 
 ### himmelblau
 - `mkosi.postinst.chroot` — Post-install customization hook (currently minimal)


### PR DESCRIPTION
## What

Packages Microsoft Edge as a sysext — the first desktop sysext that exercises the no-icon-cache pattern from #373 on the path that was actually broken (hicolor icons; the vscode sysext's pixmaps icon never hit the cache).

- `mkosi.images/edge/` reuses `shared/packages/edge/` verbatim: the runtime dep list comes in via `Include=%D/shared/packages/edge/mkosi.conf` (shared with the loaded profiles, so the two never drift) and the same `edge.chroot` does the verified-download, `/opt → /usr/lib/microsoft-edge` relocation, and hicolor logo symlinks
- sysupdate `edge.transfer`/`edge.feature` wiring, root config dependency, docs (README, CLAUDE.md, yeti)

## Postinst fix (affects sysext builds only)

Edge's postinst runs under dash with `set -e` and executes a top-level `APT_CONFIG="$(command -v apt-config …)"`. The base tree used for sysext overlay builds ships no apt, and **dash's `command -v` returns 127 on a miss** (bash returns 1) — so the bare assignment killed the install with exit 127 before MAIN even ran. Profile chroots include apt, which is why only sysext builds ever hit this. The patch step now blanks that assignment and strips the `remove_legacy_list`/`remove_legacy_key` calls (which would exec the empty `$APT_CONFIG`) alongside the two repo-install calls it already stripped. All four only manage APT repo state, meaningless in a fresh image build; verified by running the patched postinst under dash with no apt in PATH (exit 0).

## Verification

- `just sysexts` builds all 12; edge passes required-paths; zero `icon-theme.cache` files in the delta (dissect-verified); `/opt` fully relocated
- End-to-end on minisnow, freshly rebooted onto the post-#373 image (`snow 20260707161026`, ships no icon cache): sysext merges, Edge 150.0.4078.48 launches and works, `Gtk.IconTheme.has_icon('microsoft-edge')` → True resolving to `/usr/share/icons/hicolor/48x48/apps/microsoft-edge.png`, icon renders correctly in the GNOME overview — the exact lookup that failed for sysext icons before #373
- shellcheck clean at CI severity; `mkosi summary` parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)