### PR TITLE
fix: build-iso.sh appends sbin dirs to PATH for mkfs.vfat

### DIFF
--- a/shared/native-installer/tools/build-iso.sh
+++ b/shared/native-installer/tools/build-iso.sh
@@ -70,6 +70,12 @@ VERSION=${3:-$(date -u +%Y%m%d%H%M%S)}
 [[ -d "$ROOTFS" ]] || { echo "Error: rootfs directory does not exist: $ROOTFS" >&2; exit 1; }
 [[ "$VERSION" =~ ^[0-9]{14}$ ]] || { echo "Error: version must be exactly 14 digits: $VERSION" >&2; exit 1; }
 
+# mkfs.vfat lives in /usr/sbin, which Debian's default USER PATH omits; the
+# Justfile recipe runs this under `sudo PATH="$PATH"` (preserving the caller's
+# PATH for user-local tools), so sbin must be appended here rather than relied
+# on from sudo's secure_path.
+PATH="$PATH:/usr/sbin:/sbin"
+
 for cmd in xorriso mcopy mmd mkfs.vfat cpio zstd find; do
     command -v "$cmd" >/dev/null || { echo "Error: required tool not found: $cmd" >&2; exit 1; }
 done


### PR DESCRIPTION
`just native-installer-iso` fails with `required tool not found: mkfs.vfat` on a default Debian user PATH: the recipe runs `sudo PATH="$PATH" ...` (keeping user-local tools visible), which also inherits the user PATH's missing `/usr/sbin`. The e2e harness never hit it — it invokes the script under plain `sudo`, where `secure_path` provides `/usr/sbin`.

Fix: the script appends `/usr/sbin:/sbin` to PATH before its tool check (appended, not prepended, so user-local overrides keep precedence). shellcheck-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)