### PR TITLE
fix(kernel): drop mesa-va/vdpau-drivers backports pins absorbed by mesa-libgallium

### DIFF
--- a/shared/kernel/backports/mkosi.conf
+++ b/shared/kernel/backports/mkosi.conf
@@ -34,7 +34,9 @@ Packages=linux-image-amd64/trixie-backports
   libgbm1/trixie-backports
   libgl1-mesa-dri/trixie-backports
   libglx-mesa0/trixie-backports
+  # mesa >= 25.2.8-3 folds the VA-API/VDPAU drivers into mesa-libgallium
+  # (Breaks/Replaces: mesa-va-drivers, mesa-vdpau-drivers) and no longer
+  # builds those two packages; pinning them alongside mesa-libgallium from
+  # backports is unsatisfiable since the mesa 26.x backports upload.
   mesa-libgallium/trixie-backports
-  mesa-va-drivers/trixie-backports
-  mesa-vdpau-drivers/trixie-backports
   mesa-vulkan-drivers/trixie-backports

--- a/shared/kernel/surface/mkosi.conf
+++ b/shared/kernel/surface/mkosi.conf
@@ -37,7 +37,9 @@ Packages=linux-image-surface
   libgbm1/trixie-backports
   libgl1-mesa-dri/trixie-backports
   libglx-mesa0/trixie-backports
+  # mesa >= 25.2.8-3 folds the VA-API/VDPAU drivers into mesa-libgallium
+  # (Breaks/Replaces: mesa-va-drivers, mesa-vdpau-drivers) and no longer
+  # builds those two packages; pinning them alongside mesa-libgallium from
+  # backports is unsatisfiable since the mesa 26.x backports upload.
   mesa-libgallium/trixie-backports
-  mesa-va-drivers/trixie-backports
-  mesa-vdpau-drivers/trixie-backports
   mesa-vulkan-drivers/trixie-backports


### PR DESCRIPTION
## Summary

All three profile image builds (snow, cayo, snowfield) currently fail in `build-images.yml` with:

```
E: Unable to satisfy dependencies. Reached two conflicting assignments:
   1. mesa-va-drivers:amd64=25.2.6-1~bpo13+1 is selected for install
   2. mesa-va-drivers ... is not selected for install because:
      mesa-libgallium:amd64=26.1.2-1~bpo13+1 Breaks mesa-va-drivers (< 25.2.8-3)
```

**Root cause (upstream archive skew, unrelated to any repo change):** trixie-backports received mesa 26.1.2-1~bpo13+1. Starting with mesa 25.2.8-3, Debian folded the VA-API and VDPAU drivers *into* `mesa-libgallium` (`Breaks`/`Replaces: mesa-va-drivers, mesa-vdpau-drivers (<< 25.2.8-3)`) and those two binary packages are no longer built. The backports archive still carries the orphaned 25.2.6-1~bpo13+1 binaries, so our explicit pins for both `mesa-libgallium/trixie-backports` *and* `mesa-va-drivers`/`mesa-vdpau-drivers`/`trixie-backports` became mutually unsatisfiable.

**Fix:** drop the two dead pins from `shared/kernel/backports/mkosi.conf` (snow, cayo) and `shared/kernel/surface/mkosi.conf` (snowfield). Nothing is lost — the driver content now ships inside `mesa-libgallium` 26.x, and `intel-media-va-driver-non-free` is untouched. The `stock` kernel config keeps its unpinned entries: trixie stable (mesa 25.0.7-2) still builds both packages consistently, and no profile currently uses stock anyway.

## Verification

- Simulated the remaining backports kernel+mesa package set (`linux-image-amd64` + all six mesa/libgl pins + `intel-media-va-driver-non-free` + firmware) with apt on a clean trixie + trixie-backports container: resolves cleanly, mesa binaries all at 26.1.2-1~bpo13+1.
- Confirmed via the live archive indexes that `mesa-va-drivers`/`mesa-vdpau-drivers` are stranded at 25.2.6 while every other mesa binary is at 26.1.2.
- `check-duplicate-packages.sh` passes; no other references to the dropped packages remain (the unpinned duplicates flagged in fable-audit L9 were already removed).

Unblocks CI for PR #392 and any other branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)