### PR TITLE
fix: track claude-desktop launcher rename to com.anthropic.Claude.desktop

### DIFF
--- a/mkosi.images/claude-desktop/required-paths.txt
+++ b/mkosi.images/claude-desktop/required-paths.txt
@@ -3,6 +3,8 @@
 /usr/lib/claude-desktop/chrome-sandbox
 /usr/bin/claude-desktop
 # Desktop integration: launcher entry and hicolor icons (see yeti/sysexts.md
-# "Desktop Applications in Sysexts")
-/usr/share/applications/claude-desktop.desktop
+# "Desktop Applications in Sysexts"). Upstream renamed the launcher to its
+# reverse-DNS app id in 1.20186.1 (was claude-desktop.desktop); Icon= still
+# references the claude-desktop hicolor icons.
+/usr/share/applications/com.anthropic.Claude.desktop
 /usr/share/icons/hicolor/256x256/apps/claude-desktop.png


### PR DESCRIPTION
## Summary
- Fixes the `build.yml` failure on main ([run 29251391637](https://github.com/frostyard/snosi/actions/runs/29251391637)): the claude-desktop sysext's required-paths finalize check refused the build because `/usr/share/applications/claude-desktop.desktop` no longer exists.
- Root cause: claude-desktop **1.20186.1** (published to Anthropic's APT repo 2026-07-10, after the last successful build) renamed its launcher to the reverse-DNS app id `com.anthropic.Claude.desktop`. The triggering commit (#400, code-server checksums) was unrelated — it was just the first build since the upstream release.
- Fix: update `mkosi.images/claude-desktop/required-paths.txt` to the new filename. Everything else in the new deb is unchanged (binaries, SUID `chrome-sandbox`, `/usr/bin` symlink, hicolor icons), and the renamed entry still uses `Icon=claude-desktop`, so the icon paths in the check remain valid. No `SYSEXT_REVISION` bump needed — the package version itself bumped, so the sysext publishes as 1.20186.1 naturally.

## Verification
- Full local rootless mkosi build (CI-pinned mkosi commit) exited 0; log shows `sysext-required-paths: all 5 required paths present in claude-desktop` and produced `claude-desktop_1.20186.1_13_x86-64.raw`.
- Repo-wide grep: nothing else references the old `claude-desktop.desktop` name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)