### PR TITLE
feat: add lemonade sysext (Lemonade local LLM server)

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -80,6 +80,15 @@ jobs:
             echo "coder_version=$LATEST_CODER" >> $GITHUB_OUTPUT
           fi
 
+          # Check Lemonade Server
+          CURRENT_LEM=$(jq -r '.lemonade.version' "$CHECKSUMS")
+          LATEST_LEM=$(gh_api https://api.github.com/repos/lemonade-sdk/lemonade/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_LEM" && "$LATEST_LEM" != "null" ]] && ver_gt "$LATEST_LEM" "$CURRENT_LEM"; then
+            UPDATES="${UPDATES}lemonade: $CURRENT_LEM -> $LATEST_LEM\n"
+            echo "lemonade_update=true" >> $GITHUB_OUTPUT
+            echo "lemonade_version=$LATEST_LEM" >> $GITHUB_OUTPUT
+          fi
+
           # Check Microsoft Azure VPN Client
           CURRENT_AZ=$(jq -r '.["microsoft-azurevpnclient"].version' "$CHECKSUMS")
           LATEST_AZ=$(curl -fsSL --retry 3 --retry-delay 2 https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/ | grep -oP 'microsoft-azurevpnclient_\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
@@ -118,6 +127,8 @@ jobs:
           CODESERVER_VERSION: ${{ steps.check.outputs.codeserver_version }}
           CODER_UPDATE: ${{ steps.check.outputs.coder_update }}
           CODER_VERSION: ${{ steps.check.outputs.coder_version }}
+          LEMONADE_UPDATE: ${{ steps.check.outputs.lemonade_update }}
+          LEMONADE_VERSION: ${{ steps.check.outputs.lemonade_version }}
           AZUREVPN_UPDATE: ${{ steps.check.outputs.azurevpn_update }}
           AZUREVPN_VERSION: ${{ steps.check.outputs.azurevpn_version }}
           EDGE_UPDATE: ${{ steps.check.outputs.edge_update }}
@@ -157,6 +168,18 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
               '.coder.url=$u | .coder.sha256=$s | .coder.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$LEMONADE_UPDATE" == "true" ]]; then
+            VER="$LEMONADE_VERSION"
+            URL="https://github.com/lemonade-sdk/lemonade/releases/download/v${VER}/lemonade-server_${VER}-debian13_amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.lemonade.url=$u | .lemonade.sha256=$s | .lemonade.version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 15 sysext overlay images (1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode).
+**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 16 sysext overlay images (1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, podman, tailscale, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 15 sysexts
+just sysexts            # Build base + all 16 sysexts
 just snow               # Build snow desktop image
 just snowfield          # Build snowfield (Surface kernel)
 just cayo               # Build cayo server image

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The project produces:
 | **docker**          | Docker CE container runtime                                     | sysext        |
 | **edge**            | Microsoft Edge browser                                          | sysext        |
 | **incus**           | Incus container/VM manager                                      | sysext        |
+| **lemonade**        | Lemonade local LLM server (GPU/NPU accelerated)                 | sysext        |
 | **nix**             | Nix package manager                                             | sysext        |
 | **podman**          | Podman + Distrobox                                              | sysext        |
 | **tailscale**       | Tailscale VPN client                                            | sysext        |
@@ -42,7 +43,7 @@ The project produces:
              sysexts                         profiles
     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
     │    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
-  1pass azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge incus nix podman tailscale vscode │         │
+  1pass azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge incus lemonade nix podman tailscale vscode │         │
                                      snow            cayo
                                       │
                                   snowfield
@@ -72,6 +73,7 @@ Sysexts are overlay images that extend the base system without modifying it. The
 | **dev**           | build-essential, cmake, Python, valgrind, gdb | [mkosi.images/dev/mkosi.conf](mkosi.images/dev/mkosi.conf)                     |
 | **docker**        | Docker CE, containerd, buildx, compose        | [mkosi.images/docker/mkosi.conf](mkosi.images/docker/mkosi.conf)               |
 | **incus**         | Incus, QEMU/KVM, OVMF, virt-viewer            | [mkosi.images/incus/mkosi.conf](mkosi.images/incus/mkosi.conf)                 |
+| **lemonade**      | Lemonade local LLM server (lemond)            | [mkosi.images/lemonade/mkosi.conf](mkosi.images/lemonade/mkosi.conf)           |
 | **nix**           | Nix package manager, systemd integration      | [mkosi.images/nix/mkosi.conf](mkosi.images/nix/mkosi.conf)                     |
 | **podman**        | Podman, Distrobox, buildah, crun              | [mkosi.images/podman/mkosi.conf](mkosi.images/podman/mkosi.conf)               |
 | **tailscale**     | Tailscale VPN client                          | [mkosi.images/tailscale/mkosi.conf](mkosi.images/tailscale/mkosi.conf)         |
@@ -272,7 +274,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all sysexts (1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode)
+1. Builds the base image and all sysexts (1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, podman, tailscale, vscode)
 2. Publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Uploads package manifests for version tracking
 

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -12,6 +12,7 @@ Dependencies=base
              docker
              edge
              incus
+             lemonade
              nix
              podman
              tailscale

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/lemonade.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/lemonade.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=Lemonade local LLM server with GPU/NPU acceleration
+Documentation=https://lemonade-server.ai/docs/
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/lemonade.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/lemonade.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=lemonade
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/lemonade/
+MatchPattern=lemonade_@v_%w_%a.raw.zst \
+             lemonade_@v_%w_%a.raw.xz \
+             lemonade_@v_%w_%a.raw.gz \
+             lemonade_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=lemonade_@v_%w_%a.raw.zst \
+             lemonade_@v_%w_%a.raw.xz \
+             lemonade_@v_%w_%a.raw.gz \
+             lemonade_@v_%w_%a.raw
+CurrentSymlink=lemonade.raw

--- a/mkosi.images/lemonade/mkosi.conf
+++ b/mkosi.images/lemonade/mkosi.conf
@@ -1,0 +1,33 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=lemonade
+Output=lemonade
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+
+# Runtime Depends of the lemonade-server deb that the postinst's dpkg -i
+# cannot resolve itself (the sysext chroot has no apt). libcpp-httplib0.41
+# exists only in trixie-backports — enabled in the sandbox with a low pin,
+# which still wins as the sole candidate.
+Packages=libcpp-httplib0.41
+         libmbedcrypto16
+         libwebsockets19t64
+         fonts-katex
+         libatomic1
+         unzip
+
+[Build]
+# Like coder, lemonade-server is not in Packages= — the deb is installed by
+# mkosi.postinst.chroot via verified_download + dpkg -i (GitHub release, no
+# apt repo). The postoutput script still resolves KEYPACKAGE from the merged
+# dpkg database.
+Environment=KEYPACKAGE=lemonade-server

--- a/mkosi.images/lemonade/mkosi.extra/usr/lib/systemd/system-preset/40-lemonade.preset
+++ b/mkosi.images/lemonade/mkosi.extra/usr/lib/systemd/system-preset/40-lemonade.preset
@@ -1,0 +1,1 @@
+enable lemond.service

--- a/mkosi.images/lemonade/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-lemonade.conf
+++ b/mkosi.images/lemonade/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-lemonade.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=lemond.service

--- a/mkosi.images/lemonade/mkosi.extra/usr/lib/systemd/user-preset/40-lemonade.preset
+++ b/mkosi.images/lemonade/mkosi.extra/usr/lib/systemd/user-preset/40-lemonade.preset
@@ -1,0 +1,4 @@
+# The deb also ships a legacy per-user lemond.service (superseded by the
+# system service in 10.10.0); keep it off so a user-scope preset pass never
+# starts a second instance alongside the system one.
+disable lemond.service

--- a/mkosi.images/lemonade/mkosi.extra/usr/lib/sysusers.d/lemonade-groups.conf
+++ b/mkosi.images/lemonade/mkosi.extra/usr/lib/sysusers.d/lemonade-groups.conf
@@ -1,0 +1,7 @@
+# The deb's own sysusers.d/lemonade.conf (shipped in /usr) creates the
+# lemonade user at boot; its postinst additionally adds it to
+# systemd-journal (journal access) and render (GPU access) with usermod,
+# which only reaches the buildroot /etc and is stripped from the delta —
+# mirror the memberships declaratively.
+m lemonade systemd-journal
+m lemonade render

--- a/mkosi.images/lemonade/mkosi.extra/usr/lib/tmpfiles.d/lemonade.conf
+++ b/mkosi.images/lemonade/mkosi.extra/usr/lib/tmpfiles.d/lemonade.conf
@@ -1,0 +1,4 @@
+# Copy lemonade config from factory defaults (see mkosi.finalize);
+# lemond.service reads EnvironmentFile drop-ins from /etc/lemonade/conf.d
+# (HF_TOKEN, LEMONADE_API_KEY, …).
+C /etc/lemonade - - - - -

--- a/mkosi.images/lemonade/mkosi.finalize
+++ b/mkosi.images/lemonade/mkosi.finalize
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -euo pipefail
+
+# Capture /etc/lemonade to factory defaults for tmpfiles.d to restore at
+# boot. lemond.service reads EnvironmentFile=-/etc/lemonade/conf.d/*.conf
+# (HF_TOKEN, LEMONADE_API_KEY, …); the deb ships only the commented
+# zz-secrets.conf template, so the factory copy carries no real secrets.
+mkdir -p "$BUILDROOT/usr/share/factory/etc"
+
+if [ -d "$BUILDROOT/etc/lemonade" ]; then
+    cp --archive --update=none "$BUILDROOT/etc/lemonade" \
+       "$BUILDROOT/usr/share/factory/etc/"
+fi

--- a/mkosi.images/lemonade/mkosi.postinst.chroot
+++ b/mkosi.images/lemonade/mkosi.postinst.chroot
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "lemonade" "$DEBS/lemonade-server.deb"
+
+# Depends are preinstalled via Packages= (no apt in this chroot). The deb's
+# postinst creates the lemonade user and its group memberships in the
+# buildroot /etc, which is stripped from the sysext delta — the deb's own
+# sysusers.d fragment plus mkosi.extra's lemonade-groups.conf recreate them
+# at boot.
+dpkg -i "$DEBS/lemonade-server.deb"

--- a/mkosi.images/lemonade/required-paths.txt
+++ b/mkosi.images/lemonade/required-paths.txt
@@ -1,0 +1,14 @@
+# lemonade sysext: installed via verified_download + dpkg -i in postinst
+/usr/bin/lemonade
+/usr/bin/lemond
+/usr/lib/systemd/system/lemond.service
+/usr/lib/sysusers.d/lemonade.conf
+# Sole backports dependency, pulled via Packages= (not present in base)
+/usr/lib/x86_64-linux-gnu/libcpp-httplib.so.0.41
+# Factory copy of /etc/lemonade (injected at boot by tmpfiles)
+/usr/share/factory/etc/lemonade/conf.d/zz-secrets.conf
+# Boot-time group memberships, config injection, and activation
+/usr/lib/sysusers.d/lemonade-groups.conf
+/usr/lib/tmpfiles.d/lemonade.conf
+/usr/lib/systemd/system-preset/40-lemonade.preset
+/usr/lib/systemd/system/multi-user.target.d/10-lemonade.conf

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -23,5 +23,10 @@
     "url": "https://github.com/coder/coder/releases/download/v2.34.5/coder_2.34.5_linux_amd64.deb",
     "sha256": "15aea185f3491e8e922902d5585d95a3214ab7eb92557a62dc5e67f850097c7b",
     "version": "2.34.5"
+  },
+  "lemonade": {
+    "url": "https://github.com/lemonade-sdk/lemonade/releases/download/v10.10.0/lemonade-server_10.10.0-debian13_amd64.deb",
+    "sha256": "2680fb4c920855f766d52c764b40e621058209dd06fc65b7cb3875187f55986b",
+    "version": "10.10.0"
   }
 }

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -21,7 +21,7 @@ snosi is a bootable container image build system that uses [mkosi](https://githu
 
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
-1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, nix, podman, tailscale, vscode
+1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, podman, tailscale, vscode
 
 ## Architecture
 
@@ -31,7 +31,7 @@ snosi is a bootable container image build system that uses [mkosi](https://githu
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 15 sysexts)
+mkosi.images/               # Image definitions (base + 16 sysexts)
   base/                     # Foundation image: systemd, bootc/ostree (frostyard debs), firmware, core utils
     mkosi.extra/            # Base filesystem overlay (dracut, systemd units/timers, sysupdate, tmpfiles, sysusers)
       usr/lib/sysupdate.d/  # .transfer + .feature files for all sysexts
@@ -199,7 +199,7 @@ Use build-time enablement/presets for desired service state. For run-once runtim
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 15 sysexts
+just sysexts            # Build base + all 16 sysexts
 just snow               # Build snow desktop
 just snowfield          # Build snowfield (Surface)
 just cayo               # Build cayo server

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -28,6 +28,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **docker** | docker-ce | Docker CE, containerd, buildx, compose |
 | **edge** | microsoft-edge-stable | Microsoft Edge browser (pinned .deb via verified_download, relocated from /opt) |
 | **incus** | incus | Incus container/VM manager, QEMU/KVM, dnsmasq, OVMF, virt-viewer |
+| **lemonade** | lemonade-server | Lemonade local LLM server (lemond) — downloaded via `verified_download()` from lemonade-sdk/lemonade GitHub releases; libcpp-httplib0.41 dep from trixie-backports |
 | **nix** | nix-setup-systemd | Nix package manager with systemd integration |
 | **podman** | podman | Podman, distrobox, buildah, crun, slirp4netns |
 | **tailscale** | tailscale | Tailscale VPN client |
@@ -165,6 +166,16 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `usr/lib/incus/incus-sysext-setup` — The setup script the service runs
 - `usr/lib/sysusers.d/{dnsmasq,rdma}.conf` — User/group definitions
 - `usr/lib/tmpfiles.d/incus.conf` — Factory config injection + runtime dirs + xz alternatives links
+
+### lemonade
+- `mkosi.postinst.chroot` — Downloads the lemonade-server .deb (GitHub release, no apt repo) via `verified_download()`, installs with `dpkg -i`. Everything ships natively under `/usr`; no relocation
+- `Packages=` carries the deb's runtime Depends (`dpkg -i` can't resolve them; the chroot has no apt), including `libcpp-httplib0.41` which exists only in trixie-backports — the sandbox's low backports pin still selects it as the sole candidate
+- `mkosi.finalize` — Captures `/etc/lemonade/` to factory defaults; `lemond.service` reads `EnvironmentFile=-/etc/lemonade/conf.d/*.conf` (HF_TOKEN, LEMONADE_API_KEY — the deb ships only a commented template, no real secrets)
+- `usr/lib/sysusers.d/lemonade-groups.conf` — Adds the `lemonade` user (created at boot by the deb's own sysusers fragment) to `systemd-journal` and `render` (GPU access), mirroring the deb postinst's build-time-only `usermod` calls
+- `usr/lib/tmpfiles.d/lemonade.conf` — Factory config injection
+- `usr/lib/systemd/system-preset/40-lemonade.preset` — Enables `lemond.service` (web UI on port 13305)
+- `usr/lib/systemd/user-preset/40-lemonade.preset` — Disables the legacy per-user `lemond.service` the deb still ships (superseded by the system service)
+- `usr/lib/systemd/system/multi-user.target.d/10-lemonade.conf` — `Upholds=lemond.service` drop-in for reliable boot activation
 
 ### nix
 - `mkosi.finalize` — Captures `/etc/nix` to factory defaults


### PR DESCRIPTION
## Summary

Adds a **lemonade** sysext providing [Lemonade Server](https://lemonade-server.ai/) (local LLM serving with GPU/NPU acceleration), following the coder pattern: the `lemonade-server` deb is a GitHub-release download (no apt repo), installed via `verified_download()` + `dpkg -i` in `mkosi.postinst.chroot`.

- **Backports dependency:** the deb Depends on `libcpp-httplib0.41`, which exists only in trixie-backports (already enabled in the sandbox; its low pin still wins as the sole candidate). All runtime Depends are preinstalled via `Packages=` since the sysext chroot has no apt.
- **Config:** `/etc/lemonade/` (EnvironmentFile drop-ins for `HF_TOKEN`/`LEMONADE_API_KEY`; the deb ships only a commented template) is captured to factory defaults and injected at boot by tmpfiles.
- **User/groups:** the deb's own sysusers fragment creates the `lemonade` user at boot; a sysext fragment adds it to `systemd-journal` and `render` (GPU), mirroring the postinst's build-time-only `usermod` calls.
- **Activation:** preset enables `lemond.service`, `multi-user.target.d` `Upholds=` drop-in handles post-merge timing; a user-preset keeps the legacy per-user `lemond.service` off.
- **Plumbing:** root `Dependencies=`, sysupdate.d `.transfer`/`.feature` (`Enabled=false`), `required-paths.txt`, pinned checksum entry, weekly `check-dependencies.yml` tracking of lemonade-sdk/lemonade releases (downgrade-guarded), docs (CLAUDE.md, README, yeti/).

## Validation

Built rootless (`mkosi build`), then merged the resulting `lemonade_10.10.0~13_13_x86-64.raw` on **selfie (10.0.1.72, cayo)**:

- `systemd-sysext refresh` merged cleanly alongside coder/docker/incus/tailscale
- `systemd-sysusers` created the `lemonade` user with `systemd-journal` + `render` memberships
- tmpfiles injected `/etc/lemonade/conf.d/zz-secrets.conf` from factory
- after `daemon-reload`, `lemond.service` auto-started via the `Upholds=` drop-in
- web UI answers HTTP 200 on `:13305`; `/api/v1/health` returns `status: ok`, version 10.10.0
- `ldd /usr/bin/lemond` resolves `libcpp-httplib.so.0.41` from the sysext

🤖 Generated with [Claude Code](https://claude.com/claude-code)