### PR TITLE
fix(cayo): add bootc dracut module for composefs switch-root

### DIFF
--- a/shared/cayo/tree/usr/lib/dracut/dracut.conf.d/30-bootc-standard.conf
+++ b/shared/cayo/tree/usr/lib/dracut/dracut.conf.d/30-bootc-standard.conf
@@ -1,2 +1,2 @@
-# Additional modules for LVM and encryption
-add_dracutmodules+=" lvm crypt "
+# Additional modules for LVM, encryption, and bootc composefs boot
+add_dracutmodules+=" lvm crypt bootc "


### PR DESCRIPTION
Booting a cayo deployment fails at `initrd-switch-root.service` — reproduced today via `bootc switch` from an installed snow system on bare metal.

Cayo's `30-bootc-standard.conf` was copied from snow before c68859a ("Add bootc dracut module for composefs switch-root support") landed, so cayo initramfs images ship without the `bootc` dracut module and can't prepare the composefs root:

- snow: `add_dracutmodules+=" lvm crypt bootc "`
- cayo: `add_dracutmodules+=" lvm crypt "` ← only variant still missing it

Same one-line fix c68859a applied to snow. Fresh cayo installs from the ISO would hit the identical failure, so this blocks cayo testing generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)