### PR TITLE
feat: installer-owned system settings + deferred first-boot provisioning

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -87,6 +87,13 @@ jobs:
         # 8.3), intentionally out of scope for this fast per-PR check.
         run: ./test/snosi-install-test.sh
 
+      - name: Validate snosi-firstboot provisioning script
+        # Fixture test with PATH-stubbed updex/flatpak: feature enablement
+        # fan-out, flathub remote + deduplicated core set, retry semantics
+        # (any failure -> exit 1, no done marker -> the unit retries next
+        # boot), and the no-op paths. No root, no network, no image build.
+        run: ./test/snosi-firstboot-test.sh
+
       - name: Validate snosi-etc-diff drift tooling
         # Static, non-root regression test driving the real script against
         # fixture trees via its SNOSI_ETC_DIFF_LIVE_ETC/PRISTINE_ETC test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -872,7 +872,35 @@ group — warns loudly if the image lacks it) plus the standard desktop set
 if the image defines it), and creates the skel-seeded home at var `home/`
 (image `/home` → `/var/home`). The wholesale passwd copy-up is the overlay
 steady state anyway — systemd-sysusers rewrites `/etc/passwd` on first boot,
-which copies it up regardless. `shared/native-ab/keys/mok-2026.crt`
+which copies it up regardless. **System settings + deferred first-boot
+provisioning** (Phase 1 of the first-boot design, 2026-07-16; the GTK
+installer frontend is the planned Phase 2): `--hostname`/`--locale`/
+`--timezone`/`--keyboard` (interactive prompts with defaults; `-` skips a
+setting) are plain `/etc`-overlay-upper writes at seed time (`hostname`,
+`locale.conf` `LANG=`, `timezone`+`localtime` symlink, `vconsole.conf` XKB
+triplet matching first-setup's format), while the two duties that NEED the
+booted target — sysext feature enablement and the core desktop Flatpak set —
+are only RECORDED at install time (`--enable-feature` repeatable,
+`--core-flatpaks`/`--no-core-flatpaks`; desktop products default to core
+flatpaks on, `cayo-ab` refuses the flag) into `/var/lib/snosi/first-boot.json`
+and performed by **`snosi-firstboot.service`** (`shared/outformat/ab-root/
+tree`, static-wants infra unit, `After=network-online.target`,
+`TimeoutStartSec=0`): `updex --silent features enable <f> --now` per feature
+(verified against updex 1.3.0 source — `features enable` reads the union of
+the legacy dir and every discovered component, so the per-component sysext
+migration needs no syntax change) plus flathub system remote + the core set
+read from snow-first-setup's OWN `core.json`
+(`/usr/share/org.frostyard.FirstSetup/snow_first_setup/core.json`, single
+source of truth with its Mode 3 wizard; deduplicated — the list has carried
+duplicates), skipping gracefully where flatpak/core.json are absent (cayo).
+Retry semantics: any failure exits 1 WITHOUT the
+`/var/lib/snosi/first-boot.done` marker so the unit re-runs next boot; every
+operation is idempotent. This division retires first-setup's Mode 2 on
+native installs (Mode 1/nbc is retired with nbc; Mode 3 per-user login
+wizard is unchanged and verified working on native).
+`test/snosi-firstboot-test.sh` (fixture, PATH-stubbed updex/flatpak, wired
+into `validate.yml`) covers the fan-out, dedup, retry, and no-op paths.
+`shared/native-ab/keys/mok-2026.crt`
 (committed public certificate — a plain copy of gitignored `mkosi.crt`, safe
 to commit for the same reason as `import-pubring.gpg`; shipped in-image at the
 version-neutral path `/usr/lib/snosi/mok.crt`) ships alongside the pubring via

--- a/shared/native-installer/tree/usr/libexec/snosi-install
+++ b/shared/native-installer/tree/usr/libexec/snosi-install
@@ -160,6 +160,15 @@ Install mode options:
                                 (first line; file must be chmod 600)
   --user-fullname NAME          Optional GECOS full name for --username
   --no-create-user              Explicitly skip first-user creation
+  --hostname NAME               System hostname (interactive default: product)
+  --locale LOCALE               System locale, e.g. en_US.UTF-8
+  --timezone TZ                 Timezone, e.g. America/New_York (or UTC)
+  --keyboard SPEC               Console/XKB keyboard: LAYOUT[:VARIANT[:MODEL]]
+  --enable-feature NAME         Sysext feature to enable on first boot
+                                (repeatable; performed by snosi-firstboot)
+  --core-flatpaks               Install the core desktop Flatpak set on first
+                                boot (snow/snowfield default; invalid on cayo)
+  --no-core-flatpaks            Skip the core Flatpak set
   --reboot                      Reboot when finished (never automatic
                                 otherwise, in either mode)
   --non-interactive             Fully non-interactive; requires every
@@ -817,6 +826,43 @@ seed_var() { # var_device product channel version arch ssh_key_path(optional)
         install -m 0600 "$ssh_key" "$mnt/lib/snosi/etc-overlay/upper/ssh/authorized_keys.d/root"
     fi
 
+    # System settings (installer-owned: hostname/locale/timezone/keyboard)
+    # into the /etc overlay upper, plus the first-boot seed consumed by
+    # snosi-firstboot.service on the installed system (sysext features, core
+    # flatpaks -- deferred because they need the booted target's stack).
+    # Reads main()'s locals via bash dynamic scoping: set_hostname,
+    # set_locale, set_timezone, set_keyboard, enable_features[],
+    # core_flatpaks. All empty/0 -> writes nothing.
+    local upper="$mnt/lib/snosi/etc-overlay/upper"
+    local kb_layout kb_variant kb_model features_json core_json_bool
+    if [[ -n "$set_hostname$set_locale$set_timezone$set_keyboard" ]]; then
+        install -d -m 0755 "$upper"
+    fi
+    [[ -z "$set_hostname" ]] || printf '%s\n' "$set_hostname" >"$upper/hostname"
+    [[ -z "$set_locale" ]] || printf 'LANG=%s\n' "$set_locale" >"$upper/locale.conf"
+    if [[ -n "$set_timezone" ]]; then
+        printf '%s\n' "$set_timezone" >"$upper/timezone"
+        ln -sfn "../usr/share/zoneinfo/$set_timezone" "$upper/localtime"
+    fi
+    if [[ -n "$set_keyboard" ]]; then
+        IFS=: read -r kb_layout kb_variant kb_model <<<"$set_keyboard"
+        {
+            printf 'XKBLAYOUT=%s\n' "$kb_layout"
+            [[ -z "${kb_variant:-}" ]] || printf 'XKBVARIANT=%s\n' "$kb_variant"
+            [[ -z "${kb_model:-}" ]] || printf 'XKBMODEL=%s\n' "$kb_model"
+        } >"$upper/vconsole.conf"
+    fi
+    if [[ ${#enable_features[@]} -gt 0 || "${core_flatpaks:-0}" == 1 ]]; then
+        features_json="[]"
+        [[ ${#enable_features[@]} -eq 0 ]] ||
+            features_json="$(printf '%s\n' "${enable_features[@]}" | jq -R . | jq -sc .)"
+        core_json_bool=false
+        [[ "${core_flatpaks:-0}" != 1 ]] || core_json_bool=true
+        jq -n --argjson features "$features_json" --argjson core_flatpaks "$core_json_bool" \
+            '{features: $features, core_flatpaks: $core_flatpaks}' \
+            >"$mnt/lib/snosi/first-boot.json"
+    fi
+
     umount "$mnt"
     rmdir "$mnt"
 }
@@ -836,6 +882,12 @@ seed_var() { # var_device product channel version arch ssh_key_path(optional)
 # ---------------------------------------------------------------------------
 
 USERNAME_RE='^[a-z][a-z0-9_-]{0,31}$'
+HOSTNAME_RE='^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$'
+LOCALE_RE='^[A-Za-z][A-Za-z0-9_.@-]*$'
+TIMEZONE_RE='^[A-Za-z0-9_+-]+(/[A-Za-z0-9_+-]+){0,2}$'
+# LAYOUT[:VARIANT[:MODEL]], matching first-setup's XKB triplet.
+KEYBOARD_RE='^[a-z0-9,]+(:[A-Za-z0-9,_-]*(:[A-Za-z0-9_-]+)?)?$'
+FEATURE_RE='^[A-Za-z0-9._-]+$'
 
 # user_password_twice -- interactive prompt, validated twice. Sets
 # USER_PASSWORD. Same shape as mok_password_twice.
@@ -1148,6 +1200,9 @@ main() {
     local ssh_key="" do_reboot=0 non_interactive=0 allow_file=0
     local restage_mode=0
     local username="" user_password_file="" user_fullname="" no_create_user=0
+    local set_hostname="" set_locale="" set_timezone="" set_keyboard=""
+    local core_flatpaks=""
+    local -a enable_features=()
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -1169,6 +1224,13 @@ main() {
             --user-password-file) [[ $# -ge 2 ]] || usage; user_password_file="$2"; shift 2 ;;
             --user-fullname) [[ $# -ge 2 ]] || usage; user_fullname="$2"; shift 2 ;;
             --no-create-user) no_create_user=1; shift ;;
+            --hostname) [[ $# -ge 2 ]] || usage; set_hostname="$2"; shift 2 ;;
+            --locale) [[ $# -ge 2 ]] || usage; set_locale="$2"; shift 2 ;;
+            --timezone) [[ $# -ge 2 ]] || usage; set_timezone="$2"; shift 2 ;;
+            --keyboard) [[ $# -ge 2 ]] || usage; set_keyboard="$2"; shift 2 ;;
+            --enable-feature) [[ $# -ge 2 ]] || usage; enable_features+=("$2"); shift 2 ;;
+            --core-flatpaks) core_flatpaks=1; shift ;;
+            --no-core-flatpaks) core_flatpaks=0; shift ;;
             --reboot) do_reboot=1; shift ;;
             --non-interactive) non_interactive=1; shift ;;
             --allow-file) allow_file=1; shift ;;
@@ -1214,6 +1276,20 @@ main() {
         [[ -f "$user_password_file" ]] || die "--user-password-file not found: $user_password_file"
         check_secret_file_perms "$user_password_file" "--user-password-file"
     fi
+    # System-settings / first-boot-seed flag validation (format only; all
+    # writes are plain /etc-overlay or seed-file content).
+    [[ -z "$set_hostname" ]] || [[ "$set_hostname" =~ $HOSTNAME_RE ]] ||
+        die "invalid --hostname '$set_hostname'"
+    [[ -z "$set_locale" ]] || [[ "$set_locale" =~ $LOCALE_RE ]] ||
+        die "invalid --locale '$set_locale'"
+    [[ -z "$set_timezone" ]] || [[ "$set_timezone" =~ $TIMEZONE_RE ]] ||
+        die "invalid --timezone '$set_timezone' (expect Area/City or UTC)"
+    [[ -z "$set_keyboard" ]] || [[ "$set_keyboard" =~ $KEYBOARD_RE ]] ||
+        die "invalid --keyboard '$set_keyboard' (expect LAYOUT[:VARIANT[:MODEL]])"
+    local feat
+    for feat in "${enable_features[@]+"${enable_features[@]}"}"; do
+        [[ "$feat" =~ $FEATURE_RE ]] || die "invalid --enable-feature name '$feat'"
+    done
 
     local -a valid
     valid=("${VALID_PRODUCTS[@]}")
@@ -1235,6 +1311,16 @@ main() {
         [[ "$ok" -eq 1 ]] || die "--product must be one of: ${valid[*]}"
     fi
     local channel="$product" bare_product="${product%-ab}"
+
+    # Core-flatpak policy is product-shaped: cayo has no desktop, so the seed
+    # never requests flatpaks there; the desktop products default to the core
+    # set unless explicitly opted out.
+    if [[ "$product" == "cayo-ab" ]]; then
+        [[ "$core_flatpaks" != 1 ]] || die "--core-flatpaks: cayo-ab has no desktop (core flatpaks are snow/snowfield only)"
+        core_flatpaks=0
+    elif [[ -z "$core_flatpaks" && "$non_interactive" == 1 ]]; then
+        core_flatpaks=1
+    fi
 
     need_root
     # Every external command this script invokes anywhere -- an absence must
@@ -1359,6 +1445,67 @@ main() {
         fi
         if [[ "$non_interactive" != 1 && -z "$user_fullname" ]]; then
             read -r -p "Full name for '$username' (optional): " user_fullname
+        fi
+    fi
+
+    # -----------------------------------------------------------------
+    # System settings + first-boot choices (interactive; all gathered
+    # before the download, all applied at seed time). Empty answers keep
+    # the shown default; "-" skips the setting entirely (image default).
+    # -----------------------------------------------------------------
+    if [[ "$non_interactive" != 1 ]]; then
+        local answer
+        if [[ -z "$set_hostname" ]]; then
+            while true; do
+                read -r -p "Hostname [$bare_product]: " answer
+                answer="${answer:-$bare_product}"
+                [[ "$answer" == "-" ]] && break
+                [[ "$answer" =~ $HOSTNAME_RE ]] && { set_hostname="$answer"; break; }
+                echo "Invalid hostname." >&2
+            done
+        fi
+        if [[ -z "$set_locale" ]]; then
+            while true; do
+                read -r -p "Locale [en_US.UTF-8]: " answer
+                answer="${answer:-en_US.UTF-8}"
+                [[ "$answer" == "-" ]] && break
+                [[ "$answer" =~ $LOCALE_RE ]] && { set_locale="$answer"; break; }
+                echo "Invalid locale." >&2
+            done
+        fi
+        if [[ -z "$set_timezone" ]]; then
+            while true; do
+                read -r -p "Timezone (Area/City) [UTC]: " answer
+                answer="${answer:-UTC}"
+                [[ "$answer" == "-" ]] && break
+                [[ "$answer" =~ $TIMEZONE_RE ]] && { set_timezone="$answer"; break; }
+                echo "Invalid timezone." >&2
+            done
+        fi
+        if [[ -z "$set_keyboard" ]]; then
+            while true; do
+                read -r -p "Keyboard layout (LAYOUT[:VARIANT[:MODEL]]) [us]: " answer
+                answer="${answer:-us}"
+                [[ "$answer" == "-" ]] && break
+                [[ "$answer" =~ $KEYBOARD_RE ]] && { set_keyboard="$answer"; break; }
+                echo "Invalid keyboard spec." >&2
+            done
+        fi
+        if [[ ${#enable_features[@]} -eq 0 ]]; then
+            read -r -p "Sysext features to enable at first boot (comma-separated, empty for none): " answer
+            if [[ -n "$answer" ]]; then
+                IFS=, read -ra enable_features <<<"${answer// /}"
+                for feat in "${enable_features[@]}"; do
+                    [[ "$feat" =~ $FEATURE_RE ]] || die "invalid feature name '$feat'"
+                done
+            fi
+        fi
+        if [[ -z "$core_flatpaks" ]]; then
+            if confirm_yes_no "Install the core desktop Flatpak set on first boot?"; then
+                core_flatpaks=1
+            else
+                core_flatpaks=0
+            fi
         fi
     fi
 

--- a/shared/outformat/ab-root/tree/usr/lib/systemd/system/multi-user.target.wants/snosi-firstboot.service
+++ b/shared/outformat/ab-root/tree/usr/lib/systemd/system/multi-user.target.wants/snosi-firstboot.service
@@ -1,0 +1,1 @@
+../snosi-firstboot.service

--- a/shared/outformat/ab-root/tree/usr/lib/systemd/system/snosi-firstboot.service
+++ b/shared/outformat/ab-root/tree/usr/lib/systemd/system/snosi-firstboot.service
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Runs the deferred half of snosi-install's provisioning on the first boot of
+# a native A/B install: sysext feature enablement (updex) and the core desktop
+# Flatpak set -- both need the booted target's stack and network, so the
+# installer only records the choices (/var/lib/snosi/first-boot.json) and this
+# unit performs them. Retries on every boot until it fully succeeds (the done
+# marker is only written on complete success; every operation is idempotent).
+#
+# STATIC activation (no [Install], static wants link in /usr) per the snosi
+# infrastructure-unit pattern -- see CLAUDE.md "Enablement lives in presets".
+# Override with `systemctl mask`, not disable.
+[Unit]
+Description=snosi first-boot provisioning (sysext features + core flatpaks)
+ConditionPathExists=/var/lib/snosi/first-boot.json
+ConditionPathExists=!/var/lib/snosi/first-boot.done
+Wants=network-online.target
+After=network-online.target var.mount
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/snosi-firstboot
+# Flatpak runtime downloads are GBs on slow links; never kill mid-provision.
+TimeoutStartSec=0

--- a/shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot
+++ b/shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot
@@ -1,0 +1,94 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# First-boot provisioning for native A/B installs: performs the deferred,
+# needs-the-booted-target half of what snosi-install records at install time
+# in /var/lib/snosi/first-boot.json (the seed) -- sysext feature enablement
+# (updex, needs the target's sysupdate component tree + network) and the core
+# desktop Flatpak set (flatpak, needs the system installation in /var +
+# network). The install-time half (hostname/locale/timezone/keyboard, first
+# user) never involves this script -- those are plain /etc-overlay writes.
+#
+# Semantics:
+#   - No seed file          -> nothing to do (unit ConditionPathExists also
+#                              guards this; the check here keeps manual runs
+#                              safe).
+#   - Any item fails        -> every remaining item is still attempted, then
+#                              exit 1 WITHOUT writing the done marker, so the
+#                              unit retries on the next boot. All operations
+#                              are idempotent (enable is a no-op when enabled,
+#                              flatpak runs --or-update, remote-add uses
+#                              --if-not-exists).
+#   - Everything succeeds   -> /var/lib/snosi/first-boot.done is written and
+#                              the unit's ConditionPathExists=! stops future
+#                              runs.
+#
+# The core Flatpak list is owned by the snow-first-setup package (single
+# source of truth with its per-user Mode 3 wizard); this script reads the
+# list straight from that package's core.json and skips gracefully when the
+# package is not installed (cayo).
+#
+# Env overrides exist for the unit test only (test/snosi-firstboot-test.sh).
+set -euo pipefail
+
+SEED="${SNOSI_FIRSTBOOT_SEED:-/var/lib/snosi/first-boot.json}"
+DONE="${SNOSI_FIRSTBOOT_DONE:-/var/lib/snosi/first-boot.done}"
+CORE_JSON="${SNOSI_FIRSTBOOT_CORE_JSON:-/usr/share/org.frostyard.FirstSetup/snow_first_setup/core.json}"
+
+log()  { printf 'snosi-firstboot: %s\n' "$*"; }
+warn() { printf 'snosi-firstboot: warning: %s\n' "$*" >&2; }
+
+[[ -f "$SEED" ]] || { log "no seed at $SEED; nothing to do"; exit 0; }
+[[ ! -f "$DONE" ]] || { log "already completed ($DONE); nothing to do"; exit 0; }
+
+failures=0
+
+# --- sysext features -------------------------------------------------------
+mapfile -t features < <(jq -r '.features[]? // empty' "$SEED")
+for f in "${features[@]+"${features[@]}"}"; do
+    [[ "$f" =~ ^[A-Za-z0-9._-]+$ ]] || { warn "skipping invalid feature name: $f"; failures=$((failures + 1)); continue; }
+    log "enabling sysext feature: $f"
+    if ! updex --silent features enable "$f" --now; then
+        warn "failed to enable feature: $f"
+        failures=$((failures + 1))
+    fi
+done
+
+# --- core desktop flatpaks -------------------------------------------------
+if [[ "$(jq -r '.core_flatpaks // false' "$SEED")" == "true" ]]; then
+    if ! command -v flatpak >/dev/null; then
+        warn "seed requests core flatpaks but flatpak is not installed"
+        failures=$((failures + 1))
+    elif [[ ! -f "$CORE_JSON" ]]; then
+        warn "seed requests core flatpaks but $CORE_JSON is missing (snow-first-setup not installed?)"
+        failures=$((failures + 1))
+    else
+        log "adding flathub system remote"
+        if ! flatpak remote-add --system --if-not-exists flathub \
+                https://dl.flathub.org/repo/flathub.flatpakrepo; then
+            warn "failed to add the flathub remote"
+            failures=$((failures + 1))
+        else
+            # sort -u: the list is human-maintained and has carried duplicates.
+            mapfile -t core_ids < <(jq -r '.core[].id' "$CORE_JSON" | sort -u)
+            for id in "${core_ids[@]+"${core_ids[@]}"}"; do
+                log "installing core flatpak: $id"
+                if ! flatpak install --system --noninteractive --or-update -y flathub "$id"; then
+                    warn "failed to install core flatpak: $id"
+                    failures=$((failures + 1))
+                fi
+            done
+        fi
+    fi
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+    warn "$failures item(s) failed; done marker NOT written -- will retry next boot"
+    exit 1
+fi
+
+printf 'completed_at=%s\nfeatures=%s\ncore_flatpaks=%s\n' \
+    "$(date -u +%FT%TZ)" \
+    "$(jq -c '.features // []' "$SEED")" \
+    "$(jq -r '.core_flatpaks // false' "$SEED")" >"$DONE"
+log "first-boot provisioning complete"

--- a/test/snosi-firstboot-test.sh
+++ b/test/snosi-firstboot-test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Fixture test for shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot:
+# PATH-stubbed updex/flatpak record their invocations; seed/done/core.json
+# paths come from the script's test-only env overrides. Covers: the no-seed
+# and already-done no-ops, feature enablement fan-out, flathub remote + core
+# set (deduplicated), retry semantics (any failure -> exit 1, NO done
+# marker), and the success marker. No root, no network, no image build.
+#
+# Usage: ./test/snosi-firstboot-test.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot"
+
+PASS=0
+FAIL=0
+pass() { echo "ok - $1"; PASS=$((PASS + 1)); }
+fail() { echo "not ok - $1${2:+ ($2)}"; FAIL=$((FAIL + 1)); }
+assert_eq() { [[ "$2" == "$3" ]] && pass "$1" || fail "$1" "expected '$3', got '$2'"; }
+assert_file() { [[ -f "$2" ]] && pass "$1" || fail "$1" "missing $2"; }
+assert_no_file() { [[ ! -f "$2" ]] && pass "$1" || fail "$1" "unexpected $2"; }
+
+WORK_DIR="$(mktemp -d /var/tmp/snosi-firstboot-test.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# --- PATH stubs -------------------------------------------------------------
+mkdir -p "$WORK_DIR/bin"
+cat >"$WORK_DIR/bin/updex" <<EOF
+#!/bin/bash
+echo "updex \$*" >>"$WORK_DIR/calls.log"
+[[ ! -f "$WORK_DIR/updex-fail" ]] || exit 1
+EOF
+cat >"$WORK_DIR/bin/flatpak" <<EOF
+#!/bin/bash
+echo "flatpak \$*" >>"$WORK_DIR/calls.log"
+[[ ! -f "$WORK_DIR/flatpak-fail" ]] || exit 1
+EOF
+chmod +x "$WORK_DIR/bin/updex" "$WORK_DIR/bin/flatpak"
+
+# core.json fixture with a deliberate duplicate (the real list has carried
+# them) -- the script must dedup.
+cat >"$WORK_DIR/core.json" <<'EOF'
+{"core": [
+  {"name": "A", "id": "org.example.A"},
+  {"name": "B", "id": "org.example.B"},
+  {"name": "A again", "id": "org.example.A"}
+]}
+EOF
+
+run_fb() { # seed-file
+    : >"$WORK_DIR/calls.log"
+    set +e
+    # shellcheck disable=SC2034 # RUN_OUT kept for debugging failed asserts
+    RUN_OUT="$(PATH="$WORK_DIR/bin:$PATH" \
+        SNOSI_FIRSTBOOT_SEED="$1" \
+        SNOSI_FIRSTBOOT_DONE="$WORK_DIR/done" \
+        SNOSI_FIRSTBOOT_CORE_JSON="$WORK_DIR/core.json" \
+        bash "$SCRIPT" 2>&1)"
+    RUN_RC=$?
+    set -e
+}
+
+echo "=== no-op paths ==="
+run_fb "$WORK_DIR/absent.json"
+assert_eq "no seed: exit 0" "$RUN_RC" "0"
+assert_no_file "no seed: no done marker" "$WORK_DIR/done"
+
+echo "=== full success path ==="
+cat >"$WORK_DIR/seed.json" <<'EOF'
+{"features": ["docker", "tailscale"], "core_flatpaks": true}
+EOF
+run_fb "$WORK_DIR/seed.json"
+assert_eq "success: exit 0" "$RUN_RC" "0"
+assert_file "success: done marker written" "$WORK_DIR/done"
+assert_eq "success: both features enabled" \
+    "$(grep -c '^updex --silent features enable' "$WORK_DIR/calls.log")" "2"
+assert_eq "success: docker enabled with --now" \
+    "$(grep -c '^updex --silent features enable docker --now$' "$WORK_DIR/calls.log")" "1"
+assert_eq "success: flathub remote added" \
+    "$(grep -c '^flatpak remote-add --system --if-not-exists flathub' "$WORK_DIR/calls.log")" "1"
+assert_eq "success: core set installed DEDUPLICATED (2 unique ids)" \
+    "$(grep -c '^flatpak install --system --noninteractive --or-update -y flathub' "$WORK_DIR/calls.log")" "2"
+
+run_fb "$WORK_DIR/seed.json"
+assert_eq "already done: exit 0" "$RUN_RC" "0"
+assert_eq "already done: nothing invoked" "$(wc -l <"$WORK_DIR/calls.log")" "0"
+
+echo "=== retry semantics ==="
+rm -f "$WORK_DIR/done"
+touch "$WORK_DIR/updex-fail"
+run_fb "$WORK_DIR/seed.json"
+assert_eq "updex failure: exit 1" "$RUN_RC" "1"
+assert_no_file "updex failure: done marker NOT written" "$WORK_DIR/done"
+assert_eq "updex failure: flatpaks still attempted (no early abort)" \
+    "$(grep -c '^flatpak install' "$WORK_DIR/calls.log")" "2"
+rm -f "$WORK_DIR/updex-fail"
+
+touch "$WORK_DIR/flatpak-fail"
+run_fb "$WORK_DIR/seed.json"
+assert_eq "flatpak failure: exit 1" "$RUN_RC" "1"
+assert_no_file "flatpak failure: done marker NOT written" "$WORK_DIR/done"
+rm -f "$WORK_DIR/flatpak-fail"
+
+echo "=== features-only seed (cayo shape) ==="
+cat >"$WORK_DIR/seed2.json" <<'EOF'
+{"features": ["incus"], "core_flatpaks": false}
+EOF
+run_fb "$WORK_DIR/seed2.json"
+assert_eq "features-only: exit 0" "$RUN_RC" "0"
+assert_eq "features-only: no flatpak calls" "$(grep -c '^flatpak' "$WORK_DIR/calls.log" || true)" "0"
+assert_file "features-only: done marker written" "$WORK_DIR/done"
+
+echo ""
+echo "# Results: $PASS passed, $FAIL failed, $((PASS + FAIL)) total"
+[[ "$FAIL" -eq 0 ]]

--- a/test/snosi-install-test.sh
+++ b/test/snosi-install-test.sh
@@ -247,6 +247,31 @@ chmod 600 "$WORK_DIR/user-password.txt"
 run_installer "${BASE_ARGS[@]}" --username bjk --user-password-file "$WORK_DIR/user-password.txt"
 assert_contains "valid first-user args pass validation (reach root check)" "$RUN_OUT" "must run as root"
 
+# --- system settings + first-boot seed flags ---
+run_installer "${BASE_ARGS[@]}" --hostname 'bad host!'
+assert_contains "invalid --hostname rejected" "$RUN_OUT" "invalid --hostname"
+
+run_installer "${BASE_ARGS[@]}" --locale ';rm -rf /'
+assert_contains "invalid --locale rejected" "$RUN_OUT" "invalid --locale"
+
+run_installer "${BASE_ARGS[@]}" --timezone 'America/../../etc'
+assert_contains "invalid --timezone rejected" "$RUN_OUT" "invalid --timezone"
+
+run_installer "${BASE_ARGS[@]}" --keyboard 'us;evil'
+assert_contains "invalid --keyboard rejected" "$RUN_OUT" "invalid --keyboard"
+
+run_installer "${BASE_ARGS[@]}" --enable-feature 'bad/feature'
+assert_contains "invalid --enable-feature rejected" "$RUN_OUT" "invalid --enable-feature"
+
+run_installer "${BASE_ARGS[@]}" --core-flatpaks
+assert_true "--core-flatpaks on cayo-ab: exits non-zero" bash -c "[[ $RUN_RC -ne 0 ]]"
+assert_contains "--core-flatpaks on cayo-ab: clear error" "$RUN_OUT" "cayo-ab has no desktop"
+
+run_installer "${BASE_ARGS[@]}" --hostname myhost --locale en_US.UTF-8 \
+    --timezone America/New_York --keyboard 'us:intl' --enable-feature docker \
+    --enable-feature tailscale
+assert_contains "valid system-settings args pass validation (reach root check)" "$RUN_OUT" "must run as root"
+
 # --insecure-raw-var must NOT demand recovery-key-file/ack.
 mapfile -t ARGS_RAW_VAR < <(without_flag --recovery-key-file 1)
 run_installer "${ARGS_RAW_VAR[@]}" --insecure-raw-var


### PR DESCRIPTION
Phase 1 of the native first-boot design (from the Mode 2 gap analysis):

**Install time (`snosi-install`):** `--hostname`/`--locale`/`--timezone`/`--keyboard` with interactive prompts (defaults `<product>`/`en_US.UTF-8`/`UTC`/`us`; `-` skips) — plain `/etc`-overlay-upper writes, same mechanism as first-user. Sysext features (`--enable-feature`, repeatable) and core desktop flatpaks (`--core-flatpaks`, default-on for desktop products, refused on cayo) are **recorded** into `/var/lib/snosi/first-boot.json`.

**First boot (`snosi-firstboot.service`, new, all native products):** performs the deferred half — `updex --silent features enable <f> --now` (verified against updex 1.3.0 source: reads the union of legacy dir + discovered components, so the per-component migration needs no syntax change) and flathub remote + the core set from snow-first-setup's own `core.json` (single source of truth, deduplicated). Any failure → exit 1, no done marker, retries next boot; all idempotent. Static-wants infra unit per the CLAUDE.md pattern.

**Boundary outcome:** first-setup Mode 2 is fully covered on native (user creation was #417); Mode 3 unchanged and verified working. Phase 2 (GTK `snosi-setup` frontend + graphical ISO) to be planned separately.

Tests: new `test/snosi-firstboot-test.sh` 18/18 (wired into validate.yml), installer matrix 112/112, static/contracts/guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)