### PR TITLE
feat: add Azure VPN client sysext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 4 OCI desktop images (snow, snowloaded, snowfield, snowfieldloaded), 2 OCI server images (cayo, cayoloaded), and 12 sysext overlay images (1password-cli, bitwarden, code-server, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode).
+**Outputs:** 4 OCI desktop images (snow, snowloaded, snowfield, snowfieldloaded), 2 OCI server images (cayo, cayoloaded), and 13 sysext overlay images (1password-cli, azurevpn, bitwarden, code-server, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 12 sysexts
+just sysexts            # Build base + all 13 sysexts
 just snow               # Build snow desktop image
 just snowloaded         # Build snowloaded variant
 just snowfield          # Build snowfield (Surface kernel)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The project produces:
 | **cayo**            | Headless server with podman + backports kernel                  | directory → OCI (buildah/chunkah) |
 | **cayoloaded**      | cayo + Docker + Incus (baked in)                                | directory → OCI (buildah/chunkah) |
 | **1password-cli**   | 1Password CLI tool                                              | sysext        |
+| **azurevpn**        | Microsoft Azure VPN client                                      | sysext        |
 | **bitwarden**       | Bitwarden password manager desktop application                  | sysext        |
 | **code-server**     | code-server (VS Code in the browser)                            | sysext        |
 | **debdev**          | Debian development tools (debootstrap, distro-info)             | sysext        |
@@ -40,7 +41,7 @@ The project produces:
              sysexts                         profiles
     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
     │    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
-  1pass bitwarden code-server debdev dev docker edge incus nix podman tailscale vscode │         │
+  1pass azurevpn bitwarden code-server debdev dev docker edge incus nix podman tailscale vscode │         │
                                      snow            cayo
                                ┌──────┼──────┐        │
                                │      │      │    cayoloaded
@@ -283,7 +284,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all sysexts (1password-cli, bitwarden, code-server, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode)
+1. Builds the base image and all sysexts (1password-cli, azurevpn, bitwarden, code-server, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode)
 2. Publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Uploads package manifests for version tracking
 

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -2,6 +2,7 @@
 # list base + any sysexts that get built by default
 Dependencies=base
              1password-cli
+             azurevpn
              bitwarden
              code-server
              debdev

--- a/mkosi.images/azurevpn/mkosi.conf
+++ b/mkosi.images/azurevpn/mkosi.conf
@@ -1,0 +1,31 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=azurevpn
+Output=azurevpn
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+# Downloads the pinned Azure VPN client .deb via verified_download, relocates
+# /opt/microsoft/microsoft-azurevpnclient -> /usr/lib/microsoft-azurevpnclient,
+# patchelf-fixes the rpaths, adapts the polkit rules to Debian, and sets
+# cap_net_admin on the binary (same script the loaded profiles run). The
+# capability survives in the sysext: erofs preserves security.capability
+# xattrs, unlike the OCI image packaging path that made the loaded profiles
+# need microsoft-azurevpn-workaround.service — the sysext deliberately does
+# NOT ship that service or its preset.
+PostInstallationScripts=%D/shared/packages/azurevpn/mkosi.postinst.d/azurevpn.chroot
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+
+[Include]
+# Build tool + runtime deps for the .deb (shared with the loaded profiles)
+Include=%D/shared/packages/azurevpn/mkosi.conf
+
+[Build]
+Environment=KEYPACKAGE=microsoft-azurevpnclient

--- a/mkosi.images/azurevpn/required-paths.txt
+++ b/mkosi.images/azurevpn/required-paths.txt
@@ -1,0 +1,8 @@
+# azurevpn sysext: Microsoft Azure VPN client, relocated from /opt to /usr/lib
+/usr/lib/microsoft-azurevpnclient/microsoft-azurevpnclient
+/usr/lib/microsoft-azurevpnclient/lib/libLinuxCore.so
+# Desktop integration: launcher entry (absolute-path Icon=, no theme lookup)
+/usr/share/applications/microsoft-azurevpnclient.desktop
+/usr/share/icons/microsoft-azurevpnclient.png
+# Debian-adapted polkit rules
+/usr/share/polkit-1/rules.d/microsoft-azurevpnclient.rules

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/azurevpn.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/azurevpn.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=Microsoft Azure VPN client
+Documentation=https://learn.microsoft.com/azure/vpn-gateway/point-to-site-vpn-client-cert-linux
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/azurevpn.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/azurevpn.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=azurevpn
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/azurevpn/
+MatchPattern=azurevpn_@v_%w_%a.raw.zst \
+             azurevpn_@v_%w_%a.raw.xz \
+             azurevpn_@v_%w_%a.raw.gz \
+             azurevpn_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=azurevpn_@v_%w_%a.raw.zst \
+             azurevpn_@v_%w_%a.raw.xz \
+             azurevpn_@v_%w_%a.raw.gz \
+             azurevpn_@v_%w_%a.raw
+CurrentSymlink=azurevpn.raw

--- a/shared/packages/azurevpn/mkosi.conf
+++ b/shared/packages/azurevpn/mkosi.conf
@@ -1,4 +1,20 @@
-
 [Content]
-# Add your packages here
+# patchelf is a build-time tool (rpath fixes after the /opt relocation);
+# the postinst script purges it after use. The rest are runtime deps from
+# the microsoft-azurevpnclient .deb's Depends (installed via mkosi's
+# host-side apt so dpkg -i in the postinst can install the .deb — required
+# for the sysext build, whose base chroot has none of them; snow already
+# ships them all, so this is a no-op for the loaded profiles).
 Packages=patchelf
+         libatk1.0-0
+         libcap2
+         libcurl4
+         libepoxy0
+         libfontconfig1
+         libgtk-3-0
+         libpango-1.0-0
+         libpangocairo-1.0-0
+         libsecret-1-0
+         libsqlite3-0
+         libssl3
+         zenity

--- a/shared/packages/azurevpn/mkosi.postinst.d/azurevpn.chroot
+++ b/shared/packages/azurevpn/mkosi.postinst.d/azurevpn.chroot
@@ -43,9 +43,17 @@ ${SUDO} patchelf --set-rpath '/usr/lib/microsoft-azurevpnclient/lib' /usr/lib/mi
 ${SUDO} patchelf --set-rpath '/usr/lib/microsoft-azurevpnclient/lib' /usr/lib/microsoft-azurevpnclient/lib/liburl_launcher_linux_plugin.so
 ${SUDO} patchelf --set-rpath '/usr/lib/microsoft-azurevpnclient/lib' /usr/lib/microsoft-azurevpnclient/lib/libXplatSharedLibrary.so
 
-# Fix executable permissions
-# FIXME: This change is lost upon the image being built. See workaround in microsoft-azurevpn-workaround.service
+# Fix executable permissions.
+# NOTE: the capability is lost by the OCI IMAGE packaging path (hence the
+# microsoft-azurevpn-workaround.service the loaded-profile trees ship), but
+# it SURVIVES the sysext path — erofs preserves security.capability xattrs
+# and overlayfs passes them through, so the azurevpn sysext ships neither
+# the workaround service nor its preset.
 ${SUDO} /usr/sbin/setcap cap_net_admin+eip /usr/lib/microsoft-azurevpnclient/microsoft-azurevpnclient
 
 # Remove unneeded Rsyslog config
 ${SUDO} rm -f /etc/rsyslog.d/AzureVPNClient.conf
+
+# patchelf is only needed at build time (rpath fixes above) — don't ship it
+# in the image or the sysext delta.
+${SUDO} dpkg --purge patchelf

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -24,7 +24,7 @@ snosi is a bootable container image build system that uses [mkosi](https://githu
 
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
-1password-cli, bitwarden, code-server, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode
+1password-cli, azurevpn, bitwarden, code-server, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode
 
 ## Architecture
 
@@ -34,7 +34,7 @@ snosi is a bootable container image build system that uses [mkosi](https://githu
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 12 sysexts)
+mkosi.images/               # Image definitions (base + 13 sysexts)
   base/                     # Foundation image: systemd, bootc/ostree (frostyard debs), firmware, core utils
     mkosi.extra/            # Base filesystem overlay (dracut, systemd units/timers, sysupdate, tmpfiles, sysusers)
       usr/lib/sysupdate.d/  # .transfer + .feature files for all sysexts
@@ -186,7 +186,7 @@ Use build-time enablement/presets for desired service state. For run-once runtim
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 12 sysexts
+just sysexts            # Build base + all 13 sysexts
 just snow               # Build snow desktop
 just snowloaded         # Build snowloaded variant
 just snowfield          # Build snowfield (Surface)

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -6,7 +6,7 @@
 
 **Trigger:** Push/PR to main, manual dispatch
 
-Builds the base image and all 12 sysexts, publishes to the Frostyard repository on Cloudflare R2.
+Builds the base image and all 13 sysexts, publishes to the Frostyard repository on Cloudflare R2.
 
 **Steps:**
 1. Aggressive cleanup of runner (removes JDK, .NET, Android SDK, etc. to free disk space)

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -18,6 +18,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | Sysext | KEYPACKAGE | Description |
 |--------|------------|-------------|
 | **1password-cli** | 1password-cli | 1Password CLI tool |
+| **azurevpn** | microsoft-azurevpnclient | Microsoft Azure VPN client (pinned .deb via verified_download, relocated from /opt) |
 | **bitwarden** | bitwarden | Bitwarden desktop app (pinned .deb via verified_download, relocated from /opt) |
 | **code-server** | code-server | code-server (VS Code in the browser) — downloaded via `verified_download()` from coder/code-server GitHub releases |
 | **debdev** | debootstrap | Debian development tools (debootstrap, distro-info, arch-test, archive keyrings) |
@@ -85,11 +86,17 @@ installed" at build time, contributes nothing to the delta, and its paths will
 always fail the check even though they exist at runtime — caught live when
 `wget` in debdev's list failed CI on the first run.
 
-`code-server`, `edge`, and `bitwarden` are the current exceptions to the `Packages=` line: it downloads a pinned upstream `.deb` in `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` and installs it with `dpkg -i`. It still sets `KEYPACKAGE=code-server`, and the shared postoutput script resolves that version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file Exec rewrite, deps via `Include=`.
+`code-server`, `edge`, `bitwarden`, and `azurevpn` are the current exceptions to the `Packages=` line: it downloads a pinned upstream `.deb` in `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` and installs it with `dpkg -i`. It still sets `KEYPACKAGE=code-server`, and the shared postoutput script resolves that version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file Exec rewrite, deps via `Include=`.
 
 ## Sysext-Specific Extra Files
 
 Some sysexts include extra files via `mkosi.extra/`:
+
+### azurevpn
+- No `mkosi.extra/` — reuses `shared/packages/azurevpn/` (fragment + postinst) verbatim from the loaded profiles
+- Ships `cap_net_admin` as a real file capability: erofs preserves `security.capability`, so the sysext deliberately does NOT carry the loaded profiles' `microsoft-azurevpn-workaround.service` (that service exists only because the OCI image packaging path drops caps)
+- Desktop entry uses an absolute-path `Icon=` — no icon theme/cache involvement
+- The postinst purges `patchelf` after the rpath fixes so the build tool ships nowhere
 
 ### bitwarden
 - No `mkosi.extra/` — everything comes from the shared package fragment and postinst script (`shared/packages/bitwarden/`), reused verbatim from the loaded profiles


### PR DESCRIPTION
Stacked on #376 (retargets to main automatically when that merges). Part of retiring the loaded variants: this converts the last loaded-only desktop app.

## What

`mkosi.images/azurevpn/` reuses `shared/packages/azurevpn/` verbatim (verified-download of the pinned Microsoft .deb, `/opt → /usr/lib` relocation, patchelf rpath fixes, Debian polkit-rules adaptation). The fragment gains the .deb's actual runtime `Depends` (GTK stack, libsecret, zenity, …) so `dpkg -i` succeeds in the apt-less base overlay chroot — snow masked those for profile builds, same class of gap as Bitwarden's (#375). Postinst screened for the Edge dash-127 trap (#374): it's trivial guarded bash, clean.

## The interesting part: no workaround service

The loaded profiles ship `microsoft-azurevpn-workaround.service` — a `/usr/local` bind-mount dance that re-applies `cap_net_admin` at boot, because the OCI image packaging path drops file capabilities (the FIXME in azurevpn.chroot). **The sysext path doesn't have that problem**: erofs preserves `security.capability` xattrs and overlayfs passes them through. Verified in the built raw: `getcap` shows `cap_net_admin=eip` on the binary inside the erofs. So the sysext ships the capability directly and carries neither the service nor its preset. The loaded profiles keep their tree until PR D deletes them.

Bonus cleanup: the postinst now purges `patchelf` after the rpath fixes — the build tool previously shipped in the loaded images and would otherwise have shipped in the sysext delta.

## Verification

- `just sysexts` builds all 13; azurevpn passes required-paths (5/5)
- Raw dissect-checked: `cap_net_admin=eip` present, `RUNPATH=/usr/lib/microsoft-azurevpnclient/lib` applied, polkit rules contain the Debian `isInGroup("sudo")` adaptation, patchelf absent, zero `icon-theme.cache` files, no systemd units
- Desktop entry uses an absolute-path `Icon=` — no icon-theme/cache interaction at all
- shellcheck (CI severity) + `mkosi summary` pass

Runtime smoke test on minisnow to follow the same pattern as edge/bitwarden if desired — the meaningful runtime check is `getcap` post-merge plus a VPN connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)