### PR TITLE
ci: route dependency update builds

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -6,8 +6,18 @@ on:
       - build
   push:
     branches: [main]
+    paths-ignore:
+      # Sysext-only dependency metadata should rebuild/publish sysexts via
+      # build.yml without spending the OCI image matrix.
+      - "shared/download/package-versions.json"
+      - "latest-versions.txt"
+      - "shared/download/sysext-checksums.json"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "shared/download/package-versions.json"
+      - "latest-versions.txt"
+      - "shared/download/sysext-checksums.json"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,14 @@ name: Build sysexts
 on:
   push:
     branches: [main]
+    paths-ignore:
+      # Image-only direct-download metadata should rebuild OCI profiles, not
+      # the base+sysext publishing workflow.
+      - "shared/download/image-checksums.json"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "shared/download/image-checksums.json"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -8,7 +8,8 @@ on:
 permissions: {}
 
 jobs:
-  check-updates:
+  check-sysext-updates:
+    name: Check sysext dependency updates
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,12 +20,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check for dependency updates
+      - name: Check for sysext dependency updates
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CHECKSUMS="shared/download/checksums.json"
+          CHECKSUMS="shared/download/sysext-checksums.json"
           UPDATES=""
 
           # Authenticated, retried GitHub API fetch. On persistent failure it
@@ -50,16 +51,6 @@ jobs:
             echo "bitwarden_version=$LATEST_BW" >> $GITHUB_OUTPUT
           fi
 
-          # Check Homebrew install script
-          CURRENT_BREW=$(jq -r '.["brew-install"].version' "$CHECKSUMS")
-          LATEST_BREW=$(gh_api https://api.github.com/repos/Homebrew/install/commits/HEAD | jq -r '.sha' | head -c 12)
-          CURRENT_BREW_SHORT=$(echo "$CURRENT_BREW" | head -c 12)
-          if [[ -n "$LATEST_BREW" && "$LATEST_BREW" != "null" && "$LATEST_BREW" != "$CURRENT_BREW_SHORT" ]]; then
-            UPDATES="${UPDATES}brew-install: $CURRENT_BREW_SHORT -> $LATEST_BREW\n"
-            echo "brew_update=true" >> $GITHUB_OUTPUT
-            echo "brew_commit=$LATEST_BREW" >> $GITHUB_OUTPUT
-          fi
-
           # Check code-server
           CURRENT_CS=$(jq -r '.["code-server"].version' "$CHECKSUMS")
           LATEST_CS=$(gh_api https://api.github.com/repos/coder/code-server/releases/latest | jq -r '.tag_name' | sed 's/^v//')
@@ -69,9 +60,159 @@ jobs:
             echo "codeserver_version=$LATEST_CS" >> $GITHUB_OUTPUT
           fi
 
+          # Check Microsoft Azure VPN Client
+          CURRENT_AZ=$(jq -r '.["microsoft-azurevpnclient"].version' "$CHECKSUMS")
+          LATEST_AZ=$(curl -fsSL --retry 3 --retry-delay 2 https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/ | grep -oP 'microsoft-azurevpnclient_\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
+          if [[ -n "$LATEST_AZ" && "$LATEST_AZ" != "$CURRENT_AZ" ]]; then
+            UPDATES="${UPDATES}microsoft-azurevpnclient: $CURRENT_AZ -> $LATEST_AZ\n"
+            echo "azurevpn_update=true" >> $GITHUB_OUTPUT
+            echo "azurevpn_version=$LATEST_AZ" >> $GITHUB_OUTPUT
+          fi
+
+          # Check Microsoft Edge Stable
+          CURRENT_EDGE=$(jq -r '.["microsoft-edge-stable"].version' "$CHECKSUMS")
+          LATEST_EDGE=$(curl -fsSL --retry 3 --retry-delay 2 https://packages.microsoft.com/repos/edge/dists/stable/main/binary-amd64/Packages | awk '/^Package: microsoft-edge-stable$/,/^$/' | awk '/^Version:/ {print $2}' | sort -V | tail -1)
+          if [[ -n "$LATEST_EDGE" && "$LATEST_EDGE" != "$CURRENT_EDGE" ]]; then
+            UPDATES="${UPDATES}microsoft-edge-stable: $CURRENT_EDGE -> $LATEST_EDGE\n"
+            echo "edge_update=true" >> $GITHUB_OUTPUT
+            echo "edge_version=$LATEST_EDGE" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ -n "$UPDATES" ]]; then
+            echo "has_updates=true" >> $GITHUB_OUTPUT
+            echo -e "Updates available:\n$UPDATES"
+          else
+            echo "has_updates=false" >> $GITHUB_OUTPUT
+            echo "All sysext dependencies up to date"
+          fi
+
+      - name: Update sysext checksums
+        if: steps.check.outputs.has_updates == 'true'
+        # Step outputs derive from external release/commit data; passing them
+        # through env (rather than inline ${{ }} interpolation in the script)
+        # keeps a malicious upstream tag from injecting shell commands.
+        env:
+          BITWARDEN_UPDATE: ${{ steps.check.outputs.bitwarden_update }}
+          BITWARDEN_VERSION: ${{ steps.check.outputs.bitwarden_version }}
+          CODESERVER_UPDATE: ${{ steps.check.outputs.codeserver_update }}
+          CODESERVER_VERSION: ${{ steps.check.outputs.codeserver_version }}
+          AZUREVPN_UPDATE: ${{ steps.check.outputs.azurevpn_update }}
+          AZUREVPN_VERSION: ${{ steps.check.outputs.azurevpn_version }}
+          EDGE_UPDATE: ${{ steps.check.outputs.edge_update }}
+          EDGE_VERSION: ${{ steps.check.outputs.edge_version }}
+        run: |
+          CHECKSUMS="shared/download/sysext-checksums.json"
+
+          if [[ "$BITWARDEN_UPDATE" == "true" ]]; then
+            VER="$BITWARDEN_VERSION"
+            URL="https://github.com/bitwarden/clients/releases/download/desktop-v${VER}/Bitwarden-${VER}-amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.bitwarden.url=$u | .bitwarden.sha256=$s | .bitwarden.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$CODESERVER_UPDATE" == "true" ]]; then
+            VER="$CODESERVER_VERSION"
+            URL="https://github.com/coder/code-server/releases/download/v${VER}/code-server_${VER}_amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.["code-server"].url=$u | .["code-server"].sha256=$s | .["code-server"].version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$AZUREVPN_UPDATE" == "true" ]]; then
+            VER="$AZUREVPN_VERSION"
+            URL="https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/microsoft-azurevpnclient_${VER}_amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.["microsoft-azurevpnclient"].url=$u | .["microsoft-azurevpnclient"].sha256=$s | .["microsoft-azurevpnclient"].version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$EDGE_UPDATE" == "true" ]]; then
+            VER="$EDGE_VERSION"
+            URL="https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_${VER}_amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.["microsoft-edge-stable"].url=$u | .["microsoft-edge-stable"].sha256=$s | .["microsoft-edge-stable"].version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+      - name: Create sysext dependency PR
+        if: steps.check.outputs.has_updates == 'true'
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
+        with:
+          # GITHUB_TOKEN-created PRs do not trigger workflows (validate/build
+          # never run on them). Set the WORKFLOW_PAT repo secret (fine-grained
+          # PAT or GitHub App token with contents+pull-requests write) to give
+          # auto-update PRs real CI; until then this falls back to
+          # GITHUB_TOKEN and PRs must be checked manually.
+          token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update sysext dependency checksums"
+          title: "chore: update sysext dependency checksums"
+          body: |
+            Automated update of pinned direct-download dependencies consumed by sysext builds.
+
+            These updates modify `shared/download/sysext-checksums.json` and should trigger `build.yml`, not the OCI image matrix.
+
+            **Please verify the sysext build works before merging.**
+          branch: auto-update-sysext-checksums
+          delete-branch: true
+
+  check-image-updates:
+    name: Check image dependency updates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Check for image dependency updates
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHECKSUMS="shared/download/image-checksums.json"
+          UPDATES=""
+
+          gh_api() {
+            curl -fsSL --retry 3 --retry-delay 2 \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$1" || true
+          }
+
           # ostree + bootc are NOT checked here: they are consumed as debs
           # from the frostyard APT repo, built by frostyard/bootc-debian,
           # which has its own weekly upstream-version check.
+
+          # Check Homebrew install script
+          CURRENT_BREW=$(jq -r '.["brew-install"].version' "$CHECKSUMS")
+          LATEST_BREW=$(gh_api https://api.github.com/repos/Homebrew/install/commits/HEAD | jq -r '.sha' | head -c 12)
+          CURRENT_BREW_SHORT=$(echo "$CURRENT_BREW" | head -c 12)
+          if [[ -n "$LATEST_BREW" && "$LATEST_BREW" != "null" && "$LATEST_BREW" != "$CURRENT_BREW_SHORT" ]]; then
+            UPDATES="${UPDATES}brew-install: $CURRENT_BREW_SHORT -> $LATEST_BREW\n"
+            echo "brew_update=true" >> $GITHUB_OUTPUT
+            echo "brew_commit=$LATEST_BREW" >> $GITHUB_OUTPUT
+          fi
 
           # Check Surface cert (less frequent changes)
           CURRENT_SURF=$(jq -r '.["surface-cert"].version' "$CHECKSUMS")
@@ -110,42 +251,17 @@ jobs:
             echo "bazaar_commit=$LATEST_BZ" >> $GITHUB_OUTPUT
           fi
 
-          # Check Microsoft Azure VPN Client
-          CURRENT_AZ=$(jq -r '.["microsoft-azurevpnclient"].version' "$CHECKSUMS")
-          LATEST_AZ=$(curl -fsSL --retry 3 --retry-delay 2 https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/ | grep -oP 'microsoft-azurevpnclient_\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
-          if [[ -n "$LATEST_AZ" && "$LATEST_AZ" != "$CURRENT_AZ" ]]; then
-            UPDATES="${UPDATES}microsoft-azurevpnclient: $CURRENT_AZ -> $LATEST_AZ\n"
-            echo "azurevpn_update=true" >> $GITHUB_OUTPUT
-            echo "azurevpn_version=$LATEST_AZ" >> $GITHUB_OUTPUT
-          fi
-
-          # Check Microsoft Edge Stable
-          CURRENT_EDGE=$(jq -r '.["microsoft-edge-stable"].version' "$CHECKSUMS")
-          LATEST_EDGE=$(curl -fsSL --retry 3 --retry-delay 2 https://packages.microsoft.com/repos/edge/dists/stable/main/binary-amd64/Packages | awk '/^Package: microsoft-edge-stable$/,/^$/' | awk '/^Version:/ {print $2}' | sort -V | tail -1)
-          if [[ -n "$LATEST_EDGE" && "$LATEST_EDGE" != "$CURRENT_EDGE" ]]; then
-            UPDATES="${UPDATES}microsoft-edge-stable: $CURRENT_EDGE -> $LATEST_EDGE\n"
-            echo "edge_update=true" >> $GITHUB_OUTPUT
-            echo "edge_version=$LATEST_EDGE" >> $GITHUB_OUTPUT
-          fi
-
           if [[ -n "$UPDATES" ]]; then
             echo "has_updates=true" >> $GITHUB_OUTPUT
             echo -e "Updates available:\n$UPDATES"
           else
             echo "has_updates=false" >> $GITHUB_OUTPUT
-            echo "All dependencies up to date"
+            echo "All image dependencies up to date"
           fi
 
-      - name: Update checksums
+      - name: Update image checksums
         if: steps.check.outputs.has_updates == 'true'
-        # Step outputs derive from external release/commit data; passing them
-        # through env (rather than inline ${{ }} interpolation in the script)
-        # keeps a malicious upstream tag from injecting shell commands.
         env:
-          BITWARDEN_UPDATE: ${{ steps.check.outputs.bitwarden_update }}
-          BITWARDEN_VERSION: ${{ steps.check.outputs.bitwarden_version }}
-          CODESERVER_UPDATE: ${{ steps.check.outputs.codeserver_update }}
-          CODESERVER_VERSION: ${{ steps.check.outputs.codeserver_version }}
           BREW_UPDATE: ${{ steps.check.outputs.brew_update }}
           BREW_COMMIT: ${{ steps.check.outputs.brew_commit }}
           SURFACE_UPDATE: ${{ steps.check.outputs.surface_update }}
@@ -156,36 +272,8 @@ jobs:
           LOGOMENU_COMMIT: ${{ steps.check.outputs.logomenu_commit }}
           BAZAAR_UPDATE: ${{ steps.check.outputs.bazaar_update }}
           BAZAAR_COMMIT: ${{ steps.check.outputs.bazaar_commit }}
-          AZUREVPN_UPDATE: ${{ steps.check.outputs.azurevpn_update }}
-          AZUREVPN_VERSION: ${{ steps.check.outputs.azurevpn_version }}
-          EDGE_UPDATE: ${{ steps.check.outputs.edge_update }}
-          EDGE_VERSION: ${{ steps.check.outputs.edge_version }}
         run: |
-          CHECKSUMS="shared/download/checksums.json"
-
-          if [[ "$BITWARDEN_UPDATE" == "true" ]]; then
-            VER="$BITWARDEN_VERSION"
-            URL="https://github.com/bitwarden/clients/releases/download/desktop-v${VER}/Bitwarden-${VER}-amd64.deb"
-            TMP=$(mktemp)
-            curl -fsSL -o "$TMP" "$URL"
-            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
-            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
-              '.bitwarden.url=$u | .bitwarden.sha256=$s | .bitwarden.version=$v' \
-              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
-            rm -f "$TMP"
-          fi
-
-          if [[ "$CODESERVER_UPDATE" == "true" ]]; then
-            VER="$CODESERVER_VERSION"
-            URL="https://github.com/coder/code-server/releases/download/v${VER}/code-server_${VER}_amd64.deb"
-            TMP=$(mktemp)
-            curl -fsSL -o "$TMP" "$URL"
-            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
-            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
-              '.["code-server"].url=$u | .["code-server"].sha256=$s | .["code-server"].version=$v' \
-              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
-            rm -f "$TMP"
-          fi
+          CHECKSUMS="shared/download/image-checksums.json"
 
           if [[ "$BREW_UPDATE" == "true" ]]; then
             COMMIT="$BREW_COMMIT"
@@ -247,45 +335,18 @@ jobs:
             rm -f "$TMP"
           fi
 
-          if [[ "$AZUREVPN_UPDATE" == "true" ]]; then
-            VER="$AZUREVPN_VERSION"
-            URL="https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/microsoft-azurevpnclient_${VER}_amd64.deb"
-            TMP=$(mktemp)
-            curl -fsSL -o "$TMP" "$URL"
-            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
-            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
-              '.["microsoft-azurevpnclient"].url=$u | .["microsoft-azurevpnclient"].sha256=$s | .["microsoft-azurevpnclient"].version=$v' \
-              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
-            rm -f "$TMP"
-          fi
-
-          if [[ "$EDGE_UPDATE" == "true" ]]; then
-            VER="$EDGE_VERSION"
-            URL="https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_${VER}_amd64.deb"
-            TMP=$(mktemp)
-            curl -fsSL -o "$TMP" "$URL"
-            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
-            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
-              '.["microsoft-edge-stable"].url=$u | .["microsoft-edge-stable"].sha256=$s | .["microsoft-edge-stable"].version=$v' \
-              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
-            rm -f "$TMP"
-          fi
-
-      - name: Create Pull Request
+      - name: Create image dependency PR
         if: steps.check.outputs.has_updates == 'true'
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
-          # GITHUB_TOKEN-created PRs do not trigger workflows (validate/build
-          # never run on them). Set the WORKFLOW_PAT repo secret (fine-grained
-          # PAT or GitHub App token with contents+pull-requests write) to give
-          # auto-update PRs real CI; until then this falls back to
-          # GITHUB_TOKEN and PRs must be checked manually.
           token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update external dependency checksums"
-          title: "chore: update external dependency checksums"
+          commit-message: "chore: update image dependency checksums"
+          title: "chore: update image dependency checksums"
           body: |
-            Automated update of pinned external dependencies.
+            Automated update of pinned direct-download dependencies consumed by OCI image profile builds.
 
-            **Please verify the builds work before merging.**
-          branch: auto-update-checksums
+            These updates modify `shared/download/image-checksums.json` and should trigger `build-images.yml`, not the sysext publishing workflow.
+
+            **Please verify the image builds work before merging.**
+          branch: auto-update-image-checksums
           delete-branch: true

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           persist-credentials: false
 
+
+      # These packages are installed by sysext images from external APT repos.
+      # package-versions.json is only a change-detection sentinel; mkosi still
+      # resolves packages from APT during the sysext build.
       - name: Check latest package versions
         run: |
           get_latest_version() {
@@ -96,10 +100,10 @@ jobs:
           # WORKFLOW_PAT repo secret to give auto-update PRs real CI (see
           # check-dependencies.yml for details).
           token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update package versions"
-          title: "chore: update package versions"
+          commit-message: "chore: update sysext package versions"
+          title: "chore: update sysext package versions"
           body: |
-            Automated update of pinned package versions.
+            Automated update of external APT package version sentinels for sysext builds.
 
             ${{ steps.compare.outputs.summary }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ The shared sysext postoutput script (`shared/sysext/postoutput/sysext-postoutput
 
 ## Key Directories
 
-- `shared/download/` - Verified download system: `checksums.json` pins URLs+SHA256s, `verified-download.sh` provides the `verified_download()` helper
+- `shared/download/` - Verified download system: `sysext-checksums.json` pins direct downloads consumed by sysexts, `image-checksums.json` pins direct downloads consumed by OCI profile builds, `package-versions.json` tracks external APT package version sentinels for sysexts, and `verified-download.sh` provides the `verified_download()` helper
 - `shared/kernel/` - Kernel configs (backports, surface, stock) and dracut scripts
 - `shared/packages/` - Package set definitions, some with postinstall scripts for relocation
 - `shared/outformat/image/` - Image output format config (directory), finalize scripts, `buildah-package.sh` (OCI packaging), and `chunkah-package.sh` (CI re-chunks the OCI image for efficient delta updates)
@@ -104,9 +104,9 @@ The shared sysext postoutput script (`shared/sysext/postoutput/sysext-postoutput
 
 - Use `set -euo pipefail` at the top of all scripts
 - Build scripts running in chroot use `.chroot` extension
-- External downloads must go through `verified_download()` with entries in `checksums.json`
+- External direct downloads must go through `verified_download()` with entries in `sysext-checksums.json` for sysext consumers or `image-checksums.json` for OCI profile consumers
 - Pin external URLs to specific versions/commits, never `latest` or branch names
-- When adding a new verified download, also add a corresponding update check to `.github/workflows/check-dependencies.yml`
+- When adding a new verified download, also add a corresponding update check to `.github/workflows/check-dependencies.yml`; sysext APT package sentinels go in `.github/workflows/check-packages.yml`
 
 ## User Service Enablement in Chroot
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ shared/
 │   ├── surface/mkosi.conf     ← linux-surface kernel + iptsd
 │   └── scripts/               ← dracut postinst scripts
 ├── download/
-│   ├── checksums.json         ← Pinned URLs + SHA256s for all external downloads
-│   └── verified-download.sh   ← verified_download() helper
+│   ├── sysext-checksums.json ← Pinned direct downloads consumed by sysext builds
+│   ├── image-checksums.json  ← Pinned direct downloads consumed by OCI profile builds
+│   ├── package-versions.json ← External APT package version sentinels for sysexts
+│   └── verified-download.sh  ← verified_download() helper
 ├── kernel/
 │   ├── backports/mkosi.conf   ← Trixie backports kernel + firmware
 │   ├── surface/mkosi.conf     ← linux-surface kernel + iptsd
@@ -300,8 +302,8 @@ The `test-install.yml` workflow verifies the signature before every installation
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `check-dependencies.yml` | Weekly | Checks pinned external downloads (checksums.json) for updates, opens PRs |
-| `check-packages.yml` | Daily | Checks external APT package versions, opens PRs |
+| `check-dependencies.yml` | Weekly | Checks pinned direct downloads, updates `sysext-checksums.json` and/or `image-checksums.json`, opens target-specific PRs |
+| `check-packages.yml` | Daily | Checks external APT package versions for sysexts, updates `package-versions.json`, opens PRs |
 | `validate.yml` | PR/push | shellcheck (all shebang-discovered scripts, `-S warning`) + `mkosi summary` validation for every profile |
 | `test-install.yml` | Manual | Signature-verified bootc installation test in QEMU/KVM |
 | `scorecard.yml` | Weekly | OpenSSF supply-chain security analysis |
@@ -596,28 +598,48 @@ cp --archive --no-target-directory --update=none \
 
 ### Adding External Downloads with Checksum Verification
 
-Some build scripts download files directly from external URLs (not via apt). These downloads use SHA256 checksum verification for security and reproducibility.
+Some build scripts download files directly from external URLs instead of resolving
+them through APT. These downloads use SHA256 checksum verification for security,
+reproducibility, and reviewable update PRs.
 
 #### Files Involved
 
 ```
 shared/download/
-├── verified-download.sh   # Helper function for verified downloads
-├── checksums.json         # Pinned URLs and SHA256 checksums
-└── update-checksums.sh    # Manual helper to update a checksum
+├── verified-download.sh      # Helper function for verified downloads
+├── sysext-checksums.json     # Direct downloads consumed by mkosi.images/* sysexts
+├── image-checksums.json      # Direct downloads consumed by OCI profile builds
+├── package-versions.json     # APT package version sentinels for sysexts
+└── update-checksums.sh       # Manual helper to update an existing checksum key
 ```
 
-**checksums.json** contains entries like:
+The checksum files have the same schema. They are split by the build artifact
+that must be rebuilt when a dependency changes:
 
 ```json
 {
   "bitwarden": {
-    "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2025.12.1/Bitwarden-2025.12.1-amd64.deb",
-    "sha256": "33a5056f43b6205fe168f64f3fc7d52cef4c5ccbe06951584d037664aa3c6c50",
-    "version": "2025.12.1"
+    "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2026.6.1/Bitwarden-2026.6.1-amd64.deb",
+    "sha256": "421bfc6d787d842406909d393c2a9044791e957aa234718ae5670e87ae4deba7",
+    "version": "2026.6.1"
   }
 }
 ```
+
+Use the target-specific file:
+
+| Dependency kind | Metadata file | Rebuild workflow |
+|-----------------|---------------|------------------|
+| Direct download used by a sysext (`mkosi.images/<name>/...` or `shared/packages/<app>/...` consumed only by sysexts) | `shared/download/sysext-checksums.json` | `build.yml` |
+| Direct download used by profile/image build scripts (`shared/scripts/build/`, `shared/snow/scripts/build/`, `shared/cayo/...`) | `shared/download/image-checksums.json` | `build-images.yml` |
+| External APT package installed by a sysext through `Packages=` | `shared/download/package-versions.json` | `build.yml` |
+
+This routing keeps sysext-only dependency updates from spending the larger OCI
+image matrix. A dependency consumed by both sysexts and OCI profile builds
+needs an explicit design choice: split the consumers so each target has its own
+metadata entry, or update the workflow filters in the same PR. Do not hide a
+shared build input in one target-specific checksum file and assume both build
+workflows will run.
 
 #### Using Verified Downloads in Build Scripts
 
@@ -632,22 +654,29 @@ verified_download "mykey" "/path/to/output"
 ```
 
 The `verified_download` function:
-1. Reads the URL and checksum from `checksums.json` using the provided key
+1. Searches `sysext-checksums.json` and `image-checksums.json` for the key
 2. Downloads the file with retries
 3. Verifies the SHA256 checksum matches
 4. Fails the build with a clear error if verification fails
 
+Set `CHECKSUMS_FILE=/path/to/file.json` before sourcing the helper only when a
+script must intentionally restrict lookup to one explicit metadata file.
+
 #### Adding a New External Download
 
-1. **Add the entry to checksums.json:**
+1. **Choose the metadata file by consumer.**
+   - Sysext-only direct download: `shared/download/sysext-checksums.json`
+   - OCI profile direct download: `shared/download/image-checksums.json`
+   - Sysext APT package, no direct URL/checksum: `shared/download/package-versions.json`
+
+2. **Add the checksum entry.**
 
    ```bash
-   # Download the file and compute checksum
    curl -fsSL -o /tmp/myfile "https://example.com/myfile.tar.gz"
    sha256sum /tmp/myfile
    ```
 
-   Then add to `shared/download/checksums.json`:
+   Then add to the selected checksum file:
 
    ```json
    {
@@ -659,18 +688,24 @@ The `verified_download` function:
    }
    ```
 
-   Or use the helper script:
+   For an existing key, the helper updates whichever split checksum file
+   already contains the key:
 
    ```bash
    ./shared/download/update-checksums.sh mykey "https://example.com/myfile.tar.gz" "1.2.3"
    ```
 
-2. **Use in your build script:**
+3. **Use the key in the build script.**
 
    ```bash
    source "$SRCDIR/shared/download/verified-download.sh"
    verified_download "mykey" "/tmp/myfile.tar.gz"
    ```
+
+4. **Add the update check.**
+   - Sysext direct downloads go in the `check-sysext-updates` job in `.github/workflows/check-dependencies.yml`.
+   - OCI profile direct downloads go in the `check-image-updates` job in `.github/workflows/check-dependencies.yml`.
+   - Sysext APT package sentinels go in `.github/workflows/check-packages.yml` and `shared/download/package-versions.json`.
 
 #### Pinning Strategy
 
@@ -680,12 +715,18 @@ The `verified_download` function:
 
 #### Automated Update Checking
 
-The `.github/workflows/check-dependencies.yml` workflow runs weekly to check for updates:
+The `.github/workflows/check-dependencies.yml` workflow runs weekly and has two
+independent jobs:
 
-1. Compares pinned versions against latest releases/commits
-2. If updates are found, downloads new files and computes checksums
-3. Creates a PR with updated `checksums.json`
-4. **Requires manual review** before merging - verify builds work with new versions
+1. `check-sysext-updates` compares sysext direct-download pins and opens
+   `auto-update-sysext-checksums` PRs against `sysext-checksums.json`.
+2. `check-image-updates` compares OCI profile direct-download pins and opens
+   `auto-update-image-checksums` PRs against `image-checksums.json`.
+
+The `.github/workflows/check-packages.yml` workflow runs daily for external APT
+packages consumed by sysexts (`code`, `docker-ce`, `1password-cli`). It updates
+`package-versions.json`, which is only a change-detection sentinel; mkosi still
+resolves the package from APT during the sysext build.
 
 To check manually or trigger an update PR, use the "Run workflow" button in GitHub Actions.
 

--- a/shared/download/image-checksums.json
+++ b/shared/download/image-checksums.json
@@ -1,19 +1,4 @@
 {
-  "bitwarden": {
-    "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2026.6.1/Bitwarden-2026.6.1-amd64.deb",
-    "sha256": "421bfc6d787d842406909d393c2a9044791e957aa234718ae5670e87ae4deba7",
-    "version": "2026.6.1"
-  },
-  "microsoft-azurevpnclient": {
-    "url": "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/microsoft-azurevpnclient_3.0.0_amd64.deb",
-    "sha256": "9e5d360433d1d374d9a1051bb29a65103e81ca74ebeaa35155d1f0e9fc94577b",
-    "version": "3.0.0"
-  },
-  "microsoft-edge-stable": {
-    "url": "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_150.0.4078.48-1_amd64.deb",
-    "sha256": "6c091da6c061b83b4ab0e3a9946127dc91ae8f3a0632c4e1c0b6d5e31775f4b5",
-    "version": "150.0.4078.48-1"
-  },
   "surface-cert": {
     "url": "https://github.com/linux-surface/linux-surface/raw/d8887bc8ce14a47d5b9d45f6697f05d53e43fe9a/pkg/keys/surface.cer",
     "sha256": "081202cf3ea30519046bbb9faf5dafe24c3fdf56b79afea62778f24913ab6d64",
@@ -23,11 +8,6 @@
     "url": "https://raw.githubusercontent.com/Homebrew/install/16be749c0089/install.sh",
     "sha256": "99287f194a8b3c9e6b0203a11a5fa54518be57209343e6bb954dec4635796d9d",
     "version": "16be749c0089"
-  },
-  "code-server": {
-    "url": "https://github.com/coder/code-server/releases/download/v4.127.0/code-server_4.127.0_amd64.deb",
-    "sha256": "a1cb96f64d5c68736764726cd3b0c9b6e500bdc30cfefebc05f59259149380e2",
-    "version": "4.127.0"
   },
   "hotedge": {
     "url": "https://codeload.github.com/frostyard/hotedge/tar.gz/5411c3802803dbaafc6d8014b3a983027dab4704",

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -1,0 +1,22 @@
+{
+  "bitwarden": {
+    "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2026.6.1/Bitwarden-2026.6.1-amd64.deb",
+    "sha256": "421bfc6d787d842406909d393c2a9044791e957aa234718ae5670e87ae4deba7",
+    "version": "2026.6.1"
+  },
+  "microsoft-azurevpnclient": {
+    "url": "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/microsoft-azurevpnclient_3.0.0_amd64.deb",
+    "sha256": "9e5d360433d1d374d9a1051bb29a65103e81ca74ebeaa35155d1f0e9fc94577b",
+    "version": "3.0.0"
+  },
+  "microsoft-edge-stable": {
+    "url": "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_150.0.4078.48-1_amd64.deb",
+    "sha256": "6c091da6c061b83b4ab0e3a9946127dc91ae8f3a0632c4e1c0b6d5e31775f4b5",
+    "version": "150.0.4078.48-1"
+  },
+  "code-server": {
+    "url": "https://github.com/coder/code-server/releases/download/v4.127.0/code-server_4.127.0_amd64.deb",
+    "sha256": "a1cb96f64d5c68736764726cd3b0c9b6e500bdc30cfefebc05f59259149380e2",
+    "version": "4.127.0"
+  }
+}

--- a/shared/download/update-checksums.sh
+++ b/shared/download/update-checksums.sh
@@ -1,9 +1,27 @@
 #!/bin/bash
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # Usage: ./update-checksums.sh <key> <new_url> [version]
+#
+# Existing keys are updated in their target-specific metadata file:
+#   - sysext-checksums.json for direct downloads consumed by sysext builds
+#   - image-checksums.json for direct downloads consumed by OCI image builds
+# Set CHECKSUMS_FILE to update one explicit metadata file.
 set -euo pipefail
 KEY="$1"; URL="$2"; VERSION="${3:-}"
-CHECKSUMS="$(dirname "$0")/checksums.json"
+CHECKSUMS_DIR="$(dirname "$0")"
+if [[ -n "${CHECKSUMS_FILE:-}" ]]; then
+  CHECKSUMS="$CHECKSUMS_FILE"
+else
+  CHECKSUMS=""
+  for candidate in "$CHECKSUMS_DIR/sysext-checksums.json" "$CHECKSUMS_DIR/image-checksums.json"; do
+    [[ -f "$candidate" ]] || { echo "Error: Checksums file not found: $candidate" >&2; exit 1; }
+    if [[ "$(jq -r --arg k "$KEY" 'has($k)' "$candidate")" == "true" ]]; then
+      CHECKSUMS="$candidate"
+      break
+    fi
+  done
+  [[ -n "$CHECKSUMS" ]] || { echo "Error: Key '$KEY' not found in split checksum metadata" >&2; exit 1; }
+fi
 TMP=$(mktemp); trap 'rm -f "$TMP"' EXIT
 curl --retry 3 -fsSL -o "$TMP" "$URL"
 SHA=$(sha256sum "$TMP" | cut -d' ' -f1)

--- a/shared/download/verified-download.sh
+++ b/shared/download/verified-download.sh
@@ -1,19 +1,36 @@
 #!/bin/bash
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # Shared helper for verified downloads with SHA256 checksum validation.
+# By default, lookup is split by build target:
+#   - sysext-checksums.json: direct downloads consumed by mkosi.images/* sysexts
+#   - image-checksums.json: direct downloads consumed by OCI profile builds
+# Set CHECKSUMS_FILE to force lookup against one explicit metadata file.
 set -euo pipefail
 
-CHECKSUMS_FILE="${CHECKSUMS_FILE:-$(dirname "${BASH_SOURCE[0]}")/checksums.json}"
+CHECKSUMS_DIR="$(dirname "${BASH_SOURCE[0]}")"
+if [[ -n "${CHECKSUMS_FILE:-}" ]]; then
+    CHECKSUMS_FILES=("$CHECKSUMS_FILE")
+else
+    CHECKSUMS_FILES=(
+        "$CHECKSUMS_DIR/sysext-checksums.json"
+        "$CHECKSUMS_DIR/image-checksums.json"
+    )
+fi
 
 verified_download() {
     local key="$1"
     local output_path="$2"
 
-    [[ -f "$CHECKSUMS_FILE" ]] || { echo "Error: Checksums file not found: $CHECKSUMS_FILE" >&2; return 1; }
+    local url="" checksum="" checksums_file
+    for checksums_file in "${CHECKSUMS_FILES[@]}"; do
+        [[ -f "$checksums_file" ]] || { echo "Error: Checksums file not found: $checksums_file" >&2; return 1; }
 
-    local url checksum
-    url=$(jq -r --arg key "$key" '.[$key].url // empty' "$CHECKSUMS_FILE")
-    checksum=$(jq -r --arg key "$key" '.[$key].sha256 // empty' "$CHECKSUMS_FILE")
+        url=$(jq -r --arg key "$key" '.[$key].url // empty' "$checksums_file")
+        checksum=$(jq -r --arg key "$key" '.[$key].sha256 // empty' "$checksums_file")
+        if [[ -n "$url" || -n "$checksum" ]]; then
+            break
+        fi
+    done
 
     [[ -n "$url" ]] || { echo "Error: No URL for key '$key'" >&2; return 1; }
     [[ -n "$checksum" ]] || { echo "Error: No checksum for key '$key'" >&2; return 1; }

--- a/test/verified-download-split-checksums-test.sh
+++ b/test/verified-download-split-checksums-test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Focused regression test for verified_download lookup across split checksum metadata.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_HELPER="$PROJECT_ROOT/shared/download/verified-download.sh"
+WORK_DIR=""
+PASS=0
+FAIL=0
+
+cleanup() {
+    if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+record_pass() {
+    echo "ok - $1"
+    (( PASS++ )) || true
+}
+
+record_fail() {
+    echo "not ok - $1"
+    if [[ $# -gt 1 ]]; then
+        echo "  $2" >&2
+    fi
+    (( FAIL++ )) || true
+}
+
+assert_file_content() {
+    local desc="$1"
+    local path="$2"
+    local expected="$3"
+
+    if [[ ! -f "$path" ]]; then
+        record_fail "$desc" "missing output file: $path"
+        return
+    fi
+
+    local actual
+    actual="$(cat "$path")"
+    if [[ "$actual" == "$expected" ]]; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "expected '$expected', got '$actual'"
+    fi
+}
+
+run_verified_download() {
+    local checksums_file="$1"
+    local key="$2"
+    local output="$3"
+    local log="$4"
+
+    if [[ -n "$checksums_file" ]]; then
+        CHECKSUMS_FILE="$checksums_file" bash -c '
+            set -euo pipefail
+            source "$1"
+            verified_download "$2" "$3"
+        ' bash "$HELPER" "$key" "$output" >"$log" 2>&1
+    else
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            verified_download "$2" "$3"
+        ' bash "$HELPER" "$key" "$output" >"$log" 2>&1
+    fi
+}
+
+expect_download() {
+    local desc="$1"
+    local key="$2"
+    local output="$3"
+    local expected="$4"
+    local log="$WORK_DIR/$key.log"
+
+    if run_verified_download "" "$key" "$output" "$log"; then
+        assert_file_content "$desc" "$output" "$expected"
+    else
+        record_fail "$desc" "verified_download failed; log: $(cat "$log")"
+    fi
+}
+
+expect_failure() {
+    local desc="$1"
+    local checksums_file="$2"
+    local key="$3"
+    local output="$4"
+    local log="$WORK_DIR/$key.fail.log"
+
+    if run_verified_download "$checksums_file" "$key" "$output" "$log"; then
+        record_fail "$desc" "verified_download unexpectedly succeeded"
+    else
+        record_pass "$desc"
+    fi
+}
+
+sha256_of() {
+    sha256sum "$1" | cut -d' ' -f1
+}
+
+write_checksum_json() {
+    local path="$1"
+    local key="$2"
+    local payload="$3"
+    local version="$4"
+
+    cat >"$path" <<JSON
+{
+  "$key": {
+    "url": "file://$payload",
+    "sha256": "$(sha256_of "$payload")",
+    "version": "$version"
+  }
+}
+JSON
+}
+
+[[ -f "$SOURCE_HELPER" ]] || { echo "Error: helper not found: $SOURCE_HELPER" >&2; exit 1; }
+
+WORK_DIR="$(mktemp -d)"
+HELPER="$WORK_DIR/shared/download/verified-download.sh"
+mkdir -p "$WORK_DIR/shared/download" "$WORK_DIR/payloads" "$WORK_DIR/out"
+cp "$SOURCE_HELPER" "$HELPER"
+
+printf 'sysext payload fixture' >"$WORK_DIR/payloads/sysext.txt"
+printf 'image payload fixture' >"$WORK_DIR/payloads/image.txt"
+printf 'override payload fixture' >"$WORK_DIR/payloads/override.txt"
+
+write_checksum_json "$WORK_DIR/shared/download/sysext-checksums.json" \
+    "sysext-fixture" "$WORK_DIR/payloads/sysext.txt" "sysext-test"
+write_checksum_json "$WORK_DIR/shared/download/image-checksums.json" \
+    "image-fixture" "$WORK_DIR/payloads/image.txt" "image-test"
+write_checksum_json "$WORK_DIR/shared/download/override-checksums.json" \
+    "override-fixture" "$WORK_DIR/payloads/override.txt" "override-test"
+
+echo "# verified_download split checksum lookup"
+
+expect_download "sysext-checksums.json key downloads and verifies" \
+    "sysext-fixture" "$WORK_DIR/out/sysext.txt" "sysext payload fixture"
+
+expect_download "image-checksums.json key downloads and verifies" \
+    "image-fixture" "$WORK_DIR/out/image.txt" "image payload fixture"
+
+expect_failure "missing key fails" \
+    "" "missing-fixture" "$WORK_DIR/out/missing.txt"
+
+expect_failure "CHECKSUMS_FILE override excludes split checksum files" \
+    "$WORK_DIR/shared/download/override-checksums.json" \
+    "sysext-fixture" "$WORK_DIR/out/override-restricted.txt"
+
+if run_verified_download "$WORK_DIR/shared/download/override-checksums.json" \
+    "override-fixture" "$WORK_DIR/out/override.txt" "$WORK_DIR/override.log"; then
+    assert_file_content "CHECKSUMS_FILE override file key downloads and verifies" \
+        "$WORK_DIR/out/override.txt" "override payload fixture"
+else
+    record_fail "CHECKSUMS_FILE override file key downloads and verifies" \
+        "verified_download failed; log: $(cat "$WORK_DIR/override.log")"
+fi
+
+echo ""
+echo "# Results: $PASS passed, $FAIL failed, $(( PASS + FAIL )) total"
+exit "$FAIL"

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -45,7 +45,7 @@ mkosi.profiles/             # Desktop/server profile definitions (6 profiles)
   cayo/
   ...
 shared/                     # Reusable fragments composed via Include=
-  download/                 # Verified download system (checksums.json, package-versions.json + helpers)
+  download/                 # Verified download metadata (sysext/image checksums, package version sentinels) + helpers
   kernel/                   # Kernel variant configs (backports, surface, stock)
   packages/                 # Package set configs (desktop/server bases plus loaded-image extras)
   scripts/                  # Shared scripts (common-postinst.sh sourced by all profiles, brew.chroot build script)
@@ -131,11 +131,31 @@ See [sysexts.md](sysexts.md) for details.
 
 ### Verified Downloads
 
-External resources are pinned in `shared/download/checksums.json` with URL + SHA256. Scripts use `verified_download(key, output_path)` from `shared/download/verified-download.sh`. CI workflow `check-dependencies.yml` detects updates weekly and creates PRs.
+Direct external downloads are pinned with URL + SHA256 in target-specific
+metadata files under `shared/download/`:
 
-Package versions for selected APT-based externals (VSCode, Docker, 1Password, Himmelblau) are tracked separately in `shared/download/package-versions.json`, checked daily by `check-packages.yml`.
+- `sysext-checksums.json` — direct downloads consumed by sysext builds
+- `image-checksums.json` — direct downloads consumed by OCI profile builds
 
-Current checksum-managed downloads are Bitwarden, Homebrew install script, code-server, Surface secure boot certificate, Hotedge, Logomenu, Bazaar Companion, Azure VPN, and Microsoft Edge. Current APT version tracking covers `code`, `docker-ce`, and `1password-cli`; Edge is checksum-managed because the build installs a patched downloaded `.deb`. `code-server` is a sysext exception: it is installed by `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` + `dpkg -i`, while `KEYPACKAGE=code-server` still drives version extraction from the merged dpkg database.
+Scripts use `verified_download(key, output_path)` from
+`shared/download/verified-download.sh`; by default it searches both checksum
+files. CI workflow `check-dependencies.yml` detects updates weekly and opens
+target-specific PRs so sysext-only changes do not spend the OCI image matrix.
+
+Package versions for selected APT-based sysext externals (VSCode `code`,
+Docker, 1Password) are tracked separately in
+`shared/download/package-versions.json`, checked daily by `check-packages.yml`.
+This file is only a rebuild sentinel; mkosi still resolves packages from APT.
+
+Current sysext checksum-managed downloads are Bitwarden, code-server, Azure
+VPN, and Microsoft Edge. Current image checksum-managed downloads are Homebrew
+install script, Surface secure boot certificate, Hotedge, Logomenu, and Bazaar
+Companion. Current APT version tracking covers `code`, `docker-ce`, and
+`1password-cli`; Edge is checksum-managed because the build installs a patched
+downloaded `.deb`. `code-server` is a sysext exception: it is installed by
+`mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` +
+`dpkg -i`, while `KEYPACKAGE=code-server` still drives version extraction from
+the merged dpkg database.
 
 ### User Service Enablement in Chroot
 

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -257,11 +257,23 @@ Optimizes OCI image layers using [chunkah](https://quay.io/jlebon/chunkah).
 
 ## Verified Download System
 
-External resources are managed through `shared/download/`:
+External resources are managed through `shared/download/` with metadata split
+by the build artifact that must be rebuilt when a dependency changes:
 
-### checksums.json
+### sysext-checksums.json
 
-Pins URL + SHA256 for each external download:
+Pins URL + SHA256 for direct downloads consumed by sysext builds. Current
+consumers include the Bitwarden, Edge, Azure VPN, and code-server sysexts.
+Updates to this file should trigger `build.yml` and skip the OCI image matrix.
+
+### image-checksums.json
+
+Pins URL + SHA256 for direct downloads consumed by OCI profile builds. Current
+consumers include Homebrew, Surface secure boot cert, Hotedge, Logomenu, and
+Bazaar Companion. Updates to this file should trigger `build-images.yml` and
+skip the sysext publishing workflow.
+
+Both checksum files use the same schema:
 
 ```json
 {
@@ -276,18 +288,26 @@ Pins URL + SHA256 for each external download:
 ### verified-download.sh
 
 Provides `verified_download(key, output_path)`:
-1. Reads URL + checksum from checksums.json via jq
+1. Searches `sysext-checksums.json` and `image-checksums.json` via jq
 2. Downloads with curl + retries
 3. Validates SHA256 post-download
-4. Fails the build on checksum mismatch
+4. Fails the build on missing keys or checksum mismatch
+
+Set `CHECKSUMS_FILE` only when a script must intentionally restrict lookup to
+one explicit metadata file.
 
 ### package-versions.json
 
-Tracks APT-based external package versions (VSCode `code`, `docker-ce`, `1password-cli`) separately from download checksums. Updated daily by `check-packages.yml`. Edge is NOT tracked here — it is pinned via `checksums.json` and updated by `check-dependencies.yml`.
+Tracks APT-based external package versions for sysexts (`code`, `docker-ce`,
+`1password-cli`) separately from download checksums. Updated daily by
+`check-packages.yml`. This file is only a rebuild sentinel; it does not pin
+what mkosi installs from APT. Edge is NOT tracked here — it is pinned as a
+direct `.deb` in `sysext-checksums.json` and updated by `check-dependencies.yml`.
 
 ### update-checksums.sh
 
-Helper for CI to update checksums.json:
+Helper for manual updates to existing checksum keys. It updates whichever split
+checksum file already contains the key:
 ```bash
 ./update-checksums.sh <key> <url> [version]
 ```

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -4,7 +4,9 @@
 
 ### build.yml — Sysext Build and Publish
 
-**Trigger:** Push/PR to main, manual dispatch
+**Trigger:** Push/PR to main, manual dispatch. Push/PR events ignore
+`shared/download/image-checksums.json` when that is the only changed path;
+image-only direct-download updates should rebuild OCI profiles instead.
 
 Builds the base image and all 13 sysexts, publishes to the Frostyard repository on Cloudflare R2.
 
@@ -28,7 +30,11 @@ path in the image's `required-paths.txt` is missing from the buildroot.
 
 ### build-images.yml — Desktop/Server Image Build and Publish
 
-**Trigger:** repository_dispatch type `build`, push/PR to main, manual dispatch
+**Trigger:** repository_dispatch type `build`, push/PR to main, manual dispatch.
+Push/PR events ignore sysext-only dependency metadata
+(`shared/download/sysext-checksums.json`,
+`shared/download/package-versions.json`, `latest-versions.txt`) when those are
+the only changed paths.
 
 Matrix build of all 3 profiles (snow, snowfield, cayo).
 
@@ -59,42 +65,57 @@ After the matrix completes, a self-contained `release` job runs on main-branch p
 
 **Skip paths:** Missing/invalid snow artifact, no previous tag, or `previous == current` all emit warnings and skip release creation.
 
-### check-dependencies.yml — External Download Updates
+### check-dependencies.yml — Direct Download Updates
 
 **Trigger:** Weekly (Monday 9am UTC), manual dispatch
 
-Checks for updates to resources managed by the verified download system:
+Checks for updates to resources managed by the verified download system. The
+workflow has two independent jobs so update PRs touch only the metadata file
+for the build artifact that must be rebuilt.
 
+**Sysext dependency job (`shared/download/sysext-checksums.json`):**
 - Bitwarden desktop .deb
-- Homebrew install script
 - code-server .deb
+- Microsoft Azure VPN Client
+- Microsoft Edge Stable .deb
+
+Updates open `auto-update-sysext-checksums` PRs. Those PRs should trigger
+`build.yml` and skip the OCI image matrix.
+
+**OCI image dependency job (`shared/download/image-checksums.json`):**
+- Homebrew install script
 - Surface secure boot certificate
 - Hotedge GNOME extension
 - Logomenu GNOME extension
 - Bazaar Companion GNOME extension
-- Microsoft Azure VPN Client
-- Microsoft Edge Stable .deb
+
+Updates open `auto-update-image-checksums` PRs. Those PRs should trigger
+`build-images.yml` and skip the sysext publishing workflow.
 
 **Process:**
-1. Downloads each resource from its upstream URL
-2. Computes SHA256 checksum
-3. Compares against `shared/download/checksums.json`
-4. If changed: updates checksums.json, creates PR
+1. Checks each upstream release/commit/package index
+2. Downloads changed resources
+3. Computes SHA256 checksums
+4. Updates the target-specific checksum file and creates a PR
 
-### check-packages.yml — APT Package Version Updates
+### check-packages.yml — Sysext APT Package Version Updates
 
 **Trigger:** Daily (8am UTC)
 
-Checks for version updates to external APT packages:
+Checks for version updates to external APT packages installed by sysext images:
 
-- code (VS Code)
+- code (VS Code sysext)
 - docker-ce
 - 1password-cli
+
+`shared/download/package-versions.json` is only a change-detection sentinel.
+It does not pin installed package versions; mkosi resolves the package from APT
+during the sysext build.
 
 **Process:**
 1. Queries APT repositories for current versions
 2. Compares against `shared/download/package-versions.json`
-3. If changed: updates package-versions.json, creates PR
+3. If changed: updates `package-versions.json`, creates a sysext package-version PR
 
 ### validate.yml — Code Validation
 
@@ -128,8 +149,8 @@ Runs OpenSSF Scorecard analysis for supply-chain security assessment. Publishes 
 - **SBOM generation:** Syft generates SBOMs for all OCI images, attached as OCI referrers via ORAS
 - **Image signing:** OCI images and SBOM artifacts signed with Cosign after push. The public key is committed at repo root as `cosign.pub` (same keypair across frostyard repos); `test-install.yml` runs `cosign verify --key cosign.pub` before installation tests. cosign v2.6.x is the tested verifier — v3 currently fails key verification when GitHub provenance attestations are attached
 - **Build attestation:** GitHub Actions provenance attestation on image builds
-- **Checksum verification:** All external downloads verified against pinned SHA256 hashes
-- **Automated updates:** Dependency and package version checks create PRs for review (never auto-merge)
+- **Checksum verification:** Direct external downloads are verified against pinned SHA256 hashes in target-specific sysext/image metadata files
+- **Automated updates:** Dependency and package version checks create target-specific PRs for review (never auto-merge)
 
 ## Publishing Targets
 

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -65,6 +65,25 @@ Key settings:
 - `Format=sysext` — Outputs an EROFS sysext image
 - `KEYPACKAGE` — The package whose version determines the sysext version
 
+
+### Dependency update metadata
+
+Use the dependency metadata file that matches how the sysext consumes the
+upstream artifact:
+
+| Sysext dependency source | Metadata file | Update workflow |
+|--------------------------|---------------|-----------------|
+| Direct `.deb`, tarball, raw file, or commit archive downloaded with `verified_download()` | `shared/download/sysext-checksums.json` | `.github/workflows/check-dependencies.yml` `check-sysext-updates` job |
+| External APT package installed through `Packages=` | `shared/download/package-versions.json` | `.github/workflows/check-packages.yml` |
+
+Do not put sysext-only direct downloads in `image-checksums.json`; that file is
+for OCI profile build inputs and triggers the expensive `build-images.yml`
+matrix. When adding a new sysext package from an external APT repo, add the
+package to `check-packages.yml` so a version change opens a sysext rebuild PR.
+When adding a new sysext direct download, add the checksum entry to
+`sysext-checksums.json` and add the upstream version check to the
+`check-sysext-updates` job.
+
 Every sysext must also have a `mkosi.images/<name>/required-paths.txt`: one
 absolute path per line (comments with `#`) that must exist in the finished
 buildroot. The shared finalize script


### PR DESCRIPTION
## Summary
- split verified direct-download metadata into sysext and OCI image checksum files
- route sysext-only dependency updates away from the OCI image matrix and image-only checksum updates away from sysext publishing
- split check-dependencies into sysext/image update jobs with separate PR branches
- document where new direct downloads and APT package sentinels belong in README, CLAUDE.md, and yeti docs

## Verification
- ./test/verified-download-split-checksums-test.sh
- shellcheck -S warning -x shared/download/verified-download.sh shared/download/update-checksums.sh test/verified-download-split-checksums-test.sh
- jq empty shared/download/sysext-checksums.json shared/download/image-checksums.json shared/download/package-versions.json
- yq eval '.' .github/workflows/build.yml .github/workflows/build-images.yml .github/workflows/check-dependencies.yml .github/workflows/check-packages.yml >/dev/null
- bash -n on every run block in build.yml, build-images.yml, check-dependencies.yml, and check-packages.yml