### PR TITLE
ci: create .snosi-private/history before native builds

### DIFF
--- a/.github/workflows/build-native-images.yml
+++ b/.github/workflows/build-native-images.yml
@@ -175,7 +175,10 @@ jobs:
           [[ -n "$NATIVE_PCR_SIGNING_KEY" ]] || { echo "::error::secrets.NATIVE_PCR_SIGNING_KEY is not set in the native-build environment" >&2; exit 1; }
           [[ -n "$NATIVE_PCR_SIGNING_CERTIFICATE" ]] || { echo "::error::secrets.NATIVE_PCR_SIGNING_CERTIFICATE is not set in the native-build environment" >&2; exit 1; }
           umask 077
-          mkdir -p .snosi-private
+          # .snosi-private/history is a SandboxTrees= source in shared/native-ab-secure/mkosi.conf
+          # (PCR-key rotation history); mkosi refuses to build if it does not exist. It is
+          # legitimately empty when no rotation is in progress.
+          mkdir -p .snosi-private/history
           printf '%s' "$NATIVE_SECURE_BOOT_KEY" > mkosi.key
           printf '%s' "$NATIVE_SECURE_BOOT_CERTIFICATE" > mkosi.crt
           printf '%s' "$NATIVE_PCR_SIGNING_KEY" > .snosi-private/pcr-signing.key
@@ -301,7 +304,10 @@ jobs:
           [[ -n "$NATIVE_PCR_SIGNING_KEY" ]] || { echo "::error::secrets.NATIVE_PCR_SIGNING_KEY is not set in the native-build environment" >&2; exit 1; }
           [[ -n "$NATIVE_PCR_SIGNING_CERTIFICATE" ]] || { echo "::error::secrets.NATIVE_PCR_SIGNING_CERTIFICATE is not set in the native-build environment" >&2; exit 1; }
           umask 077
-          mkdir -p .snosi-private
+          # .snosi-private/history is a SandboxTrees= source in shared/native-ab-secure/mkosi.conf
+          # (PCR-key rotation history); mkosi refuses to build if it does not exist. It is
+          # legitimately empty when no rotation is in progress.
+          mkdir -p .snosi-private/history
           printf '%s' "$NATIVE_SECURE_BOOT_KEY" > mkosi.key
           printf '%s' "$NATIVE_SECURE_BOOT_CERTIFICATE" > mkosi.crt
           printf '%s' "$NATIVE_PCR_SIGNING_KEY" > .snosi-private/pcr-signing.key
@@ -415,7 +421,10 @@ jobs:
           [[ -n "$NATIVE_PCR_SIGNING_KEY" ]] || { echo "::error::secrets.NATIVE_PCR_SIGNING_KEY is not set in the native-build environment" >&2; exit 1; }
           [[ -n "$NATIVE_PCR_SIGNING_CERTIFICATE" ]] || { echo "::error::secrets.NATIVE_PCR_SIGNING_CERTIFICATE is not set in the native-build environment" >&2; exit 1; }
           umask 077
-          mkdir -p .snosi-private
+          # .snosi-private/history is a SandboxTrees= source in shared/native-ab-secure/mkosi.conf
+          # (PCR-key rotation history); mkosi refuses to build if it does not exist. It is
+          # legitimately empty when no rotation is in progress.
+          mkdir -p .snosi-private/history
           printf '%s' "$NATIVE_SECURE_BOOT_KEY" > mkosi.key
           printf '%s' "$NATIVE_SECURE_BOOT_CERTIFICATE" > mkosi.crt
           printf '%s' "$NATIVE_PCR_SIGNING_KEY" > .snosi-private/pcr-signing.key


### PR DESCRIPTION
First dispatched `build-native-images.yml` run ([29526888750](https://github.com/frostyard/snosi/actions/runs/29526888750)) failed in all three build jobs with:

```
‣ /home/runner/work/snosi/snosi/.snosi-private/history does not exist
```

**Root cause:** `shared/native-ab-secure/mkosi.conf:17` mounts the PCR-key rotation history into the build sandbox (`SandboxTrees=%D/.snosi-private/history:/usr/lib/snosi-pcr-history`), and mkosi refuses to build when a `SandboxTrees=` source is missing. Every local build has had the directory since the rotation work; the CI runner writes only `pcr-signing.{key,crt}` and never created it.

**Fix:** `mkdir -p .snosi-private/history` (legitimately empty when no rotation is in progress) at all three secret-writing sites. actionlint-clean.

**Note for the stuck run:** its promote jobs are safely no-op (no `native-verified-*` marker artifacts exist), but they hold the `build-native-images` concurrency group — reject/cancel them before re-dispatching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)