### PR TITLE
fix: dest backend helpers judge missing objects by output, not rclone exit code

### DIFF
--- a/shared/native-ab/publish/publish-lib.sh
+++ b/shared/native-ab/publish/publish-lib.sh
@@ -177,6 +177,14 @@ dest_copy_object() { # src-relpath dst-relpath [cache-control]
         dest_put_file "$DEST_LOCAL_ROOT/$src_rel" "$dst_rel" "$cache_control"
         ;;
     rclone)
+        # rclone copyto of a MISSING source exits 0 on bucket backends
+        # (empty-prefix semantics, same as dest_object_exists above) --
+        # a silent no-op copy. Mirror the local branch's explicit
+        # source-exists refusal instead.
+        dest_object_exists "$src_rel" || {
+            echo "Error: source object missing, cannot copy: $DEST_RCLONE_TARGET/$src_rel" >&2
+            exit 1
+        }
         local -a args=(copyto "$DEST_RCLONE_TARGET/$src_rel" "$DEST_RCLONE_TARGET/$dst_rel")
         [[ -z "$cache_control" ]] || args+=(--header-upload "Cache-Control: $cache_control")
         rclone "${args[@]}"
@@ -187,6 +195,10 @@ dest_copy_object() { # src-relpath dst-relpath [cache-control]
 # dest_read_object relpath outfile -- fetch DEST/relpath's bytes into
 # outfile, without going through HTTP (used by withdraw.sh to gpgv-verify an
 # archived pair directly against the storage backend, not the public edge).
+# Fails (and leaves no outfile) when the object is missing, on every
+# backend: `rclone cat`/`copyto` of a nonexistent object exit 0 on bucket
+# backends (see dest_object_exists below), so success is judged by the
+# copy actually producing outfile, not by rclone's exit status.
 dest_read_object() { # relpath outfile
     local relpath="$1" outfile="$2"
     case "$DEST_KIND" in
@@ -195,11 +207,21 @@ dest_read_object() { # relpath outfile
         cp "$DEST_LOCAL_ROOT/$relpath" "$outfile"
         ;;
     rclone)
-        rclone cat "$DEST_RCLONE_TARGET/$relpath" >"$outfile"
+        rm -f "$outfile"
+        rclone copyto "$DEST_RCLONE_TARGET/$relpath" "$outfile" || return 1
+        [[ -f "$outfile" ]]
         ;;
     esac
 }
 
+# dest_object_exists relpath -- true iff an object exists at DEST/relpath.
+# rclone's exit code is BACKEND-DEPENDENT for a missing object: directory
+# backends (local) exit 3, but bucket backends (S3/R2) have no real
+# directories, so `rclone lsf` of a nonexistent object is just an empty
+# prefix listing -- exit 0, empty output. Trusting the exit code alone made
+# this return true for missing objects on R2 (promote.sh's archive block
+# took the wrong branch on a first promotion, observed live 2026-07-16), so
+# existence is judged by lsf actually printing the object's name.
 dest_object_exists() { # relpath
     local relpath="$1"
     case "$DEST_KIND" in
@@ -207,7 +229,7 @@ dest_object_exists() { # relpath
         [[ -f "$DEST_LOCAL_ROOT/$relpath" ]]
         ;;
     rclone)
-        rclone lsf "$DEST_RCLONE_TARGET/$relpath" >/dev/null 2>&1
+        [[ "$(rclone lsf "$DEST_RCLONE_TARGET/$relpath" 2>/dev/null)" == "$(basename "$relpath")" ]]
         ;;
     esac
 }

--- a/test/native-publication-pipeline-test.sh
+++ b/test/native-publication-pipeline-test.sh
@@ -42,6 +42,7 @@ DEV_PUBRING="$ROOT_DIR/shared/native-ab/keys/import-pubring.gpg"
 
 WORK_DIR=""
 HTTP_PID=""
+S3_PID=""
 PORT=0
 PASS=0
 FAIL=0
@@ -101,6 +102,7 @@ print_summary() {
 
 cleanup() {
     [[ -z "$HTTP_PID" ]] || kill "$HTTP_PID" 2>/dev/null || true
+    [[ -z "$S3_PID" ]] || kill "$S3_PID" 2>/dev/null || true
     [[ -z "$WORK_DIR" || ! -d "$WORK_DIR" ]] || rm -rf "$WORK_DIR"
 }
 trap cleanup EXIT
@@ -224,7 +226,14 @@ assert_false "verify-remote.sh fails closed on a corrupted candidate byte" \
 assert_true "verify-remote.sh clean pass" "$PUBLISH_DIR/verify-remote.sh" "$PREPARED1" "$BASE_URL"
 
 echo "=== promote.sh: ordering, sidecars, gpgv ==="
-"$PUBLISH_DIR/promote.sh" "${PROMOTE_KEY_ARGS[@]}" --pubring "$PUBRING" "$PREPARED1" "$BASE_URL" "$DEST"
+promote1_out="$("$PUBLISH_DIR/promote.sh" "${PROMOTE_KEY_ARGS[@]}" --pubring "$PUBRING" "$PREPARED1" "$BASE_URL" "$DEST")"
+echo "$promote1_out"
+# Guards the archive block's exists-check: a first promotion has no outgoing
+# signed index, and must say so -- not take the "already advertises (or is
+# unparseable)" branch, which is what a false dest_object_exists positive
+# produced on R2 (2026-07-16).
+assert_contains "first promotion reports no existing signed index to archive" \
+    "$promote1_out" "No existing signed index to archive (first promotion"
 product_dir="$DEST/os/native/v1/$PRODUCT/x86-64"
 assert_true "final SHA256SUMS.gpg exists" test -f "$product_dir/SHA256SUMS.gpg"
 assert_true "final SHA256SUMS exists" test -f "$product_dir/SHA256SUMS"
@@ -390,5 +399,99 @@ assert_contains "ISO index advertises v1 again after withdrawal via --dest-path"
     "$(cat "$iso_product_dir/SHA256SUMS")" "snosi-native-installer_${ISO_VERSION1}_x86-64.iso"
 assert_true "gpgv accepts the withdrawn (restored) ISO index" \
     gpgv --keyring "$PUBRING" "$iso_product_dir/SHA256SUMS.gpg" "$iso_product_dir/SHA256SUMS"
+
+# ---------------------------------------------------------------------------
+# publish-lib.sh dest backend semantics: dest_object_exists /
+# dest_read_object / dest_copy_object must report a MISSING object as
+# missing on EVERY backend. rclone's exit codes are backend-dependent here:
+# bucket backends (S3/R2) have no real directories, so `rclone lsf`, `cat`,
+# and `copyto` of a nonexistent object all exit 0 with empty output --
+# observed live on R2 2026-07-16, when promote.sh took the "already
+# advertises (or is unparseable)" archive branch on a FIRST promotion. The
+# helpers must therefore key on produced output, never on exit status
+# alone. The local-backend leg always runs (and pins that both backends
+# behave identically); the S3 leg reproduces the real R2 shape via
+# `rclone serve s3` and is skipped when rclone is not installed.
+# ---------------------------------------------------------------------------
+echo "=== publish-lib.sh dest backend semantics (missing vs present objects) ==="
+
+# publib dest fn [args...] -- source publish-lib.sh in a child bash (it sets
+# set -e and an EXIT trap of its own), dest_parse `dest`, then run one helper.
+publib() { # dest fn [args...]
+    env PUBLISH_DIR="$PUBLISH_DIR" bash -ec '
+        source "$PUBLISH_DIR/publish-lib.sh"
+        dest_parse "$1"
+        fn="$2"
+        shift 2
+        "$fn" "$@"
+    ' _ "$@"
+}
+
+# run_backend_asserts label dest -- the same 8 assertions against one backend.
+run_backend_asserts() { # label dest
+    local label="$1" dest="$2"
+    local read_out="$WORK_DIR/backend-read-$label"
+    local read_missing_out="$WORK_DIR/backend-read-missing-$label"
+    rm -f "$read_out" "$read_missing_out"
+
+    assert_true "$label dest: dest_object_exists true for a present object" \
+        publib "$dest" dest_object_exists "sub/present.txt"
+    assert_false "$label dest: dest_object_exists false for a missing object" \
+        publib "$dest" dest_object_exists "sub/SHA256SUMS"
+    assert_true "$label dest: dest_read_object fetches a present object" \
+        publib "$dest" dest_read_object "sub/present.txt" "$read_out"
+    assert_eq "$label dest: dest_read_object content round-trips" \
+        "$(cat "$read_out" 2>/dev/null)" "present"
+    assert_false "$label dest: dest_read_object fails for a missing object" \
+        publib "$dest" dest_read_object "sub/SHA256SUMS" "$read_missing_out"
+    assert_false "$label dest: dest_read_object leaves no outfile for a missing object" \
+        test -e "$read_missing_out"
+    assert_false "$label dest: dest_copy_object refuses a missing source object" \
+        publib "$dest" dest_copy_object "sub/SHA256SUMS" "sub/copy-of-missing"
+    assert_true "$label dest: dest_copy_object copies a present object" \
+        publib "$dest" dest_copy_object "sub/present.txt" "sub/copy.txt"
+}
+
+LOCAL_BACKEND_DIR="$WORK_DIR/backend-local"
+mkdir -p "$LOCAL_BACKEND_DIR/sub"
+printf 'present\n' >"$LOCAL_BACKEND_DIR/sub/present.txt"
+run_backend_asserts "local" "$LOCAL_BACKEND_DIR"
+assert_false "local dest: dest_copy_object of a missing source created nothing" \
+    test -e "$LOCAL_BACKEND_DIR/sub/copy-of-missing"
+
+if command -v rclone >/dev/null; then
+    S3_ROOT="$WORK_DIR/backend-s3-root"
+    mkdir -p "$S3_ROOT/bucket/sub"
+    printf 'present\n' >"$S3_ROOT/bucket/sub/present.txt"
+    S3_PORT=18924
+    rclone serve s3 --auth-key testkey,testsecret --addr "127.0.0.1:$S3_PORT" \
+        "$S3_ROOT" >"$WORK_DIR/rclone-s3.log" 2>&1 &
+    S3_PID=$!
+    export RCLONE_CONFIG_PIPES3_TYPE=s3 \
+        RCLONE_CONFIG_PIPES3_PROVIDER=Rclone \
+        RCLONE_CONFIG_PIPES3_ENDPOINT="http://127.0.0.1:$S3_PORT" \
+        RCLONE_CONFIG_PIPES3_ACCESS_KEY_ID=testkey \
+        RCLONE_CONFIG_PIPES3_SECRET_ACCESS_KEY=testsecret \
+        RCLONE_CONFIG_PIPES3_FORCE_PATH_STYLE=true
+    s3_up=0
+    for _ in $(seq 1 20); do
+        if rclone lsf "pipes3:bucket/sub/" >/dev/null 2>&1; then
+            s3_up=1
+            break
+        fi
+        sleep 0.5
+    done
+    if [[ "$s3_up" == 1 ]]; then
+        run_backend_asserts "s3" "rclone:pipes3:bucket"
+        assert_false "s3 dest: dest_copy_object of a missing source created nothing" \
+            test -e "$S3_ROOT/bucket/sub/copy-of-missing"
+    else
+        fail "rclone serve s3 backend came up" "$(tail -5 "$WORK_DIR/rclone-s3.log" 2>/dev/null)"
+    fi
+    kill "$S3_PID" 2>/dev/null || true
+    S3_PID=""
+else
+    echo "# rclone not installed -- skipping the S3-backend leg (the local-backend leg above still ran)"
+fi
 
 print_summary

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -924,6 +924,30 @@ silent death. Caught by `test/native-publication-pipeline-test.sh`'s new
 "ISO-shaped fixture leg", which is the first test in this suite to promote
 the SAME (non-manifest-bearing) publication type twice in a row.
 
+A second latent bug in the same archive block surfaced during the first
+REAL promotion against R2 (2026-07-16): `publish-lib.sh`'s
+`dest_object_exists()` trusted `rclone lsf`'s exit code, but that exit code
+is BACKEND-DEPENDENT for a missing object -- directory backends (rclone's
+`local`) exit 3, while bucket backends (S3/R2) have no real directories, so
+`lsf`/`cat`/`copyto` of a nonexistent object are all just empty-prefix
+listings: exit 0, empty output, no file produced. On R2 this made a first
+promotion take the misleading "already advertises (or is unparseable)"
+branch (the false "exists" led to `dest_read_object` producing an empty
+file via `rclone cat`, whose version grep then matched nothing); archiving
+was still correctly skipped, but a false "exists" could have masked real
+archive/restore bugs. Fix (all three helpers now judge by produced OUTPUT,
+never rclone's exit status): `dest_object_exists` compares `lsf` output to
+the object's basename; `dest_read_object` uses `copyto` and requires the
+outfile to actually exist afterward; `dest_copy_object`'s rclone branch
+gained the same explicit source-exists refusal its local branch always
+had (a missing source was a silent no-op copy on bucket backends).
+Covered by `test/native-publication-pipeline-test.sh`'s "dest backend
+semantics" leg, which asserts missing-vs-present behavior is identical on
+a local-dir dest and on a REAL S3 backend (`rclone serve s3` against a
+temp dir, reproducing the exact R2 shape; skipped when rclone is not
+installed), plus a first-promotion assertion that `promote.sh` prints
+"No existing signed index to archive (first promotion ...)".
+
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
 1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, podman, tailscale, vscode


### PR DESCRIPTION
## Problem

During the first real promotion against R2 (2026-07-16), `promote.sh`'s archive block printed "Outgoing index already advertises 20260716200813 (or is unparseable); nothing to archive." on a **first** promotion — `rclone lsf` of the product dir showed no `SHA256SUMS`/`SHA256SUMS.gpg` at all.

Root cause (reproduced empirically against `rclone serve s3`): rclone's exit code for a missing object is **backend-dependent**. Directory backends (local) exit 3, but bucket backends (S3/R2) have no real directories, so `lsf`/`cat`/`copyto` of a nonexistent object are all empty-prefix listings — exit 0, empty output, no file produced. `dest_object_exists()` trusted the exit code, so it false-positived; `dest_read_object()` then "read" an empty file via `rclone cat`, the version grep matched nothing, and the misleading branch fired. Archiving was still correctly skipped, but a false "exists" could mask real archive/restore bugs later. Bonus finding: `rclone copyto` of a missing source **also** exits 0 on bucket backends, making `dest_copy_object`'s rclone branch a silent no-op copy — the same defect in the archive path itself.

## Fix (`shared/native-ab/publish/publish-lib.sh`)

All three helpers now judge by produced output, never rclone's exit status:

- `dest_object_exists` compares `lsf` output to the object's basename
- `dest_read_object` uses `copyto` (not `cat`), clears any stale outfile, and requires the outfile to actually exist afterward
- `dest_copy_object`'s rclone branch gains the same explicit source-exists refusal its local branch always had

## Tests (`test/native-publication-pipeline-test.sh`, 39 → 58 assertions)

- First promotion's output must contain `No existing signed index to archive (first promotion`
- New "dest backend semantics" leg: 9 missing-vs-present assertions per backend for all three helpers, run against a local-dir dest **and** a real S3 backend (`rclone serve s3`, reproducing the exact R2 shape). Written TDD-style: the S3 leg failed 4 assertions against the unfixed library. Skips cleanly when rclone is not installed (verified 49/49 with rclone absent from PATH, so validate.yml runners are fine).

## Verification

- `./test/native-publication-pipeline-test.sh`: 58/58 with rclone, 49/49 without
- `shellcheck -S warning -x` clean on both modified scripts
- Incident writeup added to `yeti/OVERVIEW.md` next to the existing archive-block bug note

🤖 Generated with [Claude Code](https://claude.com/claude-code)