### PR TITLE
feat: add fonts-noto-core for Unicode symbol coverage

### DIFF
--- a/shared/packages/snow/mkosi.conf
+++ b/shared/packages/snow/mkosi.conf
@@ -100,10 +100,15 @@ Packages=gnome-browser-connector
          malcontent-gui
 
 # Fonts
+# fonts-noto-core ships Noto Sans Symbols 2, the only font in this set covering
+# the Miscellaneous Technical range (e.g. U+23F5 ⏵, used by terminal UIs like
+# Claude Code for mode indicators). Without it those glyphs render as ?? in
+# ghostty/gnome-terminal — no other installed font, Nerd Fonts included, has them.
 Packages=fonts-dejavu
          fonts-dejavu-extra
          fonts-droid-fallback
          fonts-noto-color-emoji
+         fonts-noto-core
          fonts-noto-mono
 
 # IBus input method


### PR DESCRIPTION
## Problem

The desktop font set (snow/snowfield) had no font covering the Unicode **Miscellaneous Technical** range. Glyphs like `U+23F5` (`⏵`) — used by terminal UIs such as Claude Code for its `⏵⏵ auto-mode` indicator — rendered as `??` in ghostty/gnome-terminal.

This is distinct from Nerd Font PUA icons: **no installed font, Nerd Fonts included, covered `U+23F5`** (`fc-list :charset=23f5` returned empty).

## Fix

Add `fonts-noto-core` to the Fonts block in `shared/packages/snow/mkosi.conf`. It ships `NotoSansSymbols2-Regular.ttf` (Noto Sans Symbols 2), which provides that range, and keeps the set consistent with the existing Noto family usage (`fonts-noto-color-emoji`, `fonts-noto-mono`).

Added to the **graphical** package set only (snow + snowfield) — headless `cayo` has no display and no use for it, matching the existing convention for graphical-only packages like `libnotify-bin`.

## Verification

- `NotoSansSymbols2-Regular.ttf` confirmed to cover `U+23F5` locally (`fc-list :charset=23f5` → `Noto Sans Symbols 2`).
- Confirmed against the Debian Trixie archive that `fonts-noto-core` ships `NotoSansSymbols2-Regular.ttf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)