### PR TITLE
ci: install post-build validation tools on the native build host

### DIFF
--- a/.github/workflows/build-native-images.yml
+++ b/.github/workflows/build-native-images.yml
@@ -173,7 +173,8 @@ jobs:
           sudo apt-get remove -y apparmor || true
           sudo mkdir -p /var/lib/ca-certificates
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends debian-archive-keyring
+          sudo apt-get install -y --no-install-recommends debian-archive-keyring \
+            dracut-core binutils file python3-cryptography
 
       - name: Write Secure Boot/MOK and PCR signing key material
         # docs/native-ab-publication.md "Interim protected-builder
@@ -321,7 +322,8 @@ jobs:
           sudo apt-get remove -y apparmor || true
           sudo mkdir -p /var/lib/ca-certificates
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends debian-archive-keyring
+          sudo apt-get install -y --no-install-recommends debian-archive-keyring \
+            dracut-core binutils file python3-cryptography
 
       - name: Write Secure Boot/MOK and PCR signing key material
         env:
@@ -454,7 +456,8 @@ jobs:
           sudo apt-get remove -y apparmor || true
           sudo mkdir -p /var/lib/ca-certificates
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends debian-archive-keyring
+          sudo apt-get install -y --no-install-recommends debian-archive-keyring \
+            dracut-core binutils file python3-cryptography
 
       - name: Write Secure Boot/MOK and PCR signing key material
         env:


### PR DESCRIPTION
Attempt 3 ([29527775829](https://github.com/frostyard/snosi/actions/runs/29527775829)) got further than ever: **the mkosi builds succeeded on the runner** — snow-ab failed only at the post-build secure artifact test with `lsinitrd is required`.

Rather than fix one tool per dispatch, this audits every `command -v` gate in the post-build chain (artifact test, snowfield artifact test, prepare-native-publication, generate-sbom, publish-candidate, verify-remote) and installs the full missing set in the existing host-prep step: `dracut-core` (lsinitrd — the actual failure), plus `binutils`/`file`/`python3-cryptography` as explicit insurance for tools the tests need but the runner only incidentally provides. actionlint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)