### PR TITLE
fix: verify-remote works from metadata alone (CI cross-job verification)

### DIFF
--- a/shared/native-ab/publish/verify-remote.sh
+++ b/shared/native-ab/publish/verify-remote.sh
@@ -25,7 +25,15 @@
 #
 #   prepared-dir  same prepare-native-publication.sh output dir passed to
 #                 publish-candidate.sh (source of expected names/sizes/
-#                 hashes and of product/version).
+#                 hashes and of product/version). The full blobs are OPTIONAL:
+#                 when an object listed in SHA256SUMS is not present locally
+#                 (the CI cross-job verifier ships only publication-info.json
+#                 + SHA256SUMS between jobs -- multi-GiB blobs never travel
+#                 as artifacts), the object is downloaded once from the
+#                 public URL, verified against SHA256SUMS, and that
+#                 downloaded copy becomes the byte-level reference for the
+#                 size and range checks. Every check stays fail-closed; only
+#                 the source of the reference bytes changes.
 #   base-url      HTTP(S) URL of the product's "os/native/v1/<product>/
 #                 x86-64" directory (e.g. the local rehearsal origin, or
 #                 https://repository.frostyard.org/os/native/v1/cayo/x86-64
@@ -65,29 +73,54 @@ check_object() { # name
     local_file="$PREPARED_DIR/$name"
     url="$candidate_url/$name"
     expected_sha256="$(candidate_object_sha256 "$PREPARED_DIR" "$name")"
-    expected_size="$(stat -c %s "$local_file")"
 
     echo "  $name"
 
-    # 1. size
+    # 1. size (HEAD). With a local blob the reference size is the pre-upload
+    # file; without one it is the downloaded reference copy's size, checked
+    # after the full GET below (HEAD-vs-body consistency).
     actual_size="$(http_size "$url")" || {
         echo "    FAIL: could not fetch size (HEAD) from $url" >&2
         fail_count=$((fail_count + 1))
         return
     }
-    if [[ "$actual_size" != "$expected_size" ]]; then
-        echo "    FAIL: size mismatch: expected $expected_size, got $actual_size" >&2
-        fail_count=$((fail_count + 1))
-        return
-    fi
-    echo "    ok: size $actual_size"
 
-    # 2. full GET + sha256
-    actual_sha256="$(http_get_sha256 "$url")" || {
-        echo "    FAIL: full GET failed from $url" >&2
-        fail_count=$((fail_count + 1))
-        return
-    }
+    if [[ -f "$local_file" ]]; then
+        expected_size="$(stat -c %s "$local_file")"
+        if [[ "$actual_size" != "$expected_size" ]]; then
+            echo "    FAIL: size mismatch: expected $expected_size, got $actual_size" >&2
+            fail_count=$((fail_count + 1))
+            return
+        fi
+        echo "    ok: size $actual_size"
+
+        # 2. full GET + sha256
+        actual_sha256="$(http_get_sha256 "$url")" || {
+            echo "    FAIL: full GET failed from $url" >&2
+            fail_count=$((fail_count + 1))
+            return
+        }
+    else
+        # Metadata-only mode: download the object once; it becomes both the
+        # subject of check 2 and the byte-level reference for check 3.
+        local_file="$(mktemp /var/tmp/verify-remote-ref.XXXXXX)"
+        register_cleanup "rm -f '$local_file'"
+        echo "    (no local blob -- downloading reference copy)"
+        http_get_to_file "$url" "$local_file" || {
+            echo "    FAIL: full GET failed from $url" >&2
+            fail_count=$((fail_count + 1))
+            return
+        }
+        expected_size="$(stat -c %s "$local_file")"
+        if [[ "$actual_size" != "$expected_size" ]]; then
+            echo "    FAIL: HEAD Content-Length $actual_size != downloaded body size $expected_size" >&2
+            fail_count=$((fail_count + 1))
+            return
+        fi
+        echo "    ok: size $actual_size"
+        actual_sha256="$(sha256sum "$local_file" | cut -d' ' -f1)"
+    fi
+
     if [[ "$actual_sha256" != "$expected_sha256" ]]; then
         echo "    FAIL: sha256 mismatch: expected $expected_sha256, got $actual_sha256" >&2
         fail_count=$((fail_count + 1))


### PR DESCRIPTION
Attempt 5 ([29530766658](https://github.com/frostyard/snosi/actions/runs/29530766658)) reached R2 for real — all three builds + candidate uploads succeeded — then every `test-public-origin` leg failed at:

```
stat: cannot statx '/var/tmp/native-publish/cayo/x86-64/cayo-ab_..._root.raw.xz': No such file or directory
```

**Root cause:** the cross-job verifier only carries `publication-info.json` + `SHA256SUMS` between jobs (deliberately — blobs are multi-GiB), but `verify-remote.sh` reads its size reference and both range-GET references from the local pre-upload blobs. It could never have worked in that job; local rehearsals always had the blobs on disk.

**Fix:** when a `SHA256SUMS`-listed object is absent locally, download it once from the public URL, verify it against `SHA256SUMS`, and use the downloaded copy as the byte-level reference for the size (HEAD-vs-body consistency) and range checks. Local-blob mode is byte-identical to before. Every check stays fail-closed.

**Validated locally** against `range-http-server.py`: metadata-only → pass; local-blob → pass (regression); tampered remote in metadata-only → sha256 mismatch, RC=1. Full synthetic pipeline test: 39/39.

Promotes on the current run are safely skippable (no verified markers were produced) — reject them, merge this, re-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)