### PR TITLE
feat: add coder sysext

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -60,6 +60,15 @@ jobs:
             echo "codeserver_version=$LATEST_CS" >> $GITHUB_OUTPUT
           fi
 
+          # Check coder
+          CURRENT_CODER=$(jq -r '.coder.version' "$CHECKSUMS")
+          LATEST_CODER=$(gh_api https://api.github.com/repos/coder/coder/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_CODER" && "$LATEST_CODER" != "null" && "$LATEST_CODER" != "$CURRENT_CODER" ]]; then
+            UPDATES="${UPDATES}coder: $CURRENT_CODER -> $LATEST_CODER\n"
+            echo "coder_update=true" >> $GITHUB_OUTPUT
+            echo "coder_version=$LATEST_CODER" >> $GITHUB_OUTPUT
+          fi
+
           # Check Microsoft Azure VPN Client
           CURRENT_AZ=$(jq -r '.["microsoft-azurevpnclient"].version' "$CHECKSUMS")
           LATEST_AZ=$(curl -fsSL --retry 3 --retry-delay 2 https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/ | grep -oP 'microsoft-azurevpnclient_\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
@@ -96,6 +105,8 @@ jobs:
           BITWARDEN_VERSION: ${{ steps.check.outputs.bitwarden_version }}
           CODESERVER_UPDATE: ${{ steps.check.outputs.codeserver_update }}
           CODESERVER_VERSION: ${{ steps.check.outputs.codeserver_version }}
+          CODER_UPDATE: ${{ steps.check.outputs.coder_update }}
+          CODER_VERSION: ${{ steps.check.outputs.coder_version }}
           AZUREVPN_UPDATE: ${{ steps.check.outputs.azurevpn_update }}
           AZUREVPN_VERSION: ${{ steps.check.outputs.azurevpn_version }}
           EDGE_UPDATE: ${{ steps.check.outputs.edge_update }}
@@ -123,6 +134,18 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
               '.["code-server"].url=$u | .["code-server"].sha256=$s | .["code-server"].version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$CODER_UPDATE" == "true" ]]; then
+            VER="$CODER_VERSION"
+            URL="https://github.com/coder/coder/releases/download/v${VER}/coder_${VER}_linux_amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.coder.url=$u | .coder.sha256=$s | .coder.version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 14 sysext overlay images (1password-cli, azurevpn, bitwarden, claude-desktop, code-server, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode).
+**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 15 sysext overlay images (1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 14 sysexts
+just sysexts            # Build base + all 15 sysexts
 just snow               # Build snow desktop image
 just snowfield          # Build snowfield (Surface kernel)
 just cayo               # Build cayo server image

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The project produces:
 | **bitwarden**       | Bitwarden password manager desktop application                  | sysext        |
 | **claude-desktop**  | Claude desktop application                                      | sysext        |
 | **code-server**     | code-server (VS Code in the browser)                            | sysext        |
+| **coder**           | Coder self-hosted development workspaces server                 | sysext        |
 | **debdev**          | Debian development tools (debootstrap, distro-info)             | sysext        |
 | **dev**             | Build essentials, Python, cmake, valgrind, gdb                  | sysext        |
 | **docker**          | Docker CE container runtime                                     | sysext        |
@@ -41,7 +42,7 @@ The project produces:
              sysexts                         profiles
     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
     │    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
-  1pass azurevpn bitwarden claude-desktop code-server debdev dev docker edge incus nix podman tailscale vscode │         │
+  1pass azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge incus nix podman tailscale vscode │         │
                                      snow            cayo
                                       │
                                   snowfield
@@ -66,6 +67,7 @@ Sysexts are overlay images that extend the base system without modifying it. The
 | ----------------- | --------------------------------------------- | ------------------------------------------------------------------------------ |
 | **1password-cli** | 1Password CLI tool                            | [mkosi.images/1password-cli/mkosi.conf](mkosi.images/1password-cli/mkosi.conf) |
 | **code-server**   | code-server (VS Code in the browser)          | [mkosi.images/code-server/mkosi.conf](mkosi.images/code-server/mkosi.conf)     |
+| **coder**         | Coder workspaces server + workspace proxy     | [mkosi.images/coder/mkosi.conf](mkosi.images/coder/mkosi.conf)                 |
 | **debdev**        | debootstrap, distro-info, archive keyrings    | [mkosi.images/debdev/mkosi.conf](mkosi.images/debdev/mkosi.conf)               |
 | **dev**           | build-essential, cmake, Python, valgrind, gdb | [mkosi.images/dev/mkosi.conf](mkosi.images/dev/mkosi.conf)                     |
 | **docker**        | Docker CE, containerd, buildx, compose        | [mkosi.images/docker/mkosi.conf](mkosi.images/docker/mkosi.conf)               |
@@ -270,7 +272,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all sysexts (1password-cli, azurevpn, bitwarden, claude-desktop, code-server, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode)
+1. Builds the base image and all sysexts (1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode)
 2. Publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Uploads package manifests for version tracking
 

--- a/check-profile-dependencies.sh
+++ b/check-profile-dependencies.sh
@@ -8,6 +8,7 @@ sysexts=(
     1password-cli
     claude-desktop
     code-server
+    coder
     debdev
     dev
     docker

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -6,6 +6,7 @@ Dependencies=base
              bitwarden
              claude-desktop
              code-server
+             coder
              debdev
              dev
              docker

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/coder.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/coder.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=Coder self-hosted development workspaces server
+Documentation=https://coder.com/docs
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/coder.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/coder.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=coder
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/coder/
+MatchPattern=coder_@v_%w_%a.raw.zst \
+             coder_@v_%w_%a.raw.xz \
+             coder_@v_%w_%a.raw.gz \
+             coder_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=coder_@v_%w_%a.raw.zst \
+             coder_@v_%w_%a.raw.xz \
+             coder_@v_%w_%a.raw.gz \
+             coder_@v_%w_%a.raw
+CurrentSymlink=coder.raw

--- a/mkosi.images/coder/mkosi.conf
+++ b/mkosi.images/coder/mkosi.conf
@@ -1,0 +1,22 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=coder
+Output=coder
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+
+[Build]
+# Like code-server, coder is not in Packages= — the deb is installed by
+# mkosi.postinst.chroot via verified_download + dpkg -i (GitHub release, no
+# apt repo). The postoutput script still resolves KEYPACKAGE from the merged
+# dpkg database.
+Environment=KEYPACKAGE=coder

--- a/mkosi.images/coder/mkosi.extra/usr/lib/systemd/system-preset/40-coder.preset
+++ b/mkosi.images/coder/mkosi.extra/usr/lib/systemd/system-preset/40-coder.preset
@@ -1,0 +1,4 @@
+enable coder.service
+# The workspace proxy is a separate opt-in role (needs its own env file and
+# a running coder server to register with); admins enable it explicitly.
+disable coder-workspace-proxy.service

--- a/mkosi.images/coder/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-coder.conf
+++ b/mkosi.images/coder/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-coder.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=coder.service

--- a/mkosi.images/coder/mkosi.extra/usr/lib/sysusers.d/coder.conf
+++ b/mkosi.images/coder/mkosi.extra/usr/lib/sysusers.d/coder.conf
@@ -1,0 +1,10 @@
+# sysusers.d configuration for coder
+# The deb's preinst creates this user at build time, but that lands in the
+# buildroot /etc/passwd, which is stripped from the sysext delta — recreate
+# it declaratively at boot. Membership mirrors the preinst (docker) plus
+# incus-admin so coder templates can provision Incus containers/VMs; the
+# groups are implicitly created if the owning sysext is not merged
+# (docker/incus define them via their own sysusers/profile-tree fragments).
+u coder - "Coder workspace provisioner" /home/coder /bin/false
+m coder docker
+m coder incus-admin

--- a/mkosi.images/coder/mkosi.extra/usr/lib/tmpfiles.d/coder.conf
+++ b/mkosi.images/coder/mkosi.extra/usr/lib/tmpfiles.d/coder.conf
@@ -1,0 +1,6 @@
+# Copy coder daemon config from factory defaults (see mkosi.finalize);
+# coder.service is condition-gated on this file being non-empty.
+C /etc/coder.d - - - - -
+# Home for the coder system user (the deb preinst's --create-home is
+# build-time only; /home is persistent /var/home on installed systems)
+d /home/coder 0700 coder coder -

--- a/mkosi.images/coder/mkosi.finalize
+++ b/mkosi.images/coder/mkosi.finalize
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -euo pipefail
+
+# Capture /etc/coder.d to factory defaults for tmpfiles.d to restore at boot.
+# coder.service has EnvironmentFile=/etc/coder.d/coder.env and is gated on
+# ConditionFileNotEmpty=/etc/coder.d/coder.env, so the unit stays inert until
+# an admin fills in the config (CODER_ACCESS_URL etc.).
+mkdir -p "$BUILDROOT/usr/share/factory/etc"
+
+if [ -d "$BUILDROOT/etc/coder.d" ]; then
+    cp --archive --update=none "$BUILDROOT/etc/coder.d" \
+       "$BUILDROOT/usr/share/factory/etc/"
+fi

--- a/mkosi.images/coder/mkosi.postinst.chroot
+++ b/mkosi.images/coder/mkosi.postinst.chroot
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "coder" "$DEBS/coder.deb"
+
+# The deb has no Depends (single static binary); its preinst creates the
+# coder user in the buildroot, which is stripped from the sysext delta —
+# the shipped sysusers.d fragment recreates it at boot.
+dpkg -i "$DEBS/coder.deb"

--- a/mkosi.images/coder/required-paths.txt
+++ b/mkosi.images/coder/required-paths.txt
@@ -1,0 +1,11 @@
+# coder sysext: installed via verified_download + dpkg -i in postinst
+/usr/bin/coder
+/usr/lib/systemd/system/coder.service
+/usr/lib/systemd/system/coder-workspace-proxy.service
+# Factory copy of /etc/coder.d (injected at boot by tmpfiles)
+/usr/share/factory/etc/coder.d/coder.env
+# Boot-time user creation, config injection, and activation
+/usr/lib/sysusers.d/coder.conf
+/usr/lib/tmpfiles.d/coder.conf
+/usr/lib/systemd/system-preset/40-coder.preset
+/usr/lib/systemd/system/multi-user.target.d/10-coder.conf

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -18,5 +18,10 @@
     "url": "https://github.com/coder/code-server/releases/download/v4.127.0/code-server_4.127.0_amd64.deb",
     "sha256": "a1cb96f64d5c68736764726cd3b0c9b6e500bdc30cfefebc05f59259149380e2",
     "version": "4.127.0"
+  },
+  "coder": {
+    "url": "https://github.com/coder/coder/releases/download/v2.35.1/coder_2.35.1_linux_amd64.deb",
+    "sha256": "f14dd6654a801f23e753a3cbff894dfc9ca76281ffd457dbf5fcff67a18b085a",
+    "version": "2.35.1"
   }
 }

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -21,7 +21,7 @@ snosi is a bootable container image build system that uses [mkosi](https://githu
 
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
-1password-cli, azurevpn, bitwarden, claude-desktop, code-server, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode
+1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode
 
 ## Architecture
 
@@ -31,7 +31,7 @@ snosi is a bootable container image build system that uses [mkosi](https://githu
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 14 sysexts)
+mkosi.images/               # Image definitions (base + 15 sysexts)
   base/                     # Foundation image: systemd, bootc/ostree (frostyard debs), firmware, core utils
     mkosi.extra/            # Base filesystem overlay (dracut, systemd units/timers, sysupdate, tmpfiles, sysusers)
       usr/lib/sysupdate.d/  # .transfer + .feature files for all sysexts
@@ -147,8 +147,8 @@ Docker, 1Password) are tracked separately in
 `shared/download/package-versions.json`, checked daily by `check-packages.yml`.
 This file is only a rebuild sentinel; mkosi still resolves packages from APT.
 
-Current sysext checksum-managed downloads are Bitwarden, code-server, Azure
-VPN, and Microsoft Edge. Current image checksum-managed downloads are Homebrew
+Current sysext checksum-managed downloads are Bitwarden, code-server, coder,
+Azure VPN, and Microsoft Edge. Current image checksum-managed downloads are Homebrew
 install script, Surface secure boot certificate, Hotedge, Logomenu, and Bazaar
 Companion. Current APT version tracking covers `code`, `docker-ce`,
 `1password-cli`, and `claude-desktop`; Edge is checksum-managed because the build installs a patched
@@ -199,7 +199,7 @@ Use build-time enablement/presets for desired service state. For run-once runtim
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 14 sysexts
+just sysexts            # Build base + all 15 sysexts
 just snow               # Build snow desktop
 just snowfield          # Build snowfield (Surface)
 just cayo               # Build cayo server

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -22,6 +22,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **bitwarden** | bitwarden | Bitwarden desktop app (pinned .deb via verified_download, relocated from /opt) |
 | **claude-desktop** | claude-desktop | Claude desktop application (from downloads.claude.ai apt repo) |
 | **code-server** | code-server | code-server (VS Code in the browser) — downloaded via `verified_download()` from coder/code-server GitHub releases |
+| **coder** | coder | Coder workspaces server — downloaded via `verified_download()` from coder/coder GitHub releases |
 | **debdev** | debootstrap | Debian development tools (debootstrap, distro-info, arch-test, archive keyrings) |
 | **dev** | build-essential | Build essentials, cmake, Python3, valgrind, gdb, strace |
 | **docker** | docker-ce | Docker CE, containerd, buildx, compose |
@@ -106,7 +107,7 @@ installed" at build time, contributes nothing to the delta, and its paths will
 always fail the check even though they exist at runtime — caught live when
 `wget` in debdev's list failed CI on the first run.
 
-`code-server`, `edge`, `bitwarden`, and `azurevpn` are the current exceptions to the `Packages=` line: it downloads a pinned upstream `.deb` in `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` and installs it with `dpkg -i`. It still sets `KEYPACKAGE=code-server`, and the shared postoutput script resolves that version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file Exec rewrite, deps via `Include=`.
+`code-server`, `coder`, `edge`, `bitwarden`, and `azurevpn` are the current exceptions to the `Packages=` line: it downloads a pinned upstream `.deb` in `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` and installs it with `dpkg -i`. It still sets `KEYPACKAGE=code-server`, and the shared postoutput script resolves that version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file Exec rewrite, deps via `Include=`.
 
 ## Sysext-Specific Extra Files
 
@@ -131,6 +132,14 @@ Some sysexts include extra files via `mkosi.extra/`:
 
 ### code-server
 - `mkosi.postinst.chroot` — Downloads code-server .deb via `verified_download()`, installs with `dpkg -i`. Upstream package targets `/usr/lib/code-server` with `/usr/bin/code-server` symlink and systemd units under `/usr/lib/systemd/`, so no relocation is required.
+
+### coder
+- `mkosi.postinst.chroot` — Downloads the coder .deb (GitHub release, no apt repo) via `verified_download()`, installs with `dpkg -i`. Single static binary + two units, all natively under `/usr`; no relocation
+- `mkosi.finalize` — Captures `/etc/coder.d/` to factory defaults; `coder.service` is gated on `ConditionFileNotEmpty=/etc/coder.d/coder.env`, so the enabled+upheld unit stays inert until an admin fills in `CODER_ACCESS_URL` etc.
+- `usr/lib/sysusers.d/coder.conf` — Recreates the `coder` system user at boot (the deb preinst's `useradd` lands in the buildroot `/etc/passwd`, stripped from the delta) with membership in `docker` (mirrors preinst) and `incus-admin` (Incus-template provisioning); `m` lines implicitly create those groups when the owning sysext isn't merged
+- `usr/lib/tmpfiles.d/coder.conf` — Factory config injection + `/home/coder` creation
+- `usr/lib/systemd/system-preset/40-coder.preset` — Enables `coder.service`, explicitly disables `coder-workspace-proxy.service` (separate opt-in role, needs its own env file)
+- `usr/lib/systemd/system/multi-user.target.d/10-coder.conf` — `Upholds=coder.service` drop-in for reliable boot activation
 
 ### debdev / dev
 - `mkosi.postinst.chroot` — Repoints `/usr/bin`+`/usr/sbin` symlinks that route through `/etc/alternatives` to their resolved targets. Sysexts cannot ship `/etc`, so alternatives symlinks created while installing these sysexts' packages would dangle at runtime (observed live: `/usr/bin/automake -> /etc/alternatives/automake`, missing).


### PR DESCRIPTION
## Summary

Adds a **coder** sysext delivering [Coder](https://coder.com) (self-hosted development workspaces server), from the `coder_2.35.1_linux_amd64.deb` GitHub release asset.

Follows the **code-server pattern** for distribution (fitting — same vendor): no apt repo, so the .deb is pinned in `sysext-checksums.json` (sha256-verified) and installed via `verified_download()` + `dpkg -i`; a release check is added to `check-dependencies.yml` (`coder/coder` latest tag → checksum refresh, same shape as the code-server block).

The deb is sysext-friendly: one static binary (`/usr/bin/coder`) plus `coder.service` and `coder-workspace-proxy.service` natively under `/usr/lib/systemd/system` — no relocation. The sysext-specific plumbing:

- **sysusers.d** — the deb preinst's `useradd coder` runs at build time and lands in the buildroot `/etc/passwd`, which is stripped from the delta; the shipped fragment recreates the user at boot with membership in `docker` (mirrors the preinst) **and `incus-admin`** (so Coder templates can provision Incus containers/VMs). `m` lines implicitly create those groups when the owning sysext isn't merged.
- **Factory /etc** — `/etc/coder.d/` captured to `/usr/share/factory/etc/` (tailscale pattern) and injected by tmpfiles. `coder.service` has `ConditionFileNotEmpty=/etc/coder.d/coder.env`, so the enabled+upheld unit stays **inert until an admin fills in `CODER_ACCESS_URL`** etc. — safe default for an opt-in sysext.
- **Activation** — `40-coder.preset` enables `coder.service`; `multi-user.target.d/10-coder.conf` ships the standard `Upholds=` drop-in for merge-timing. The workspace proxy is preset-disabled (separate opt-in role needing its own env file; it's condition-gated on that file too).
- tmpfiles also creates `/home/coder` (the preinst's `--create-home` is build-time only).

Plus the standard wiring: `required-paths.txt` (8 paths), sysupdate.d `.transfer`/`.feature` (`Enabled=false`), root `Dependencies=`, profile-dependency guard entry, and doc updates (CLAUDE.md, README, yeti/).

## Verification

- Full local rootless mkosi build succeeded; `coder_2.35.1-1_13_x86-64.raw` produced, all 8 required paths present.
- Inspected the erofs: delta is exactly the coder package — binary (0755), both units, sysusers/tmpfiles fragments, factory `coder.env` (content intact), preset, Upholds drop-in, extension-release; root contains only `/usr`.
- `systemd-sysusers --root` dry run against the fragment: creates `coder` with membership in `docker` and `incus-admin` (groups implicitly created); `systemd-tmpfiles --dry-run` parses and would create `/home/coder`.
- shellcheck (CI severity), `check-runtime-etc-guard.sh`, `check-duplicate-packages.sh`, JSON/YAML validation all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)