### PR TITLE
ci: prepare native build host like the systemd/mkosi action

### DIFF
--- a/.github/workflows/build-native-images.yml
+++ b/.github/workflows/build-native-images.yml
@@ -159,6 +159,22 @@ jobs:
       - name: Assert mkosi pin matches build.yml
         run: ./shared/native-ab/ci/check-mkosi-pin.sh .mkosi
 
+      - name: Prepare mkosi build host
+        # Mirrors the host setup the systemd/mkosi action gives build.yml /
+        # build-images.yml for free (minus KVM device setup -- these jobs
+        # never boot VMs): the Debian archive keyring mkosi needs to verify
+        # deb.debian.org, unprivileged user namespaces, removal of the
+        # runner's broken apparmor profiles (apparmor/apparmor#402), and the
+        # ca-certificates mountpoint.
+        run: |
+          sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_unconfined=0
+          sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
+          sudo aa-teardown || true
+          sudo apt-get remove -y apparmor || true
+          sudo mkdir -p /var/lib/ca-certificates
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends debian-archive-keyring
+
       - name: Write Secure Boot/MOK and PCR signing key material
         # docs/native-ab-publication.md "Interim protected-builder
         # constraints": ephemeral, file-based, never echoed, removed
@@ -291,6 +307,22 @@ jobs:
       - name: Assert mkosi pin matches build.yml
         run: ./shared/native-ab/ci/check-mkosi-pin.sh .mkosi
 
+      - name: Prepare mkosi build host
+        # Mirrors the host setup the systemd/mkosi action gives build.yml /
+        # build-images.yml for free (minus KVM device setup -- these jobs
+        # never boot VMs): the Debian archive keyring mkosi needs to verify
+        # deb.debian.org, unprivileged user namespaces, removal of the
+        # runner's broken apparmor profiles (apparmor/apparmor#402), and the
+        # ca-certificates mountpoint.
+        run: |
+          sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_unconfined=0
+          sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
+          sudo aa-teardown || true
+          sudo apt-get remove -y apparmor || true
+          sudo mkdir -p /var/lib/ca-certificates
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends debian-archive-keyring
+
       - name: Write Secure Boot/MOK and PCR signing key material
         env:
           NATIVE_SECURE_BOOT_KEY: ${{ secrets.NATIVE_SECURE_BOOT_KEY }}
@@ -407,6 +439,22 @@ jobs:
 
       - name: Assert mkosi pin matches build.yml
         run: ./shared/native-ab/ci/check-mkosi-pin.sh .mkosi
+
+      - name: Prepare mkosi build host
+        # Mirrors the host setup the systemd/mkosi action gives build.yml /
+        # build-images.yml for free (minus KVM device setup -- these jobs
+        # never boot VMs): the Debian archive keyring mkosi needs to verify
+        # deb.debian.org, unprivileged user namespaces, removal of the
+        # runner's broken apparmor profiles (apparmor/apparmor#402), and the
+        # ca-certificates mountpoint.
+        run: |
+          sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_unconfined=0
+          sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
+          sudo aa-teardown || true
+          sudo apt-get remove -y apparmor || true
+          sudo mkdir -p /var/lib/ca-certificates
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends debian-archive-keyring
 
       - name: Write Secure Boot/MOK and PCR signing key material
         env:


### PR DESCRIPTION
Second gap surfaced by dispatched run [29527340630](https://github.com/frostyard/snosi/actions/runs/29527340630): all builds failed with

```
‣ Keyring for repo http://deb.debian.org/debian not found at /usr/share/keyrings/debian-archive-keyring.gpg
```

**Root cause:** Ubuntu runners don't ship `debian-archive-keyring`. The bootc workflows get it (plus userns sysctls, apparmor teardown, `/var/lib/ca-certificates`) from the `systemd/mkosi` action's setup steps; the native workflow bootstraps mkosi from the repo-local `.mkosi` checkout and skipped all host prep.

**Fix:** a `Prepare mkosi build host` step in all three build jobs mirroring the pinned action's setup (read from `.mkosi/action.yaml` at the exact pinned commit), minus its KVM device setup — these jobs never boot VMs. Mirroring the whole set rather than just the keyring avoids discovering the userns/apparmor gaps one CI cycle at a time. actionlint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)