### PR TITLE
feat: graphical installer (snosi-setup GTK4 kiosk) — Phase 2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -87,6 +87,13 @@ jobs:
         # 8.3), intentionally out of scope for this fast per-PR check.
         run: ./test/snosi-install-test.sh
 
+      - name: Validate snosi-setup GUI model
+        # Pure-python test of setup_gui/model.py (validation, argv assembly,
+        # proto-1 event parsing, disk-list/typed-confirm handling) against an
+        # embedded --print-defaults fixture plus a live-drift check against
+        # the real snosi-install. No GTK, no display, no root.
+        run: python3 ./test/snosi-setup-model-test.py
+
       - name: Validate snosi-firstboot provisioning script
         # Fixture test with PATH-stubbed updex/flatpak: feature enablement
         # fan-out, flathub remote + deduplicated core set, retry semantics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -918,6 +918,43 @@ image defeat the check, while a raw `dd`/`cp` of the ISO preserves it and is
 correctly detected. Full design notes: `yeti/OVERVIEW.md` "snosi-install CLI
 (Task 8.2)".
 
+**Graphical setup wizard (`shared/native-installer/setup-gui/`, 2026-07-17):**
+`snosi-install` now also carries a machine-readable GUI contract —
+`--print-defaults` (products with capacity floors + per-product core-flatpaks
+policy, interactive defaults, every validation regex), `--list-disks-json`
+(installable disks + refusal reasons), and `--json-progress` (line-delimited
+proto-1 event stream: `start`/`phase`/`log`/`error`/`done` at main()'s nine
+section boundaries; byte-level download progress is deliberately NOT in proto
+1 — the download is a five-stage pipeline with no clean byte hook, and
+receivers must ignore unknown events so it can be added compatibly). The GTK4/
+libadwaita kiosk `snosi-setup` (in-tree Python/GI package, installed to
+`/usr/lib/snosi-setup`, launcher symlink `/usr/bin/snosi-setup`; GTK-free
+`setup_gui/model.py` holds all logic — validation, argv assembly, event-stream
+parsing — with `test/snosi-setup-model-test.py` covering it, wired into
+`validate.yml`) drives exactly one `snosi-install --non-interactive
+--json-progress` invocation and performs no privileged operation itself.
+**Activation is a static wants link + unit Conditions** (`snosi-setup.service`,
+`ConditionPathExistsGlob=/dev/dri/card*`,
+`ConditionKernelCommandLine=!snosi.textmode=1`), with `getty@tty1` stopped
+IMPERATIVELY in `ExecStartPre`, never via `Conflicts=`: Conflicts stops the
+conflicting unit at transaction-build time, BEFORE this unit's Conditions
+evaluate, so a statically-wanted unit with Conflicts kills getty even on the
+no-display boot where its own Condition then fails — ExecStartPre runs only
+after Conditions pass, i.e. only when the kiosk really starts, so the
+text-mode fallback never loses getty (and `OnFailure=getty@tty1` restores it
+on a crash-loop). A udev DRM device-pull was tried and abandoned: DRM cards
+emit an `add` then a `bind` uevent and the `bind` drops `:systemd:` from the
+device's CURRENT_TAGS at coldplug, so the `.device` unit never pulled the
+kiosk on a real boot (it worked only on a manual `udevadm trigger`). The ISO
+gains the cage/GTK4/Mesa-llvmpipe/python3-gi/cantarell stack plus the picker
+data files (`locales`/`xkb-data`/`tzdata`, else the pickers silently degrade),
+taking it to ~1.1–1.3 GB. `test/snosi-setup-boot-test.sh` (local, root+KVM,
+not in CI) boots the real ISO twice under enforced Secure Boot — virtio-vga
+(kiosk up: cage + the GTK app, getty yielded, no crash loop) and no-display
+(getty fallback, Condition-skipped cleanly) — 13/13; the serial text flow is
+never affected either way. Design/plan: `docs/plans/2026-07-17-graphical-
+installer-plan.md`.
+
 The Phase 7 candidate/verify/promote/withdraw publication pipeline
 (`shared/native-ab/publish/`) now also publishes this ISO, under the flat
 `isos/native/v1/` namespace (docs/native-ab-contracts.md §5) via a new

--- a/docs/native-ab-contracts.md
+++ b/docs/native-ab-contracts.md
@@ -339,6 +339,18 @@ Never Snosi-MOK-only for the ISO: the ISO boots before any Snosi MOK exists
 on the target machine's firmware and must validate on hardware that has never
 enrolled a Snosi certificate, with Secure Boot enforced.
 
+**Graphical setup (informative, not name-frozen):** the ISO carries a GTK4
+kiosk wizard (`snosi-setup`, launched by cage on tty1 via
+`snosi-setup.service`) that drives one `snosi-install --non-interactive
+--json-progress` invocation — it performs no privileged operation itself.
+It runs only when a DRM display device exists and `snosi.textmode=1` is not
+on the kernel command line; in every other case (no display, the cmdline
+escape hatch, or three kiosk crashes in 60s) tty1 belongs to getty exactly
+as before, and the serial console text flow is never affected. The
+machine-readable backend contract (`--print-defaults`, `--list-disks-json`,
+the `--json-progress` proto-1 event stream) is documented in the
+snosi-install usage text and CLAUDE.md, and versioned by its `proto` field.
+
 ## 9. Kernel module/firmware policy
 
 Release native profiles ship the complete packaged module and firmware set.

--- a/docs/native-ab-publication.md
+++ b/docs/native-ab-publication.md
@@ -217,6 +217,11 @@ sees.
 
 ## Installer ISO publication
 
+> **Size note:** since the graphical setup wizard landed (GTK4/cage/Mesa
+> stack + picker data), the ISO is roughly 1.1–1.3 GB rather than the
+> original ~550 MB. Candidate upload, `verify-remote`'s full re-download,
+> and promotion re-hashing all scale with it; budget CI time accordingly.
+
 The network-installer ISO (`docs/native-ab-contracts.md` "Installer ISO",
 §5's flat `isos/native/v1/` namespace -- no per-product/x86-64 subpath, since
 there is exactly one installer, not one per product) goes through the

--- a/docs/plans/ab-deploy-checklist.md
+++ b/docs/plans/ab-deploy-checklist.md
@@ -348,6 +348,11 @@ Full commands in runbook §"Candidate → verify → promote → purge procedure
 - [ ] Internal canary: install each product on internal hardware from the real
       ISO, take at least one real published update, and confirm
       `snosi-update-status` / `snosi-update-status --check` report correctly.
+      Include a **hands-on GRAPHICAL pass** once the snosi-setup kiosk ships
+      on the ISO: boot on a machine (or QEMU with virtio-vga + display) and
+      complete an install through the wizard — the model tests and boot smoke
+      (test/snosi-setup-boot-test.sh) prove logic and liveness, but only a
+      human sees the pixels, focus order, and keyboard behavior.
       Include a **hands-on interactive pass** (console login, no injected SSH
       keys, real HTTPS origin) — the 2026-07-16 human QEMU install found four
       ship-blockers (`login`, `ca-certificates`, `mount`, no first user; PR

--- a/shared/native-installer/mkosi.conf
+++ b/shared/native-installer/mkosi.conf
@@ -228,5 +228,27 @@ Packages=firmware-linux-free
 ExtraTrees=%D/shared/native-installer/tree
 ExtraTrees=%D/shared/native-ab/keys/import-pubring.gpg:/usr/lib/snosi/os-update-pubring.gpg
 ExtraTrees=%D/shared/native-ab/keys/mok-2026.crt:/usr/lib/snosi/mok.crt
+# The GTK4 kiosk setup wizard (T2/T3, docs/plans/2026-07-17-graphical-
+# installer-plan.md) installs as a plain directory; /usr/bin/snosi-setup is
+# a symlink shipped in tree/ pointing into it.
+ExtraTrees=%D/shared/native-installer/setup-gui:/usr/lib/snosi-setup
+
+# Graphical setup stack (T3): cage kiosk compositor + GTK4/libadwaita via
+# Python/GI, Mesa's software (llvmpipe) fallback so virtio/simple-framebuffer
+# machines render, a real UI font, and the picker data files snosi-setup's
+# locale/keyboard/timezone pages read (locales: /usr/share/i18n/SUPPORTED;
+# xkb-data: evdev.lst; tzdata: zoneinfo) -- without them the pickers silently
+# degrade to a tiny embedded list. Every entry explicit, per the forky-drift
+# rule ("mount" incident, 2026-07-16).
+Packages=cage
+         gir1.2-gtk-4.0
+         gir1.2-adw-1
+         python3-gi
+         fonts-cantarell
+         libgl1-mesa-dri
+         libegl-mesa0
+         locales
+         xkb-data
+         tzdata
 
 PostInstallationScripts=%D/shared/native-installer/postinst/mkosi.postinst.chroot

--- a/shared/native-installer/setup-gui/setup_gui/__init__.py
+++ b/shared/native-installer/setup-gui/setup_gui/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# setup_gui -- the snosi-setup GTK4/libadwaita kiosk frontend package
+# (T2, docs/plans/2026-07-17-graphical-installer-plan.md).
+#
+# Layering rule (load-bearing for tests): model.py and data.py must never
+# import GTK/GI -- test/snosi-setup-model-test.py runs them on hosts with no
+# GTK at all. Only app.py and pages.py may touch gi.
+
+__version__ = "0.1.0"

--- a/shared/native-installer/setup-gui/setup_gui/__main__.py
+++ b/shared/native-installer/setup-gui/setup_gui/__main__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# `python3 -m setup_gui` entry point (equivalent to the snosi-setup wrapper).
+import sys
+
+from .app import main
+
+sys.exit(main())

--- a/shared/native-installer/setup-gui/setup_gui/app.py
+++ b/shared/native-installer/setup-gui/setup_gui/app.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# app.py -- Adw.Application + wizard window for snosi-setup. The window is
+# the first-setup window.py pattern (page stack + Back/Next in a header
+# bar, window.set_ready gating Next), built in code, no gresource.
+#
+# The app performs ZERO privileged operations itself beyond spawning
+# `snosi-install` (progress page) and `systemctl reboot` (done page); it
+# runs as root on the installer ISO because everything there is root, but
+# the boundary stays clean.
+
+import argparse
+import json
+import subprocess
+import sys
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # noqa: E402
+
+from . import model, pages  # noqa: E402
+
+APP_ID = "org.frostyard.SnosiSetup"
+
+# Fixture used ONLY by --self-check when no snosi-install is runnable (e.g.
+# a dev host); a real run always loads live `snosi-install --print-defaults`
+# output so the frontend can never drift from the backend.
+_SELF_CHECK_DEFAULTS = {
+    "proto": 1,
+    "products": [
+        {"name": "cayo-ab", "bare": "cayo", "minimum_disk_bytes": 16642998272,
+         "core_flatpaks_default": False, "core_flatpaks_allowed": False},
+        {"name": "snow-ab", "bare": "snow", "minimum_disk_bytes": 23085449216,
+         "core_flatpaks_default": True, "core_flatpaks_allowed": True},
+    ],
+    "defaults": {"locale": "en_US.UTF-8", "timezone": "UTC", "keyboard": "us"},
+    "origin_default": "https://repository.frostyard.org",
+    "mok_cert_default": "/usr/lib/snosi/mok.crt",
+    "regexes": {
+        "username": "^[a-z][a-z0-9_-]{0,31}$",
+        "hostname": "^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+        "locale": "^[A-Za-z][A-Za-z0-9_.@-]*$",
+        "timezone": "^[A-Za-z0-9_+-]+(/[A-Za-z0-9_+-]+){0,2}$",
+        "keyboard": "^[a-z0-9,]+(:[A-Za-z0-9,_-]*(:[A-Za-z0-9_-]+)?)?$",
+        "feature": "^[A-Za-z0-9._-]+$",
+    },
+}
+
+
+def load_defaults(installer):
+    """Run `snosi-install --print-defaults` and parse it. Raises on any
+    failure -- a frontend without the backend document must not guess."""
+    proc = subprocess.run([installer, "--print-defaults"],
+                          capture_output=True, text=True, timeout=60)
+    if proc.returncode != 0:
+        raise RuntimeError("%s --print-defaults failed (%d): %s" %
+                           (installer, proc.returncode, proc.stderr.strip()))
+    return model.Defaults.from_json(proc.stdout)
+
+
+class SetupWindow(Adw.ApplicationWindow):
+    """Page stack + Back/Next chrome. Navigation follows
+    model.page_sequence(state.product) BY NAME (the sequence changes when a
+    product without core-flatpaks support is chosen), so pages are looked up
+    per hop, never by a frozen index."""
+
+    def __init__(self, application, defaults, installer, fullscreen=True):
+        super().__init__(application=application, title="Snosi Setup",
+                         default_width=1024, default_height=700)
+        self.defaults = defaults
+        self.installer = installer
+        self.state = model.SetupState()
+        self.can_continue = False
+
+        self.back_btn = Gtk.Button(icon_name="go-previous-symbolic",
+                                   tooltip_text="Back")
+        self.back_btn.connect("clicked", lambda *_: self.go_back())
+        self.next_btn = Gtk.Button(label="Next")
+        self.next_btn.add_css_class("suggested-action")
+        self.next_btn.connect("clicked", lambda *_: self.finish_step())
+
+        header = Adw.HeaderBar()
+        header.pack_start(self.back_btn)
+        header.pack_end(self.next_btn)
+
+        self.stack = Gtk.Stack(
+            transition_type=Gtk.StackTransitionType.SLIDE_LEFT_RIGHT,
+            hexpand=True, vexpand=True)
+        self.pages = {}
+        for name in model.page_sequence(None):
+            page = pages.PAGE_CLASSES[name](self)
+            self.pages[name] = page
+            self.stack.add_named(page, name)
+
+        view = Adw.ToolbarView()
+        view.add_top_bar(header)
+        view.set_content(self.stack)
+        self.set_content(view)
+
+        self.current_name = model.PAGE_WELCOME
+        self._show(self.current_name, activate=True)
+        if fullscreen:
+            self.fullscreen()
+
+    # -- page protocol (first-setup window.py shape) -----------------------
+
+    def page_by_name(self, name):
+        return self.pages.get(name)
+
+    def set_ready(self, ready=True):
+        self.can_continue = ready
+        self.next_btn.set_sensitive(ready)
+
+    def _sequence(self):
+        return model.page_sequence(self.state.product)
+
+    def finish_step(self):
+        if not self.can_continue:
+            return
+        self.advance()
+
+    def advance(self):
+        """Commit the current page and move forward (also driven
+        programmatically: network skip, progress-page done event)."""
+        page = self.pages[self.current_name]
+        if not page.finish():
+            self.set_ready(False)
+            return
+        seq = self._sequence()
+        idx = seq.index(self.current_name)
+        if idx + 1 < len(seq):
+            self._show(seq[idx + 1])
+
+    def go_back(self):
+        seq = self._sequence()
+        idx = seq.index(self.current_name)
+        if idx > 0:
+            self._show(seq[idx - 1])
+
+    def _show(self, name, activate=True):
+        old = self.pages.get(self.current_name)
+        page = self.pages[name]
+        self.current_name = name
+        self.stack.set_visible_child_name(name)
+        self.back_btn.set_visible(not page.no_back_button)
+        self.next_btn.set_visible(not page.no_next_button)
+        self.set_ready(False)
+        if old is not None and old is not page:
+            old.set_page_inactive()
+        if activate:
+            page.set_page_active()
+
+
+class SetupApp(Adw.Application):
+    def __init__(self, defaults, installer, fullscreen=True):
+        super().__init__(application_id=APP_ID)
+        self._defaults = defaults
+        self._installer = installer
+        self._fullscreen = fullscreen
+
+    def do_activate(self):
+        win = self.get_active_window()
+        if win is None:
+            win = SetupWindow(self, self._defaults, self._installer,
+                              fullscreen=self._fullscreen)
+        win.present()
+
+
+def self_check(installer):
+    """Construct the Application and every page without presenting anything
+    (CI/dev smoke test; needs GTK to initialize, i.e. some display)."""
+    if not Gtk.init_check():
+        print("self-check: SKIP (no display available)", file=sys.stderr)
+        return 0
+    Adw.init()
+    try:
+        defaults = load_defaults(installer)
+        source = installer
+    except (OSError, RuntimeError, ValueError) as e:
+        defaults = model.Defaults(json.loads(json.dumps(_SELF_CHECK_DEFAULTS)))
+        source = "embedded fixture (%s)" % e
+    app = SetupApp(defaults, installer, fullscreen=False)
+    assert app.get_application_id() == APP_ID
+    # application=None: attaching a window to a not-yet-started GApplication
+    # triggers a Gtk-CRITICAL; construction coverage is identical.
+    win = SetupWindow(None, defaults, installer, fullscreen=False)
+    expected = set(model.page_sequence(None))
+    built = set(win.pages)
+    if built != expected:
+        print("self-check: FAIL (pages %r != %r)" % (built, expected),
+              file=sys.stderr)
+        return 1
+    # Exercise the welcome page's activation path (no subprocess spawns).
+    win.pages[model.PAGE_WELCOME].set_page_active()
+    print("self-check: OK (%d pages constructed; defaults from %s)" %
+          (len(win.pages), source))
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="snosi-setup")
+    parser.add_argument("--installer", default=None,
+                        help="path to snosi-install (default: "
+                             "$SNOSI_INSTALL or %s)" % model.INSTALLER_DEFAULT)
+    parser.add_argument("--self-check", action="store_true",
+                        help="construct the app + every page, then exit")
+    parser.add_argument("--windowed", action="store_true",
+                        help="do not fullscreen (development)")
+    args = parser.parse_args(argv)
+
+    import os
+    installer = args.installer or os.environ.get("SNOSI_INSTALL") \
+        or model.INSTALLER_DEFAULT
+
+    if args.self_check:
+        return self_check(installer)
+
+    try:
+        defaults = load_defaults(installer)
+    except (OSError, RuntimeError, ValueError) as e:
+        print("snosi-setup: cannot load installer defaults: %s" % e,
+              file=sys.stderr)
+        return 1
+    app = SetupApp(defaults, installer, fullscreen=not args.windowed)
+    return app.run(None)

--- a/shared/native-installer/setup-gui/setup_gui/data.py
+++ b/shared/native-installer/setup-gui/setup_gui/data.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# data.py -- locale / keyboard / timezone choice tables for snosi-setup.
+# NO GTK imports (see __init__.py).
+#
+# Ported PATTERNS (not code imported at runtime) from first-setup
+# (/home/bjk/projects/frostyard/first-setup) snow_first_setup/core/
+# {languages,keyboard,timezones}.py:
+#   - locales: parse /usr/share/i18n/SUPPORTED for UTF-8 locales, resolve a
+#     display name from the lang_name field of /usr/share/i18n/locales/<loc>
+#     (languages.py did the same, eagerly; we do it lazily with a cache).
+#   - keyboards: first-setup used GnomeDesktop.XkbInfo; the ISO should not
+#     need GnomeDesktop, so the same layout/variant inventory is read from
+#     /usr/share/X11/xkb/rules/evdev.lst (the file XkbInfo itself is fed
+#     from). Specs are LAYOUT or LAYOUT:VARIANT, matching snosi-install's
+#     KEYBOARD_RE triplet grammar.
+#   - timezones: first-setup used pytz + GWeather geolocation; the ISO
+#     needs neither -- Python's stdlib zoneinfo enumerates the system tzdata
+#     (fallback: /usr/share/zoneinfo/zone.tab), and there is no network
+#     geolocation lookup on an installer.
+#   - search_*: the same multi-term case-insensitive substring match with a
+#     result limit + "list shortened" flag as first-setup's search helpers.
+#
+# Every loader has a small embedded fallback so the wizard never renders an
+# empty picker even on a host missing the data files.
+
+import os
+
+SUPPORTED_PATH = "/usr/share/i18n/SUPPORTED"
+LOCALES_DIR = "/usr/share/i18n/locales"
+EVDEV_LST_PATH = "/usr/share/X11/xkb/rules/evdev.lst"
+ZONE_TAB_PATH = "/usr/share/zoneinfo/zone.tab"
+
+FALLBACK_LOCALES = [
+    "en_US.UTF-8", "en_GB.UTF-8", "de_DE.UTF-8", "fr_FR.UTF-8",
+    "es_ES.UTF-8", "it_IT.UTF-8", "pt_BR.UTF-8", "nl_NL.UTF-8",
+    "pl_PL.UTF-8", "ru_RU.UTF-8", "ja_JP.UTF-8", "ko_KR.UTF-8",
+    "zh_CN.UTF-8", "zh_TW.UTF-8", "sv_SE.UTF-8", "nb_NO.UTF-8",
+    "da_DK.UTF-8", "fi_FI.UTF-8", "cs_CZ.UTF-8", "tr_TR.UTF-8",
+]
+
+# (spec, display name); specs match snosi-install's KEYBOARD_RE.
+FALLBACK_KEYBOARDS = [
+    ("us", "English (US)"), ("gb", "English (UK)"), ("de", "German"),
+    ("fr", "French"), ("es", "Spanish"), ("it", "Italian"),
+    ("br", "Portuguese (Brazil)"), ("pt", "Portuguese (Portugal)"),
+    ("nl", "Dutch"), ("pl", "Polish"), ("ru", "Russian"),
+    ("jp", "Japanese"), ("kr", "Korean"), ("se", "Swedish"),
+    ("no", "Norwegian"), ("dk", "Danish"), ("fi", "Finnish"),
+    ("cz", "Czech"), ("tr", "Turkish"), ("ch", "German (Switzerland)"),
+]
+
+FALLBACK_TIMEZONES = [
+    "UTC", "America/New_York", "America/Chicago", "America/Denver",
+    "America/Los_Angeles", "America/Sao_Paulo", "Europe/London",
+    "Europe/Berlin", "Europe/Paris", "Europe/Madrid", "Europe/Rome",
+    "Europe/Amsterdam", "Europe/Warsaw", "Europe/Moscow", "Asia/Tokyo",
+    "Asia/Seoul", "Asia/Shanghai", "Asia/Kolkata", "Australia/Sydney",
+    "Pacific/Auckland",
+]
+
+_locale_display_cache = {}
+
+
+def load_locales():
+    """UTF-8 locale codes from /usr/share/i18n/SUPPORTED (first-setup
+    languages.py pattern), or the fallback list."""
+    locales = []
+    try:
+        with open(SUPPORTED_PATH, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) < 2 or "UTF-8" not in parts[1]:
+                    continue
+                loc = parts[0]
+                if loc not in locales:
+                    locales.append(loc)
+    except OSError:
+        pass
+    return locales or list(FALLBACK_LOCALES)
+
+
+def locale_display_name(loc):
+    """\"<lang_name> -- <code>\" when the locale definition file carries a
+    lang_name (same extraction first-setup languages.py performs), else the
+    bare code. Lazy + cached: only the rows actually rendered pay the file
+    read."""
+    if loc in _locale_display_cache:
+        return _locale_display_cache[loc]
+    name = ""
+    filename = os.path.join(LOCALES_DIR, loc.split(".")[0])
+    try:
+        with open(filename, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if line.startswith("lang_name"):
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        name = parts[1].strip().strip('"')
+                    break
+    except OSError:
+        pass
+    display = "%s — %s" % (name, loc) if name else loc
+    _locale_display_cache[loc] = display
+    return display
+
+
+def load_keyboards():
+    """[(spec, display)] from evdev.lst's `! layout` and `! variant`
+    sections; specs are LAYOUT or LAYOUT:VARIANT. Falls back to the
+    embedded table."""
+    layouts = []       # (code, name)
+    variants = []      # (layout:variant, name)
+    section = None
+    try:
+        with open(EVDEV_LST_PATH, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if line.startswith("!"):
+                    section = line[1:].strip()
+                    continue
+                line = line.rstrip("\n")
+                if not line.strip():
+                    continue
+                if section == "layout":
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        layouts.append((parts[0], parts[1].strip()))
+                elif section == "variant":
+                    parts = line.split(None, 1)
+                    if len(parts) != 2:
+                        continue
+                    variant = parts[0]
+                    rest = parts[1].strip()
+                    # "<layout>: <display name>"
+                    if ":" not in rest:
+                        continue
+                    layout, disp = rest.split(":", 1)
+                    variants.append(("%s:%s" % (layout.strip(), variant),
+                                     disp.strip()))
+    except OSError:
+        pass
+    if not layouts:
+        return list(FALLBACK_KEYBOARDS)
+    return layouts + variants
+
+
+def load_timezones():
+    """Sorted IANA timezone names, UTC first. stdlib zoneinfo enumerates the
+    system tzdata; zone.tab is the fallback for stripped systems, the
+    embedded list the last resort."""
+    names = set()
+    try:
+        import zoneinfo
+        names = {n for n in zoneinfo.available_timezones()
+                 if "/" in n or n == "UTC"}
+    except Exception:
+        pass
+    if not names:
+        try:
+            with open(ZONE_TAB_PATH, "r", encoding="utf-8",
+                      errors="replace") as f:
+                for line in f:
+                    if line.startswith("#"):
+                        continue
+                    parts = line.split("\t")
+                    if len(parts) >= 3:
+                        names.add(parts[2].strip())
+        except OSError:
+            pass
+    if not names:
+        return list(FALLBACK_TIMEZONES)
+    ordered = sorted(names)
+    if "UTC" in names:
+        ordered.remove("UTC")
+        ordered.insert(0, "UTC")
+    return ordered
+
+
+def search_choices(choices, term, limit=50):
+    """first-setup's search pattern: every whitespace-separated term must
+    substring-match (case-insensitive) the display text or the code.
+    Returns (matches, shortened). Empty term returns the head of the list."""
+    term_parts = term.lower().split()
+    matches = []
+    shortened = False
+    for code, display in choices:
+        if len(matches) >= limit:
+            shortened = True
+            break
+        hay = ("%s %s" % (code, display)).lower()
+        if all(p in hay for p in term_parts):
+            matches.append((code, display))
+    return matches, shortened

--- a/shared/native-installer/setup-gui/setup_gui/model.py
+++ b/shared/native-installer/setup-gui/setup_gui/model.py
@@ -1,0 +1,494 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# model.py -- pure-logic core of snosi-setup (NO GTK imports, ever; see
+# __init__.py). Everything a page needs to decide, validate, assemble, or
+# parse lives here so test/snosi-setup-model-test.py can cover it without a
+# display or GI bindings:
+#
+#   - Defaults / Product: the `snosi-install --print-defaults` document
+#     (proto 1), including the validation regexes the CLI itself enforces.
+#   - Disk / parse_disks: the `snosi-install --list-disks-json` document.
+#   - confirm_matches: byte-for-byte port of the CLI's
+#     confirm_typed_matches() (path exact-match, or non-empty serial
+#     exact-match) so the GUI's typed-erase gate can never accept something
+#     the CLI would then reject.
+#   - SetupState + build_install_argv: the one place the
+#     `snosi-install --non-interactive --json-progress ...` command line is
+#     assembled. Secrets NEVER appear on argv -- only --*-file paths.
+#   - ProgressParser: the --json-progress proto-1 line-delimited event
+#     stream (start/phase/log/error/done; unknown events and non-JSON lines
+#     are tolerated per the contract comment in snosi-install).
+#   - page_sequence: the wizard page order, with product-conditional skips.
+#   - write_secret_file / SecretFiles: 0600 tmpfiles under XDG_RUNTIME_DIR
+#     (fallback /run), created immediately before spawn and deleted in a
+#     finally block by the caller.
+
+import json
+import os
+import re
+import secrets as _secrets
+import stat
+
+INSTALLER_DEFAULT = "/usr/libexec/snosi-install"
+
+# ---------------------------------------------------------------------------
+# --print-defaults document (proto 1)
+# ---------------------------------------------------------------------------
+
+
+class Product:
+    def __init__(self, obj):
+        self.name = obj["name"]                      # e.g. "snow-ab"
+        self.bare = obj["bare"]                      # e.g. "snow"
+        self.minimum_disk_bytes = int(obj["minimum_disk_bytes"])
+        self.core_flatpaks_default = bool(obj["core_flatpaks_default"])
+        self.core_flatpaks_allowed = bool(obj["core_flatpaks_allowed"])
+
+
+class Defaults:
+    """Parsed `snosi-install --print-defaults` document."""
+
+    def __init__(self, doc):
+        proto = doc.get("proto")
+        if proto != 1:
+            raise ValueError("unsupported defaults document proto: %r" % (proto,))
+        self.proto = proto
+        self.products = [Product(p) for p in doc["products"]]
+        self.defaults = dict(doc["defaults"])        # locale/timezone/keyboard
+        self.origin_default = doc["origin_default"]
+        self.mok_cert_default = doc["mok_cert_default"]
+        self.regexes = dict(doc["regexes"])          # raw ERE strings
+
+    @classmethod
+    def from_json(cls, text):
+        return cls(json.loads(text))
+
+    def product(self, name):
+        for p in self.products:
+            if p.name == name:
+                return p
+        raise KeyError("unknown product: %r" % (name,))
+
+    def product_names(self):
+        return [p.name for p in self.products]
+
+    # -- validation -------------------------------------------------------
+    # snosi-install validates with bash `[[ =~ ]]` (POSIX ERE); the shipped
+    # patterns use only constructs Python's `re` interprets identically, and
+    # they carry their own ^...$ anchors, so re.search() mirrors bash.
+
+    def _matches(self, key, value):
+        return re.search(self.regexes[key], value) is not None
+
+    def valid_username(self, v):
+        return self._matches("username", v)
+
+    def valid_hostname(self, v):
+        return self._matches("hostname", v)
+
+    def valid_locale(self, v):
+        return self._matches("locale", v)
+
+    def valid_timezone(self, v):
+        return self._matches("timezone", v)
+
+    def valid_keyboard(self, v):
+        return self._matches("keyboard", v)
+
+    def valid_feature(self, v):
+        return self._matches("feature", v)
+
+
+# ---------------------------------------------------------------------------
+# --list-disks-json document
+# ---------------------------------------------------------------------------
+
+
+class Disk:
+    def __init__(self, obj):
+        self.path = obj["path"]
+        self.model = obj.get("model") or ""
+        self.serial = obj.get("serial") or ""
+        self.size_bytes = int(obj["size_bytes"])
+        self.transport = obj.get("transport") or ""
+        self.refusal = obj.get("refusal")            # None == installable
+
+    @property
+    def installable(self):
+        return self.refusal is None
+
+
+def parse_disks(text):
+    return [Disk(d) for d in json.loads(text)]
+
+
+def human_bytes(n):
+    """Binary-unit pretty printer for disk sizes (display only)."""
+    n = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if n < 1024 or unit == "TiB":
+            if unit == "B":
+                return "%d %s" % (int(n), unit)
+            return "%.1f %s" % (n, unit)
+        n /= 1024
+    raise AssertionError("unreachable")
+
+
+def confirm_matches(typed, path, serial):
+    """Exact port of snosi-install confirm_typed_matches(): the typed value
+    must equal the resolved disk's path, or (when the serial is non-empty)
+    its serial. An empty typed value never matches."""
+    if typed == "" or path == "":
+        return False
+    if typed == path:
+        return True
+    if serial != "" and typed == serial:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Wizard state + page flow
+# ---------------------------------------------------------------------------
+
+PAGE_WELCOME = "welcome"
+PAGE_NETWORK = "network"
+PAGE_LOCALE = "locale"
+PAGE_KEYBOARD = "keyboard"
+PAGE_TIMEZONE = "timezone"
+PAGE_HOSTNAME = "hostname"
+PAGE_USER = "user"
+PAGE_FEATURES = "features"
+PAGE_FLATPAKS = "flatpaks"
+PAGE_DISK = "disk"
+PAGE_CONFIRM = "confirm"
+PAGE_RECOVERY = "recovery"
+PAGE_MOK = "mok"
+PAGE_PROGRESS = "progress"
+PAGE_DONE = "done"
+
+_ALL_PAGES = [
+    PAGE_WELCOME, PAGE_NETWORK, PAGE_LOCALE, PAGE_KEYBOARD, PAGE_TIMEZONE,
+    PAGE_HOSTNAME, PAGE_USER, PAGE_FEATURES, PAGE_FLATPAKS, PAGE_DISK,
+    PAGE_CONFIRM, PAGE_RECOVERY, PAGE_MOK, PAGE_PROGRESS, PAGE_DONE,
+]
+
+
+def page_sequence(product=None):
+    """The wizard page order. The core-flatpaks page is dropped entirely for
+    products where core_flatpaks_allowed is false (the CLI dies on
+    --core-flatpaks for cayo-ab; the GUI never shows the choice)."""
+    pages = list(_ALL_PAGES)
+    if product is not None and not product.core_flatpaks_allowed:
+        pages.remove(PAGE_FLATPAKS)
+    return pages
+
+
+class SetupState:
+    """Everything the wizard collects. Plain data; pages mutate it, and
+    build_install_argv() consumes it."""
+
+    def __init__(self):
+        self.product = None            # Product
+        self.network_skipped = False
+        self.locale = None             # str or None (None == image default)
+        self.timezone = None
+        self.keyboard = None
+        self.hostname = None
+        self.username = None           # None == no first user
+        self.user_fullname = ""
+        self.user_password = None      # secret; NEVER placed on argv
+        self.features = []             # list[str]
+        self.core_flatpaks = None      # True/False/None (None == CLI default)
+        self.disk = None               # Disk
+        self.confirm_text = ""         # what the user typed on the erase gate
+        self.recovery_ack = False      # "I will save the passphrase" gate
+        self.recovery_key_file = None  # path this app chose (under /root)
+        self.mok_password = None       # secret; NEVER placed on argv
+        self.origin = None             # None == CLI default origin
+
+    def confirm_ok(self):
+        return self.disk is not None and confirm_matches(
+            self.confirm_text, self.disk.path, self.disk.serial)
+
+
+def default_recovery_key_path(product_name, now=None):
+    """A fresh path under /root for the generated recovery passphrase.
+    snosi-install refuses a pre-existing file, so embed a timestamp."""
+    import time
+    stamp = time.strftime("%Y%m%d%H%M%S", time.gmtime(now))
+    return "/root/%s-recovery-key-%s.txt" % (product_name, stamp)
+
+
+class StateError(ValueError):
+    """A SetupState that cannot be turned into a valid install command."""
+
+
+def validate_state(state, defaults):
+    """Full-state validation, run before command assembly. Returns a list of
+    human-readable problems (empty == good). Mirrors snosi-install's own
+    --non-interactive argument matrix so a GUI bug fails HERE, not minutes
+    into an install."""
+    problems = []
+    if state.product is None:
+        problems.append("no product selected")
+    if state.disk is None:
+        problems.append("no target disk selected")
+    elif state.disk.refusal is not None:
+        problems.append("selected disk is refused: %s" % state.disk.refusal)
+    if state.disk is not None and not state.confirm_ok():
+        problems.append("typed confirmation does not match the disk path or serial")
+    if not state.recovery_ack:
+        problems.append("recovery passphrase not acknowledged")
+    if not state.recovery_key_file:
+        problems.append("no recovery key file path chosen")
+    if not state.mok_password:
+        problems.append("no MOK password set")
+    if state.username is not None:
+        if not defaults.valid_username(state.username):
+            problems.append("invalid username %r" % state.username)
+        if not state.user_password:
+            problems.append("username set but no user password")
+    if state.hostname is not None and not defaults.valid_hostname(state.hostname):
+        problems.append("invalid hostname %r" % state.hostname)
+    if state.locale is not None and not defaults.valid_locale(state.locale):
+        problems.append("invalid locale %r" % state.locale)
+    if state.timezone is not None and not defaults.valid_timezone(state.timezone):
+        problems.append("invalid timezone %r" % state.timezone)
+    if state.keyboard is not None and not defaults.valid_keyboard(state.keyboard):
+        problems.append("invalid keyboard %r" % state.keyboard)
+    for feat in state.features:
+        if not defaults.valid_feature(feat):
+            problems.append("invalid feature name %r" % feat)
+    if state.product is not None and state.core_flatpaks and \
+            not state.product.core_flatpaks_allowed:
+        problems.append("core flatpaks are not allowed for %s" % state.product.name)
+    return problems
+
+
+def build_install_argv(state, defaults, user_password_file, mok_password_file,
+                       installer=INSTALLER_DEFAULT):
+    """Assemble the ONE snosi-install invocation. Secrets travel exclusively
+    via the two 0600 file paths; raising StateError on an invalid state is
+    the last line of defense (pages should have gated earlier)."""
+    problems = validate_state(state, defaults)
+    if problems:
+        raise StateError("; ".join(problems))
+    if not mok_password_file:
+        raise StateError("mok_password_file is required")
+    if state.username is not None and not user_password_file:
+        raise StateError("user_password_file is required when a username is set")
+
+    argv = [
+        installer,
+        "--non-interactive",
+        "--json-progress",
+        "--product", state.product.name,
+        "--disk", state.disk.path,
+        "--confirm", state.confirm_text,
+        "--encrypt-var",
+        "--recovery-key-file", state.recovery_key_file,
+        "--acknowledge-recovery-saved",
+        "--mok-password-file", mok_password_file,
+    ]
+    if state.origin is not None:
+        argv += ["--origin", state.origin]
+    if state.hostname is not None:
+        argv += ["--hostname", state.hostname]
+    if state.locale is not None:
+        argv += ["--locale", state.locale]
+    if state.timezone is not None:
+        argv += ["--timezone", state.timezone]
+    if state.keyboard is not None:
+        argv += ["--keyboard", state.keyboard]
+    if state.username is not None:
+        argv += ["--username", state.username,
+                 "--user-password-file", user_password_file]
+        if state.user_fullname:
+            argv += ["--user-fullname", state.user_fullname]
+    else:
+        argv += ["--no-create-user"]
+    for feat in state.features:
+        argv += ["--enable-feature", feat]
+    if state.product.core_flatpaks_allowed:
+        if state.core_flatpaks is True:
+            argv += ["--core-flatpaks"]
+        elif state.core_flatpaks is False:
+            argv += ["--no-core-flatpaks"]
+        # None: let the CLI apply its own default (currently: enabled).
+    else:
+        # Explicit is better: cayo-ab dies on --core-flatpaks, accepts
+        # --no-core-flatpaks as a no-op restatement of its forced policy.
+        argv += ["--no-core-flatpaks"]
+
+    # Belt and suspenders: no secret material may ever ride on argv.
+    for secret in (state.user_password, state.mok_password):
+        if secret and any(secret in a for a in argv):
+            raise StateError("secret material leaked onto argv")
+    return argv
+
+
+# ---------------------------------------------------------------------------
+# --json-progress proto-1 event stream
+# ---------------------------------------------------------------------------
+
+
+class Event:
+    def __init__(self, kind, data):
+        self.kind = kind    # start|phase|log|error|done|unknown
+        self.data = data
+
+    def __repr__(self):
+        return "Event(%r, %r)" % (self.kind, self.data)
+
+
+_KNOWN_EVENTS = ("start", "phase", "log", "error", "done")
+
+
+def parse_event(line):
+    """One line of installer stdout -> Event or None. Non-JSON lines and
+    JSON without an \"event\" key return None (the contract routes all
+    human-oriented output away from stdout in --json-progress mode, but a
+    tolerant reader costs nothing). Unknown event kinds come back as
+    kind=\"unknown\" -- the proto-1 grammar comment requires receivers to
+    ignore them so new events can be added compatibly."""
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        obj = json.loads(line)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict) or "event" not in obj:
+        return None
+    kind = obj["event"]
+    if kind not in _KNOWN_EVENTS:
+        return Event("unknown", obj)
+    return Event(kind, obj)
+
+
+class ProgressParser:
+    """Feed installer stdout lines; exposes the rolled-up install status the
+    progress page renders. Tail is bounded so a chatty install can't grow
+    memory without limit."""
+
+    LOG_TAIL_MAX = 400
+
+    def __init__(self):
+        self.proto = None
+        self.product = None
+        self.version = None
+        self.phase_id = None
+        self.phase_title = None
+        self.log_tail = []          # newest last; bounded
+        self.error = None           # first error message wins
+        self.done = None            # the done event dict, when seen
+        self.saw_start = False
+
+    def feed_line(self, line):
+        ev = parse_event(line)
+        if ev is None:
+            return None
+        if ev.kind == "start":
+            self.saw_start = True
+            self.proto = ev.data.get("proto")
+            self.product = ev.data.get("product")
+            self.version = ev.data.get("version")
+        elif ev.kind == "phase":
+            self.phase_id = ev.data.get("id")
+            self.phase_title = ev.data.get("title")
+        elif ev.kind == "log":
+            msg = ev.data.get("message", "")
+            if ev.data.get("level") == "warning":
+                msg = "Warning: " + msg
+            self._append_log(msg)
+        elif ev.kind == "error":
+            if self.error is None:
+                self.error = ev.data.get("message", "install failed")
+            self._append_log("Error: " + ev.data.get("message", ""))
+        elif ev.kind == "done":
+            self.done = ev.data
+        return ev
+
+    def _append_log(self, msg):
+        self.log_tail.append(msg)
+        if len(self.log_tail) > self.LOG_TAIL_MAX:
+            del self.log_tail[: len(self.log_tail) - self.LOG_TAIL_MAX]
+
+    @property
+    def succeeded(self):
+        return self.done is not None and self.error is None
+
+
+# ---------------------------------------------------------------------------
+# Secret files (0600, XDG_RUNTIME_DIR with /run fallback)
+# ---------------------------------------------------------------------------
+
+
+def runtime_secrets_dir():
+    """A root-only directory for secret tmpfiles. XDG_RUNTIME_DIR when set
+    and usable, else /run (the ISO runs everything as root; /run is a
+    tmpfs), else the system tempdir as a last resort. The snosi-setup
+    subdirectory is created 0700."""
+    base = os.environ.get("XDG_RUNTIME_DIR")
+    if not base or not os.path.isdir(base):
+        base = "/run" if os.path.isdir("/run") else None
+    if base is None:
+        import tempfile
+        base = tempfile.gettempdir()
+    d = os.path.join(base, "snosi-setup")
+    os.makedirs(d, mode=0o700, exist_ok=True)
+    os.chmod(d, 0o700)
+    return d
+
+
+def write_secret_file(content, label, directory=None):
+    """Create a fresh 0600 file containing `content` (one line, as the
+    installer reads with head -1) and return its path. O_EXCL so an existing
+    path is never silently reused."""
+    directory = directory or runtime_secrets_dir()
+    path = os.path.join(directory, "%s-%s" % (label, _secrets.token_hex(8)))
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, content.encode("utf-8"))
+        if not content.endswith("\n"):
+            os.write(fd, b"\n")
+    finally:
+        os.close(fd)
+    # Refuse to hand back anything a non-owner could read (paranoia against
+    # umask/ACL surprises; mirrors the CLI's check_secret_file_perms).
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    if mode & 0o077:
+        os.unlink(path)
+        raise OSError("secret file %s ended up mode %o" % (path, mode))
+    return path
+
+
+class SecretFiles:
+    """Context manager owning the per-install secret files: created on
+    entry-time writes, ALWAYS deleted on exit (the finally-block contract
+    from the plan)."""
+
+    def __init__(self, directory=None):
+        self._directory = directory
+        self.paths = []
+
+    def add(self, content, label):
+        path = write_secret_file(content, label, self._directory)
+        self.paths.append(path)
+        return path
+
+    def cleanup(self):
+        for path in self.paths:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        self.paths = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.cleanup()
+        return False

--- a/shared/native-installer/setup-gui/setup_gui/pages.py
+++ b/shared/native-installer/setup-gui/setup_gui/pages.py
@@ -1,0 +1,1080 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# pages.py -- the GTK4/libadwaita wizard pages of snosi-setup. All install
+# decisions/validation/argv assembly/event parsing live in model.py (no GTK
+# there); these classes only render state and mutate SetupState.
+#
+# Widget idioms (Adw.StatusPage + Adw.Clamp + PreferencesGroup/EntryRow/
+# PasswordEntryRow, per-page set_page_active/set_page_inactive/finish with
+# window.set_ready gating the Next button) are ported from first-setup's
+# views (window.py + views/*.py); no Gtk.Template/gresource -- everything is
+# built in code so there is no build step.
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gio, GLib, Gtk  # noqa: E402
+
+from . import data, model  # noqa: E402
+
+
+def _clamped(*children):
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+    for child in children:
+        box.append(child)
+    clamp = Adw.Clamp(maximum_size=560)
+    clamp.set_child(box)
+    return clamp
+
+
+class Page(Adw.Bin):
+    """Base page: window/state/defaults plumbing + the first-setup page
+    protocol (set_page_active/set_page_inactive/finish)."""
+
+    name = None
+    title = ""
+    no_back_button = False
+    no_next_button = False
+
+    def __init__(self, window):
+        super().__init__()
+        self.window = window
+        self.state = window.state
+        self.defaults = window.defaults
+        self.build()
+
+    def build(self):
+        raise NotImplementedError
+
+    def set_page_active(self):
+        self.window.set_ready(True)
+
+    def set_page_inactive(self):
+        pass
+
+    def finish(self):
+        """Commit page state into SetupState; False blocks navigation."""
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 1. Welcome / product picker
+# ---------------------------------------------------------------------------
+
+
+class WelcomePage(Page):
+    name = model.PAGE_WELCOME
+    title = "Welcome"
+    no_back_button = True
+
+    def build(self):
+        self._selected = None
+        status = Adw.StatusPage(
+            icon_name="computer-symbolic",
+            title="Install Snosi Linux",
+            description="Choose the product to install. The serial console "
+                        "always offers the text-mode installer as well.")
+        group = Adw.PreferencesGroup(title="Product")
+        first_radio = None
+        for product in self.defaults.products:
+            row = Adw.ActionRow(
+                title=product.name,
+                subtitle="needs at least %s of disk" %
+                         model.human_bytes(product.minimum_disk_bytes))
+            radio = Gtk.CheckButton(valign=Gtk.Align.CENTER, focusable=False)
+            if first_radio is None:
+                first_radio = radio
+            else:
+                radio.set_group(first_radio)
+            radio.connect("toggled", self._on_toggled, product.name)
+            row.add_prefix(radio)
+            row.set_activatable_widget(radio)
+            group.add(row)
+        status.set_child(_clamped(group))
+        self.set_child(status)
+
+    def _on_toggled(self, radio, name):
+        if radio.get_active():
+            self._selected = name
+            self.window.set_ready(True)
+
+    def set_page_active(self):
+        self.window.set_ready(self._selected is not None)
+
+    def finish(self):
+        if self._selected is None:
+            return False
+        self.state.product = self.defaults.product(self._selected)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 2. Network check (HEAD against the origin; skippable with a warning)
+# ---------------------------------------------------------------------------
+
+
+class NetworkPage(Page):
+    name = model.PAGE_NETWORK
+    title = "Network"
+
+    def build(self):
+        self._checking = False
+        self._ok = False
+        self.status = Adw.StatusPage(
+            icon_name="network-wired-symbolic",
+            title="Checking the download server…",
+            description="The installer downloads the OS image from\n%s" %
+                        self.defaults.origin_default)
+        self.spinner = Gtk.Spinner(spinning=True, width_request=32,
+                                   height_request=32,
+                                   halign=Gtk.Align.CENTER)
+        self.retry_btn = Gtk.Button(label="Check again",
+                                    halign=Gtk.Align.CENTER, visible=False)
+        self.retry_btn.connect("clicked", lambda *_: self._start_check())
+        self.skip_btn = Gtk.Button(label="Continue anyway (install will "
+                                         "fail without network)",
+                                   halign=Gtk.Align.CENTER, visible=False)
+        self.skip_btn.add_css_class("destructive-action")
+        self.skip_btn.connect("clicked", self._on_skip)
+        self.status.set_child(_clamped(self.spinner, self.retry_btn,
+                                       self.skip_btn))
+        self.set_child(self.status)
+
+    def set_page_active(self):
+        self.window.set_ready(self._ok)
+        if not self._ok:
+            self._start_check()
+
+    def _start_check(self):
+        if self._checking:
+            return
+        self._checking = True
+        self.spinner.set_visible(True)
+        self.spinner.start()
+        self.retry_btn.set_visible(False)
+        self.skip_btn.set_visible(False)
+        self.status.set_title("Checking the download server…")
+        try:
+            # A literal HEAD request against the origin, async on the GLib
+            # loop; curl ships on the ISO for snosi-install itself.
+            proc = Gio.Subprocess.new(
+                ["curl", "-fsI", "--connect-timeout", "10", "--max-time",
+                 "20", self.defaults.origin_default],
+                Gio.SubprocessFlags.STDOUT_SILENCE |
+                Gio.SubprocessFlags.STDERR_SILENCE)
+        except GLib.Error:
+            self._finish_check(False)
+            return
+        proc.wait_async(None, self._on_check_done)
+
+    def _on_check_done(self, proc, result):
+        try:
+            proc.wait_finish(result)
+            ok = proc.get_successful()
+        except GLib.Error:
+            ok = False
+        self._finish_check(ok)
+
+    def _finish_check(self, ok):
+        self._checking = False
+        self._ok = ok
+        self.spinner.stop()
+        self.spinner.set_visible(False)
+        if ok:
+            self.status.set_icon_name("emblem-ok-symbolic")
+            self.status.set_title("Download server reachable")
+            self.state.network_skipped = False
+            self.window.set_ready(True)
+        else:
+            self.status.set_icon_name("network-wired-disconnected-symbolic")
+            self.status.set_title("Cannot reach the download server")
+            self.retry_btn.set_visible(True)
+            self.skip_btn.set_visible(True)
+            self.window.set_ready(False)
+
+    def _on_skip(self, *_):
+        self.state.network_skipped = True
+        self._ok = True
+        self.window.set_ready(True)
+        self.window.advance()
+
+
+# ---------------------------------------------------------------------------
+# 3-5. Searchable choice pages (locale / keyboard / timezone)
+# ---------------------------------------------------------------------------
+
+
+class ChoicePage(Page):
+    """Shared searchable single-select list, the shape of first-setup's
+    language/keyboard/timezone pickers (search entry + rows, limit +
+    'shortened' hint)."""
+
+    icon_name = "preferences-desktop-locale-symbolic"
+    description = ""
+    RESULT_LIMIT = 60
+
+    def load_choices(self):
+        raise NotImplementedError  # -> [(code, display)]
+
+    def default_code(self):
+        raise NotImplementedError
+
+    def commit(self, code):
+        raise NotImplementedError
+
+    def build(self):
+        self._choices = None
+        self._selected = None
+        self._rows = []
+        self.status = Adw.StatusPage(icon_name=self.icon_name,
+                                     title=self.title,
+                                     description=self.description)
+        self.search = Gtk.SearchEntry(placeholder_text="Search…")
+        self.search.connect("search-changed", lambda *_: self._refresh())
+        self.listbox = Gtk.ListBox(selection_mode=Gtk.SelectionMode.SINGLE)
+        self.listbox.add_css_class("boxed-list")
+        self.listbox.connect("row-selected", self._on_row_selected)
+        scrolled = Gtk.ScrolledWindow(min_content_height=320,
+                                      max_content_height=420,
+                                      propagate_natural_height=True,
+                                      hscrollbar_policy=Gtk.PolicyType.NEVER)
+        scrolled.set_child(self.listbox)
+        self.hint = Gtk.Label(label="", halign=Gtk.Align.CENTER)
+        self.hint.add_css_class("dim-label")
+        self.status.set_child(_clamped(self.search, scrolled, self.hint))
+        self.set_child(self.status)
+
+    def set_page_active(self):
+        if self._choices is None:
+            self._choices = self.load_choices()
+            if self._selected is None:
+                self._selected = self.default_code()
+            self._refresh()
+        self.window.set_ready(self._selected is not None)
+
+    def _refresh(self):
+        matches, shortened = data.search_choices(
+            self._choices, self.search.get_text(), self.RESULT_LIMIT)
+        self.listbox.remove_all()
+        self._rows = []
+        select_row = None
+        for code, display in matches:
+            row = Gtk.ListBoxRow()
+            label = Gtk.Label(label="%s  (%s)" % (display, code),
+                              halign=Gtk.Align.START, margin_top=8,
+                              margin_bottom=8, margin_start=12,
+                              margin_end=12, ellipsize=3)  # PANGO_ELLIPSIZE_END
+            row.set_child(label)
+            row.code = code
+            self.listbox.append(row)
+            self._rows.append(row)
+            if code == self._selected:
+                select_row = row
+        if select_row is not None:
+            self.listbox.select_row(select_row)
+        self.hint.set_label(
+            "More matches than shown — refine the search." if shortened
+            else "")
+
+    def _on_row_selected(self, listbox, row):
+        if row is not None:
+            self._selected = row.code
+        self.window.set_ready(self._selected is not None)
+
+    def finish(self):
+        if self._selected is None:
+            return False
+        self.commit(self._selected)
+        return True
+
+
+class LocalePage(ChoicePage):
+    name = model.PAGE_LOCALE
+    title = "Language & Locale"
+    description = "System language and formats."
+
+    def load_choices(self):
+        return [(loc, data.locale_display_name(loc))
+                for loc in data.load_locales()]
+
+    def default_code(self):
+        return self.defaults.defaults.get("locale")
+
+    def commit(self, code):
+        self.state.locale = code
+
+
+class KeyboardPage(ChoicePage):
+    name = model.PAGE_KEYBOARD
+    title = "Keyboard"
+    icon_name = "input-keyboard-symbolic"
+    description = "Console and desktop keyboard layout."
+
+    def load_choices(self):
+        return data.load_keyboards()
+
+    def default_code(self):
+        return self.defaults.defaults.get("keyboard")
+
+    def commit(self, code):
+        self.state.keyboard = code
+
+
+class TimezonePage(ChoicePage):
+    name = model.PAGE_TIMEZONE
+    title = "Timezone"
+    icon_name = "preferences-system-time-symbolic"
+    description = "System timezone."
+
+    def load_choices(self):
+        return [(tz, tz.replace("_", " ")) for tz in data.load_timezones()]
+
+    def default_code(self):
+        return self.defaults.defaults.get("timezone")
+
+    def commit(self, code):
+        self.state.timezone = code
+
+
+# ---------------------------------------------------------------------------
+# 6. Hostname
+# ---------------------------------------------------------------------------
+
+
+class HostnamePage(Page):
+    name = model.PAGE_HOSTNAME
+    title = "Hostname"
+
+    def build(self):
+        self._defaulted = False
+        status = Adw.StatusPage(icon_name="network-server-symbolic",
+                                title="Hostname",
+                                description="The name this machine uses on "
+                                            "the network.")
+        group = Adw.PreferencesGroup()
+        self.entry = Adw.EntryRow(title="Hostname")
+        self.entry.connect("changed", lambda *_: self._validate())
+        group.add(self.entry)
+        self.error = Gtk.Label(
+            label="Letters, digits and inner hyphens only (max 63).",
+            halign=Gtk.Align.CENTER, opacity=0.0)
+        self.error.add_css_class("dim-label")
+        status.set_child(_clamped(group, self.error))
+        self.set_child(status)
+
+    def set_page_active(self):
+        if not self._defaulted and self.state.product is not None:
+            self.entry.set_text(self.state.product.bare)
+            self._defaulted = True
+        self._validate()
+
+    def _validate(self):
+        text = self.entry.get_text()
+        ok = self.defaults.valid_hostname(text)
+        if ok:
+            self.entry.remove_css_class("error")
+        else:
+            self.entry.add_css_class("error")
+        self.error.set_opacity(0.0 if ok else 1.0)
+        self.window.set_ready(ok)
+        return ok
+
+    def finish(self):
+        if not self._validate():
+            return False
+        self.state.hostname = self.entry.get_text()
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 7. First user
+# ---------------------------------------------------------------------------
+
+
+class UserPage(Page):
+    name = model.PAGE_USER
+    title = "First User"
+
+    def build(self):
+        status = Adw.StatusPage(
+            icon_name="system-users-symbolic", title="Create Your User",
+            description="An administrator account (sudo + desktop groups).")
+        group = Adw.PreferencesGroup()
+        self.fullname = Adw.EntryRow(title="Full name (optional)")
+        self.username = Adw.EntryRow(title="Username")
+        self.password = Adw.PasswordEntryRow(title="Password")
+        self.password2 = Adw.PasswordEntryRow(title="Confirm password")
+        for w in (self.fullname, self.username, self.password,
+                  self.password2):
+            w.connect("changed", lambda *_: self._validate())
+            group.add(w)
+        self.skip_user = Gtk.CheckButton(
+            label="Do not create a user account (headless/server setup)")
+        self.skip_user.connect("toggled", lambda *_: self._validate())
+        self.error = Gtk.Label(label="", halign=Gtk.Align.CENTER)
+        self.error.add_css_class("dim-label")
+        status.set_child(_clamped(group, self.skip_user, self.error))
+        self.set_child(status)
+
+    def set_page_active(self):
+        self._validate()
+
+    def _problem(self):
+        if self.skip_user.get_active():
+            return ""
+        username = self.username.get_text()
+        if not username:
+            return "Enter a username."
+        if not self.defaults.valid_username(username):
+            return ("Usernames start with a lowercase letter; lowercase, "
+                    "digits, - and _ only (max 32).")
+        if not self.password.get_text():
+            return "Enter a password."
+        if self.password.get_text() != self.password2.get_text():
+            return "Passwords do not match."
+        return ""
+
+    def _validate(self):
+        problem = self._problem()
+        skip = self.skip_user.get_active()
+        for w in (self.fullname, self.username, self.password,
+                  self.password2):
+            w.set_sensitive(not skip)
+        bad_user = (not skip and self.username.get_text() and
+                    not self.defaults.valid_username(self.username.get_text()))
+        if bad_user:
+            self.username.add_css_class("error")
+        else:
+            self.username.remove_css_class("error")
+        self.error.set_label(problem)
+        self.window.set_ready(problem == "")
+        return problem == ""
+
+    def finish(self):
+        if not self._validate():
+            return False
+        if self.skip_user.get_active():
+            self.state.username = None
+            self.state.user_password = None
+            self.state.user_fullname = ""
+        else:
+            self.state.username = self.username.get_text()
+            self.state.user_password = self.password.get_text()
+            self.state.user_fullname = self.fullname.get_text()
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 8. Sysext features
+# ---------------------------------------------------------------------------
+
+
+class FeaturesPage(Page):
+    name = model.PAGE_FEATURES
+    title = "Extensions"
+
+    def build(self):
+        self._features = []
+        status = Adw.StatusPage(
+            icon_name="application-x-addon-symbolic",
+            title="System Extensions",
+            description="Optional sysext features to enable on first boot "
+                        "(e.g. docker, tailscale, vscode). Leave empty to "
+                        "add none.")
+        entry_group = Adw.PreferencesGroup()
+        self.entry = Adw.EntryRow(title="Feature name")
+        self.entry.connect("entry-activated", self._on_add)
+        self.entry.connect("changed", lambda *_: self._validate_entry())
+        add_btn = Gtk.Button(icon_name="list-add-symbolic",
+                             valign=Gtk.Align.CENTER)
+        add_btn.add_css_class("flat")
+        add_btn.connect("clicked", self._on_add)
+        self.entry.add_suffix(add_btn)
+        entry_group.add(self.entry)
+        self.list_group = Adw.PreferencesGroup(title="Enabled at first boot")
+        self.list_group.set_visible(False)
+        self._rows = []
+        status.set_child(_clamped(entry_group, self.list_group))
+        self.set_child(status)
+
+    def _validate_entry(self):
+        text = self.entry.get_text()
+        if text and not self.defaults.valid_feature(text):
+            self.entry.add_css_class("error")
+        else:
+            self.entry.remove_css_class("error")
+
+    def _on_add(self, *_):
+        text = self.entry.get_text().strip()
+        if not text or not self.defaults.valid_feature(text):
+            return
+        if text in self._features:
+            self.entry.set_text("")
+            return
+        self._features.append(text)
+        row = Adw.ActionRow(title=text)
+        remove = Gtk.Button(icon_name="list-remove-symbolic",
+                            valign=Gtk.Align.CENTER)
+        remove.add_css_class("flat")
+        remove.connect("clicked", self._on_remove, row, text)
+        row.add_suffix(remove)
+        self.list_group.add(row)
+        self._rows.append(row)
+        self.list_group.set_visible(True)
+        self.entry.set_text("")
+
+    def _on_remove(self, _btn, row, text):
+        self._features.remove(text)
+        self.list_group.remove(row)
+        self._rows.remove(row)
+        self.list_group.set_visible(bool(self._rows))
+
+    def finish(self):
+        self.state.features = list(self._features)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 9. Core flatpaks (skipped entirely when the product disallows them)
+# ---------------------------------------------------------------------------
+
+
+class FlatpaksPage(Page):
+    name = model.PAGE_FLATPAKS
+    title = "Applications"
+
+    def build(self):
+        self._defaulted = False
+        status = Adw.StatusPage(
+            icon_name="system-software-install-symbolic",
+            title="Core Applications",
+            description="Install the core desktop Flatpak set on first "
+                        "boot (browser and essential apps).")
+        group = Adw.PreferencesGroup()
+        self.switch = Adw.SwitchRow(title="Install core Flatpaks")
+        group.add(self.switch)
+        status.set_child(_clamped(group))
+        self.set_child(status)
+
+    def set_page_active(self):
+        if not self._defaulted and self.state.product is not None:
+            self.switch.set_active(self.state.product.core_flatpaks_default)
+            self._defaulted = True
+        self.window.set_ready(True)
+
+    def finish(self):
+        self.state.core_flatpaks = self.switch.get_active()
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 10. Disk selection
+# ---------------------------------------------------------------------------
+
+
+class DiskPage(Page):
+    name = model.PAGE_DISK
+    title = "Disk"
+
+    def build(self):
+        self._disks = []
+        self._rows = []
+        self._selected = None
+        self.status = Adw.StatusPage(
+            icon_name="drive-harddisk-symbolic", title="Select Target Disk",
+            description="The ENTIRE selected disk will be erased.")
+        self.group = Adw.PreferencesGroup()
+        self.spinner = Gtk.Spinner(spinning=False, halign=Gtk.Align.CENTER)
+        self.empty = Gtk.Label(label="", halign=Gtk.Align.CENTER,
+                               visible=False)
+        self.status.set_child(_clamped(self.spinner, self.group, self.empty))
+        self.set_child(self.status)
+
+    def set_page_active(self):
+        self.window.set_ready(False)
+        self._refresh()
+
+    def _refresh(self):
+        for row in self._rows:
+            self.group.remove(row)
+        self._rows = []
+        self._selected = None
+        self.empty.set_visible(False)
+        self.spinner.set_visible(True)
+        self.spinner.start()
+        try:
+            proc = Gio.Subprocess.new(
+                [self.window.installer, "--list-disks-json",
+                 "--product", self.state.product.name],
+                Gio.SubprocessFlags.STDOUT_PIPE |
+                Gio.SubprocessFlags.STDERR_SILENCE)
+        except GLib.Error as e:
+            self._show_empty("Could not run the disk scan: %s" % e.message)
+            return
+        proc.communicate_utf8_async(None, None, self._on_disks)
+
+    def _on_disks(self, proc, result):
+        try:
+            _ok, stdout, _stderr = proc.communicate_utf8_finish(result)
+            disks = model.parse_disks(stdout)
+        except (GLib.Error, ValueError, KeyError) as e:
+            self._show_empty("Disk scan failed: %s" % e)
+            return
+        self.spinner.stop()
+        self.spinner.set_visible(False)
+        self._disks = disks
+        if not disks:
+            self._show_empty("No disks found.")
+            return
+        first_radio = None
+        for disk in disks:
+            title = "%s — %s" % (disk.path, model.human_bytes(disk.size_bytes))
+            bits = [b for b in (disk.model, disk.transport,
+                                "serial: %s" % disk.serial if disk.serial
+                                else "") if b]
+            row = Adw.ActionRow(title=title, subtitle="  ·  ".join(bits))
+            radio = Gtk.CheckButton(valign=Gtk.Align.CENTER, focusable=False)
+            if first_radio is None:
+                first_radio = radio
+            else:
+                radio.set_group(first_radio)
+            if disk.installable:
+                radio.connect("toggled", self._on_toggled, disk)
+                row.add_prefix(radio)
+                row.set_activatable_widget(radio)
+            else:
+                # Visible but not selectable, with the CLI's refusal reason.
+                row.add_prefix(radio)
+                row.set_subtitle("REFUSED: %s" % disk.refusal)
+                row.set_sensitive(False)
+            self.group.add(row)
+            self._rows.append(row)
+
+    def _show_empty(self, message):
+        self.spinner.stop()
+        self.spinner.set_visible(False)
+        self.empty.set_label(message)
+        self.empty.set_visible(True)
+        self.window.set_ready(False)
+
+    def _on_toggled(self, radio, disk):
+        if radio.get_active():
+            self._selected = disk
+            self.window.set_ready(True)
+
+    def finish(self):
+        if self._selected is None or not self._selected.installable:
+            return False
+        if self.state.disk is not self._selected:
+            # Changing disks invalidates a previously-typed confirmation.
+            self.state.confirm_text = ""
+        self.state.disk = self._selected
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 11. Typed erase confirmation
+# ---------------------------------------------------------------------------
+
+
+class ConfirmPage(Page):
+    name = model.PAGE_CONFIRM
+    title = "Confirm Erase"
+
+    def build(self):
+        self.status = Adw.StatusPage(
+            icon_name="dialog-warning-symbolic",
+            title="This Disk Will Be Erased",
+            description="")
+        group = Adw.PreferencesGroup()
+        self.entry = Adw.EntryRow(title="Type the disk path or serial")
+        self.entry.connect("changed", lambda *_: self._validate())
+        group.add(self.entry)
+        self.hint = Gtk.Label(label="", halign=Gtk.Align.CENTER)
+        self.hint.add_css_class("dim-label")
+        self.status.set_child(_clamped(group, self.hint))
+        self.set_child(self.status)
+
+    def set_page_active(self):
+        disk = self.state.disk
+        serial_bit = (" (serial %s)" % disk.serial) if disk.serial else ""
+        self.status.set_description(
+            "EVERYTHING on %s%s — %s, %s — will be permanently destroyed.\n"
+            "To continue, type its path%s exactly." % (
+                disk.path, serial_bit, disk.model or "unknown model",
+                model.human_bytes(disk.size_bytes),
+                " or serial" if disk.serial else ""))
+        self.entry.set_text(self.state.confirm_text)
+        self._validate()
+
+    def _validate(self):
+        typed = self.entry.get_text()
+        # Exactly the CLI's confirm_typed_matches(): path, or non-empty
+        # serial, exact string equality.
+        ok = model.confirm_matches(typed, self.state.disk.path,
+                                   self.state.disk.serial)
+        self.hint.set_label("" if ok or not typed else "Does not match.")
+        self.window.set_ready(ok)
+        return ok
+
+    def finish(self):
+        if not self._validate():
+            return False
+        self.state.confirm_text = self.entry.get_text()
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 12. Recovery key acknowledgement
+# ---------------------------------------------------------------------------
+
+
+class RecoveryPage(Page):
+    name = model.PAGE_RECOVERY
+    title = "Recovery Key"
+
+    def build(self):
+        self.status = Adw.StatusPage(
+            icon_name="dialog-password-symbolic",
+            title="/var Encryption Recovery Passphrase",
+            description="")
+        self.ack = Gtk.CheckButton(
+            label="I understand I must copy the recovery passphrase "
+                  "somewhere OFF this machine before rebooting")
+        self.ack.connect("toggled", lambda *_: self.window.set_ready(
+            self.ack.get_active()))
+        self.status.set_child(_clamped(self.ack))
+        self.set_child(self.status)
+
+    def set_page_active(self):
+        if self.state.recovery_key_file is None:
+            self.state.recovery_key_file = model.default_recovery_key_path(
+                self.state.product.name)
+        self.status.set_description(
+            "Your data partition (/var) is encrypted. A recovery passphrase "
+            "is generated during the install and is the ONLY way to unlock "
+            "your data if the TPM is unavailable or replaced.\n\n"
+            "It will be written to:\n%s\n\n"
+            "The passphrase is shown on the final screen after the install "
+            "completes. Copy it somewhere safe that is NOT this computer "
+            "(password manager, phone, paper)." % self.state.recovery_key_file)
+        self.window.set_ready(self.ack.get_active())
+
+    def finish(self):
+        if not self.ack.get_active():
+            return False
+        self.state.recovery_ack = True
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 13. MOK password
+# ---------------------------------------------------------------------------
+
+
+class MokPage(Page):
+    name = model.PAGE_MOK
+    title = "Secure Boot"
+
+    def build(self):
+        status = Adw.StatusPage(
+            icon_name="security-high-symbolic",
+            title="Secure Boot Enrollment Password",
+            description="On the next boot a blue \"MOK Management\" screen "
+                        "appears automatically. Choose \"Enroll MOK\", "
+                        "continue, and re-enter THIS password there once. "
+                        "The system cannot boot until that is done.")
+        group = Adw.PreferencesGroup()
+        self.password = Adw.PasswordEntryRow(title="One-time password")
+        self.password2 = Adw.PasswordEntryRow(title="Confirm password")
+        for w in (self.password, self.password2):
+            w.connect("changed", lambda *_: self._validate())
+            group.add(w)
+        self.error = Gtk.Label(label="", halign=Gtk.Align.CENTER)
+        self.error.add_css_class("dim-label")
+        status.set_child(_clamped(group, self.error))
+        self.set_child(status)
+
+    def set_page_active(self):
+        self._validate()
+
+    def _problem(self):
+        # The CLI requires a non-empty first line; min length 1.
+        if not self.password.get_text():
+            return "Enter a password."
+        if self.password.get_text() != self.password2.get_text():
+            return "Passwords do not match."
+        return ""
+
+    def _validate(self):
+        problem = self._problem()
+        self.error.set_label(problem)
+        self.window.set_ready(problem == "")
+        return problem == ""
+
+    def finish(self):
+        if not self._validate():
+            return False
+        self.state.mok_password = self.password.get_text()
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 14. Progress (the one privileged action: spawning snosi-install)
+# ---------------------------------------------------------------------------
+
+
+class ProgressPage(Page):
+    name = model.PAGE_PROGRESS
+    title = "Installing"
+    no_back_button = True
+    no_next_button = True   # window.advance() is driven by the done event
+
+    def build(self):
+        self._started = False
+        self._finished = False
+        self._secrets = None
+        self._proc = None
+        self.parser = None
+        self._stderr_tail = []
+        self._stdout_eof = False
+        self._exited = False
+        self._exit_ok = False
+        self.status = Adw.StatusPage(icon_name="emblem-synchronizing-symbolic",
+                                     title="Installing…", description="")
+        self.progress = Gtk.ProgressBar(show_text=False)
+        buf = Gtk.TextBuffer()
+        self.logview = Gtk.TextView(buffer=buf, editable=False,
+                                    cursor_visible=False, monospace=True)
+        self.logview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        scrolled = Gtk.ScrolledWindow(min_content_height=220,
+                                      max_content_height=280,
+                                      propagate_natural_height=True)
+        scrolled.set_child(self.logview)
+        scrolled.add_css_class("card")
+        self.quit_btn = Gtk.Button(label="Quit to console",
+                                   halign=Gtk.Align.CENTER, visible=False)
+        self.quit_btn.connect("clicked",
+                              lambda *_: self.window.get_application().quit())
+        self.status.set_child(_clamped(self.progress, scrolled,
+                                       self.quit_btn))
+        self.set_child(self.status)
+
+    def set_page_active(self):
+        self.window.set_ready(False)
+        if not self._started:
+            self._started = True
+            self._start_install()
+            GLib.timeout_add(150, self._pulse)
+
+    def _pulse(self):
+        if self._finished:
+            return False
+        self.progress.pulse()
+        return True
+
+    def _fail(self, message):
+        self._finished = True
+        if self._secrets is not None:
+            self._secrets.cleanup()
+            self._secrets = None
+        self.status.set_icon_name("dialog-error-symbolic")
+        self.status.set_title("Installation Failed")
+        self.status.set_description(message)
+        self.progress.set_visible(False)
+        self.quit_btn.set_visible(True)
+        self.window.set_ready(False)
+
+    def _start_install(self):
+        self.parser = model.ProgressParser()
+        # Secrets: written 0600 under XDG_RUNTIME_DIR (fallback /run)
+        # IMMEDIATELY before spawn; deleted in _on_exited (and _fail) no
+        # matter how the process ends. Never on argv, never logged.
+        self._secrets = model.SecretFiles()
+        try:
+            mok_file = self._secrets.add(self.state.mok_password, "mok")
+            user_file = None
+            if self.state.username is not None:
+                user_file = self._secrets.add(self.state.user_password,
+                                              "userpw")
+            argv = model.build_install_argv(
+                self.state, self.defaults, user_file, mok_file,
+                installer=self.window.installer)
+        except (model.StateError, OSError) as e:
+            self._fail("Could not assemble the install command:\n%s" % e)
+            return
+        try:
+            self._proc = Gio.Subprocess.new(
+                argv,
+                Gio.SubprocessFlags.STDOUT_PIPE |
+                Gio.SubprocessFlags.STDERR_PIPE)
+        except GLib.Error as e:
+            self._fail("Could not start the installer:\n%s" % e.message)
+            return
+        out = Gio.DataInputStream.new(self._proc.get_stdout_pipe())
+        err = Gio.DataInputStream.new(self._proc.get_stderr_pipe())
+        out.read_line_async(GLib.PRIORITY_DEFAULT, None,
+                            self._on_stdout_line)
+        err.read_line_async(GLib.PRIORITY_DEFAULT, None,
+                            self._on_stderr_line)
+        self._proc.wait_async(None, self._on_exited)
+
+    # -- stdout: the proto-1 JSON event stream (NEVER parse human text) ----
+    def _on_stdout_line(self, stream, result):
+        try:
+            line, _len = stream.read_line_finish_utf8(result)
+        except GLib.Error:
+            line = None
+        if line is None:
+            # EOF. The verdict needs BOTH this and process exit: wait_async
+            # can fire while buffered events (including "done") are still
+            # unread, so deciding at exit alone mis-reports success as
+            # failure (caught live by the headless drive-through).
+            self._stdout_eof = True
+            self._maybe_conclude()
+            return
+        ev = self.parser.feed_line(line)
+        if ev is not None:
+            self._render()
+        stream.read_line_async(GLib.PRIORITY_DEFAULT, None,
+                               self._on_stdout_line)
+
+    # -- stderr: kept only as failure diagnostics, never parsed ------------
+    def _on_stderr_line(self, stream, result):
+        try:
+            line, _len = stream.read_line_finish_utf8(result)
+        except GLib.Error:
+            return
+        if line is None:
+            return
+        self._stderr_tail.append(line)
+        del self._stderr_tail[:-30]
+        stream.read_line_async(GLib.PRIORITY_DEFAULT, None,
+                               self._on_stderr_line)
+
+    def _render(self):
+        p = self.parser
+        if p.phase_title:
+            self.status.set_title(p.phase_title)
+        if p.version:
+            self.status.set_description("%s %s" % (p.product or "",
+                                                   p.version))
+        buf = self.logview.get_buffer()
+        buf.set_text("\n".join(p.log_tail))
+        end = buf.get_end_iter()
+        self.logview.scroll_to_iter(end, 0.0, False, 0.0, 1.0)
+
+    def _on_exited(self, proc, result):
+        try:
+            proc.wait_finish(result)
+        except GLib.Error:
+            pass
+        # Secrets are only needed while the installer can still read them.
+        if self._secrets is not None:
+            self._secrets.cleanup()
+            self._secrets = None
+        self._exited = True
+        self._exit_ok = proc.get_successful()
+        self._maybe_conclude()
+
+    def _maybe_conclude(self):
+        if self._finished or not (self._exited and self._stdout_eof):
+            return
+        if self._exit_ok and self.parser.succeeded:
+            self._finished = True
+            self.progress.set_fraction(1.0)
+            self.window.advance()
+        else:
+            message = self.parser.error or "\n".join(self._stderr_tail[-8:]) \
+                or "The installer exited unexpectedly."
+            self._fail(message)
+
+
+# ---------------------------------------------------------------------------
+# 15. Done
+# ---------------------------------------------------------------------------
+
+
+class DonePage(Page):
+    name = model.PAGE_DONE
+    title = "Done"
+    no_back_button = True
+    no_next_button = True
+
+    def build(self):
+        self.status = Adw.StatusPage(icon_name="emblem-ok-symbolic",
+                                     title="Installation Complete",
+                                     description="")
+        self.key_label = Gtk.Label(label="", selectable=True, wrap=True,
+                                   halign=Gtk.Align.CENTER)
+        self.key_label.add_css_class("monospace")
+        self.key_label.add_css_class("title-2")
+        key_frame = Gtk.Frame()
+        key_frame.set_child(self.key_label)
+        self.key_note = Gtk.Label(label="", wrap=True,
+                                  halign=Gtk.Align.CENTER)
+        self.key_note.add_css_class("dim-label")
+        reboot = Gtk.Button(label="Reboot", halign=Gtk.Align.CENTER)
+        reboot.add_css_class("suggested-action")
+        reboot.add_css_class("pill")
+        reboot.connect("clicked", self._on_reboot)
+        quit_btn = Gtk.Button(label="Quit to console",
+                              halign=Gtk.Align.CENTER)
+        quit_btn.add_css_class("flat")
+        quit_btn.connect("clicked",
+                         lambda *_: self.window.get_application().quit())
+        self.status.set_child(_clamped(self.key_note, key_frame, reboot,
+                                       quit_btn))
+        self.set_child(self.status)
+
+    def set_page_active(self):
+        self.window.set_ready(False)
+        done = {}
+        progress_page = self.window.page_by_name(model.PAGE_PROGRESS)
+        if progress_page is not None and progress_page.parser is not None \
+                and progress_page.parser.done:
+            done = progress_page.parser.done
+        summary = "%s %s installed to %s." % (
+            done.get("product", self.state.product.name if self.state.product
+                     else "?"),
+            done.get("version", ""), done.get("disk", ""))
+        self.status.set_description(
+            "%s\n\nOn the next boot, enroll the Secure Boot key in the blue "
+            "MOK Management screen using the password you set." % summary)
+        # The recovery passphrase: read from the file the installer wrote
+        # (this app chose the path), displayed ONLY here, after the install.
+        passphrase = None
+        if self.state.recovery_key_file:
+            try:
+                with open(self.state.recovery_key_file, "r",
+                          encoding="utf-8") as f:
+                    passphrase = f.read().strip()
+            except OSError:
+                passphrase = None
+        if passphrase:
+            self.key_label.set_label(passphrase)
+            self.key_note.set_label(
+                "Your /var recovery passphrase (also at %s — that copy "
+                "vanishes at reboot). WRITE IT DOWN NOW, off this machine:" %
+                self.state.recovery_key_file)
+        else:
+            self.key_label.set_label("(recovery passphrase unavailable)")
+            self.key_note.set_label(
+                "Could not read %s — recover it from a console BEFORE "
+                "rebooting." % (self.state.recovery_key_file or "?"))
+
+    def _on_reboot(self, *_):
+        try:
+            Gio.Subprocess.new(["systemctl", "reboot"],
+                               Gio.SubprocessFlags.NONE)
+        except GLib.Error:
+            pass
+
+
+PAGE_CLASSES = {
+    cls.name: cls for cls in (
+        WelcomePage, NetworkPage, LocalePage, KeyboardPage, TimezonePage,
+        HostnamePage, UserPage, FeaturesPage, FlatpaksPage, DiskPage,
+        ConfirmPage, RecoveryPage, MokPage, ProgressPage, DonePage)
+}

--- a/shared/native-installer/setup-gui/snosi-setup
+++ b/shared/native-installer/setup-gui/snosi-setup
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# snosi-setup -- GTK4/libadwaita kiosk frontend for the snosi native
+# installer ISO (T2, docs/plans/2026-07-17-graphical-installer-plan.md).
+# Launched by cage on tty1; drives ONE `snosi-install --non-interactive
+# --json-progress` invocation. All logic lives in the adjacent setup_gui
+# package so this wrapper works both installed and straight from the tree.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+from setup_gui.app import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shared/native-installer/tree/usr/bin/snosi-setup
+++ b/shared/native-installer/tree/usr/bin/snosi-setup
@@ -1,0 +1,1 @@
+../lib/snosi-setup/snosi-setup

--- a/shared/native-installer/tree/usr/lib/systemd/system/multi-user.target.wants/snosi-setup.service
+++ b/shared/native-installer/tree/usr/lib/systemd/system/multi-user.target.wants/snosi-setup.service
@@ -1,0 +1,1 @@
+../snosi-setup.service

--- a/shared/native-installer/tree/usr/lib/systemd/system/snosi-setup.service
+++ b/shared/native-installer/tree/usr/lib/systemd/system/snosi-setup.service
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Graphical setup kiosk for the network-installer ISO (T3,
+# docs/plans/2026-07-17-graphical-installer-plan.md): cage running exactly
+# one client, snosi-setup, on tty1. The text-mode path is unaffected and
+# always available: serial-getty@ttyS0 is untouched, and this unit yields
+# tty1 back to getty whenever it cannot or should not run --
+#
+#   - no display hardware        -> ConditionPathExistsGlob fails, getty runs
+#   - snosi.textmode=1 cmdline   -> ConditionKernelCommandLine fails, getty runs
+#   - crashes 3x in 60s          -> start limit trips, OnFailure starts getty
+#
+# LIBSEAT_BACKEND=builtin: the ISO environment runs everything as root with
+# no logind session for this service; wlroots' builtin seat takes DRM/input
+# directly, avoiding seatd/PAM session choreography entirely.
+# WLR_NO_HARDWARE_CURSORS=1: virtio-vga/llvmpipe render without a hardware
+# cursor plane; without this the pointer is invisible on QEMU.
+[Unit]
+Description=snosi graphical setup (cage kiosk)
+ConditionPathExistsGlob=/dev/dri/card*
+ConditionKernelCommandLine=!snosi.textmode=1
+Conflicts=getty@tty1.service
+After=getty@tty1.service systemd-user-sessions.service
+OnFailure=getty@tty1.service
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/cage -- /usr/bin/snosi-setup
+Restart=on-failure
+RestartSec=2
+TTYPath=/dev/tty1
+StandardInput=tty-fail
+StandardOutput=journal
+StandardError=journal
+Environment=LIBSEAT_BACKEND=builtin
+Environment=WLR_NO_HARDWARE_CURSORS=1
+RuntimeDirectory=snosi-setup
+Environment=XDG_RUNTIME_DIR=/run/snosi-setup

--- a/shared/native-installer/tree/usr/lib/systemd/system/snosi-setup.service
+++ b/shared/native-installer/tree/usr/lib/systemd/system/snosi-setup.service
@@ -2,24 +2,32 @@
 #
 # Graphical setup kiosk for the network-installer ISO (T3,
 # docs/plans/2026-07-17-graphical-installer-plan.md): cage running exactly
-# one client, snosi-setup, on tty1. The text-mode path is unaffected and
-# always available: serial-getty@ttyS0 is untouched, and this unit yields
-# tty1 back to getty whenever it cannot or should not run --
+# one client, snosi-setup, on tty1.
 #
-#   - no display hardware        -> ConditionPathExistsGlob fails, getty runs
-#   - snosi.textmode=1 cmdline   -> ConditionKernelCommandLine fails, getty runs
-#   - crashes 3x in 60s          -> start limit trips, OnFailure starts getty
+# Activation is a STATIC wants link + unit Conditions (not a udev device
+# pull). Two conditions gate it, both evaluated when the statically-wanted
+# unit is about to start -- by which point udev coldplug has settled and
+# /dev/dri/card* exists if any display does:
+#   - no DRM device      -> ConditionPathExistsGlob fails -> getty runs
+#   - snosi.textmode=1    -> ConditionKernelCommandLine fails -> getty runs
 #
-# LIBSEAT_BACKEND=builtin: the ISO environment runs everything as root with
-# no logind session for this service; wlroots' builtin seat takes DRM/input
-# directly, avoiding seatd/PAM session choreography entirely.
-# WLR_NO_HARDWARE_CURSORS=1: virtio-vga/llvmpipe render without a hardware
-# cursor plane; without this the pointer is invisible on QEMU.
+# getty@tty1 is stopped IMPERATIVELY in ExecStartPre, NOT via Conflicts=:
+# Conflicts stops the conflicting unit at TRANSACTION build time, before this
+# unit's Conditions are evaluated, so a statically-wanted unit with Conflicts
+# kills getty even on the no-display boot where its own Condition then fails
+# (root-caused live 2026-07-17 across four activation designs;
+# test/snosi-setup-boot-test.sh leg 2 is the regression guard). ExecStartPre
+# runs only AFTER the Conditions pass, i.e. only when the kiosk really starts,
+# so the fallback boot never loses getty. A later kiosk crash that trips the
+# start limit hands tty1 back via OnFailure.
+#
+# LIBSEAT_BACKEND=builtin: the ISO runs everything as root with no logind
+# session here; wlroots' builtin seat takes DRM/input directly.
+# WLR_NO_HARDWARE_CURSORS=1: virtio-vga/llvmpipe have no hardware cursor plane.
 [Unit]
 Description=snosi graphical setup (cage kiosk)
 ConditionPathExistsGlob=/dev/dri/card*
 ConditionKernelCommandLine=!snosi.textmode=1
-Conflicts=getty@tty1.service
 After=getty@tty1.service systemd-user-sessions.service
 OnFailure=getty@tty1.service
 StartLimitIntervalSec=60
@@ -27,6 +35,7 @@ StartLimitBurst=3
 
 [Service]
 Type=simple
+ExecStartPre=-/usr/bin/systemctl stop getty@tty1.service
 ExecStart=/usr/bin/cage -- /usr/bin/snosi-setup
 Restart=on-failure
 RestartSec=2

--- a/shared/native-installer/tree/usr/libexec/snosi-install
+++ b/shared/native-installer/tree/usr/libexec/snosi-install
@@ -92,9 +92,75 @@ PUBRING="${SNOSI_INSTALL_PUBRING:-$PUBRING_DEFAULT}"
 # ---------------------------------------------------------------------------
 # Small helpers
 # ---------------------------------------------------------------------------
-log()  { printf '%s\n' "$*"; }
-warn() { printf 'Warning: %s\n' "$*" >&2; }
-die()  { printf 'Error: %s\n' "$*" >&2; exit 1; }
+# --json-progress (GUI contract, docs/plans/2026-07-17-graphical-installer-
+# plan.md): line-delimited JSON events on stdout, protocol 1. Grammar:
+#   {"event":"start","proto":1,"product":...,"version":...}
+#   {"event":"phase","id":...,"title":...}
+#   {"event":"log","level":"info"|"warning","message":...}
+#   {"event":"error","message":...}   (then exit non-zero)
+#   {"event":"done","product":...,"version":...,"disk":...}
+# Byte-level download progress is deliberately NOT part of proto 1 (the
+# download is a 5-stage shell pipeline with no clean byte hook); receivers
+# must ignore unknown event types so it can be added compatibly.
+JSON_PROGRESS=0
+json_event() { # jq-args...
+    [[ "$JSON_PROGRESS" == 1 ]] || return 0
+    jq -cn "$@"
+}
+log()  {
+    if [[ "$JSON_PROGRESS" == 1 ]]; then
+        jq -cn --arg m "$*" '{event:"log",level:"info",message:$m}'
+    else
+        printf '%s\n' "$*"
+    fi
+}
+warn() {
+    [[ "$JSON_PROGRESS" != 1 ]] || jq -cn --arg m "$*" '{event:"log",level:"warning",message:$m}'
+    printf 'Warning: %s\n' "$*" >&2
+}
+die()  {
+    [[ "$JSON_PROGRESS" != 1 ]] || jq -cn --arg m "$*" '{event:"error",message:$m}'
+    printf 'Error: %s\n' "$*" >&2
+    exit 1
+}
+json_phase() { # id title
+    json_event --arg id "$1" --arg title "$2" '{event:"phase",id:$id,title:$title}'
+}
+
+# print_defaults -- the GUI contract's static metadata document (products,
+# capacity floors, interactive defaults, validation regexes). Everything the
+# frontend needs so it never hardcodes what this script already knows.
+print_defaults() {
+    local p bare cf products="[]"
+    for p in "${VALID_PRODUCTS[@]}"; do
+        bare="${p%-ab}"
+        cf=true; [[ "$p" != "cayo-ab" ]] || cf=false
+        products="$(jq -cn --argjson acc "$products" --arg name "$p" --arg bare "$bare" \
+            --argjson min "$(minimum_disk_bytes "$bare")" --argjson cf "$cf" \
+            '$acc + [{name:$name, bare:$bare, minimum_disk_bytes:$min,
+                      core_flatpaks_default:$cf, core_flatpaks_allowed:$cf}]')"
+    done
+    jq -n --argjson products "$products" \
+        --arg origin "$ORIGIN_DEFAULT" --arg mok_cert "$MOK_CERT_DEFAULT" \
+        --arg u "$USERNAME_RE" --arg h "$HOSTNAME_RE" --arg l "$LOCALE_RE" \
+        --arg t "$TIMEZONE_RE" --arg k "$KEYBOARD_RE" --arg f "$FEATURE_RE" \
+        '{proto: 1, products: $products,
+          defaults: {locale: "en_US.UTF-8", timezone: "UTC", keyboard: "us"},
+          origin_default: $origin, mok_cert_default: $mok_cert,
+          regexes: {username: $u, hostname: $h, locale: $l,
+                    timezone: $t, keyboard: $k, feature: $f}}'
+}
+
+# list_disks_json min_bytes self_device -- list_installable_disks as JSON
+# (refusal: null means installable). Read-only; usable without root wherever
+# lsblk is.
+list_disks_json() { # min_bytes self_device
+    list_installable_disks "$1" "$2" |
+        jq -Rn '[inputs | split("|") |
+                 {path: .[0], model: .[1], serial: .[2],
+                  size_bytes: (.[3] | tonumber), transport: .[4],
+                  refusal: (if (.[5] // "") == "" then null else .[5] end)}]'
+}
 
 # rereadpt_settle disk -- tells the kernel to reread disk's partition table
 # (blockdev --rereadpt) and waits for udev to finish processing the
@@ -173,6 +239,12 @@ Install mode options:
                                 otherwise, in either mode)
   --non-interactive             Fully non-interactive; requires every
                                 security-relevant flag above
+  --json-progress               Emit line-delimited JSON events on stdout
+                                (GUI frontend contract, protocol 1)
+  --print-defaults              Print the GUI metadata document (products,
+                                defaults, validation regexes) as JSON; no install
+  --list-disks-json             Print installable disks (+ refusal reasons) as
+                                JSON; requires --product; no install
   --allow-file                  TEST ONLY: install target may be a regular
                                 file instead of a whole block device
   -h, --help                    Show this help
@@ -1213,6 +1285,7 @@ main() {
     local ssh_key="" do_reboot=0 non_interactive=0 allow_file=0
     local restage_mode=0
     local username="" user_password_file="" user_fullname="" no_create_user=0
+    local print_defaults_mode=0 list_disks_mode=0
     local set_hostname="" set_locale="" set_timezone="" set_keyboard=""
     local core_flatpaks=""
     local -a enable_features=()
@@ -1246,6 +1319,9 @@ main() {
             --no-core-flatpaks) core_flatpaks=0; shift ;;
             --reboot) do_reboot=1; shift ;;
             --non-interactive) non_interactive=1; shift ;;
+            --json-progress) JSON_PROGRESS=1; shift ;;
+            --print-defaults) print_defaults_mode=1; shift ;;
+            --list-disks-json) list_disks_mode=1; shift ;;
             --allow-file) allow_file=1; shift ;;
             -h|--help) usage ;;
             --) shift; break ;;
@@ -1256,6 +1332,20 @@ main() {
 
     if [[ "$restage_mode" == 1 ]]; then
         restage_mok "$non_interactive" "$mok_cert" "$mok_password_file" "$do_reboot" "$disk"
+        return
+    fi
+
+    # GUI-contract query modes: metadata only, no install, no root.
+    if [[ "$print_defaults_mode" == 1 ]]; then
+        print_defaults
+        return
+    fi
+    if [[ "$list_disks_mode" == 1 ]]; then
+        [[ -n "$product" ]] || die "--list-disks-json requires --product (capacity floor is product-shaped)"
+        local lp ok=0
+        for lp in "${VALID_PRODUCTS[@]}"; do [[ "$lp" == "$product" ]] && ok=1; done
+        [[ "$ok" -eq 1 ]] || die "--product must be one of: ${VALID_PRODUCTS[*]}"
+        list_disks_json "$(minimum_disk_bytes "${product%-ab}")" "$(self_boot_device)"
         return
     fi
 
@@ -1362,10 +1452,13 @@ main() {
     # shellcheck disable=SC2064 # intentional: expand $workdir NOW, see above
     trap "close_var_mapper; rm -rf '$workdir'" EXIT
 
+    json_phase index "Fetching and verifying the signed release index"
     fetch_verified_index "$origin" "$channel" "$workdir"
     local version
     version="$(latest_channel_version "$INDEX_FILE" "$channel")"
     [[ -n "$version" ]] || die "no published version found for $channel in the verified index"
+    json_event --arg product "$channel" --arg version "$version" \
+        '{event:"start",proto:1,product:$product,version:$version}'
 
     local disk_name disk_sha256
     disk_name="${channel}_${version}.disk.raw.xz"
@@ -1525,6 +1618,7 @@ main() {
     # -----------------------------------------------------------------
     # Download + write (plan steps 8-9)
     # -----------------------------------------------------------------
+    json_phase download "Downloading and writing the disk image"
     local disk_url="$INDEX_BASE_URL/$disk_name"
     log "Downloading and writing $disk_url to $RESOLVED_DISK_PATH..."
     stream_download_verify "$disk_url" "$disk_sha256" "$RESOLVED_DISK_PATH" ||
@@ -1548,6 +1642,7 @@ main() {
     # -----------------------------------------------------------------
     # Post-write layout sanity check, BEFORE any partition surgery
     # -----------------------------------------------------------------
+    json_phase layout "Validating and growing the partition layout"
     log "Validating the written disk's partition layout..."
     validate_disk_image_layout "$RESOLVED_DISK_PATH"
 
@@ -1569,6 +1664,7 @@ main() {
         die "--acknowledge-recovery-saved is required with /var encryption in --non-interactive mode"
     fi
 
+    json_phase var "Creating encrypted /var"
     log "Formatting /var..."
     local var_device
     var_device="$(format_var "$var_part" "$encrypt_var" "$recovery_key_file")"
@@ -1576,6 +1672,7 @@ main() {
     # -----------------------------------------------------------------
     # TPM enrollment (plan step 15)
     # -----------------------------------------------------------------
+    json_phase tpm "Enrolling TPM unlock"
     if [[ "$encrypt_var" == 1 ]]; then
         if [[ "$no_tpm" == 1 ]]; then
             log "Skipping TPM enrollment (--no-tpm). /var is only unlockable with the recovery passphrase."
@@ -1595,6 +1692,7 @@ main() {
     # -----------------------------------------------------------------
     # Record install metadata + optional SSH key (plan steps 18-19)
     # -----------------------------------------------------------------
+    json_phase seed "Applying system configuration"
     log "Recording install metadata..."
     seed_var "$var_device" "$bare_product" "$channel" "$version" "$arch" "$ssh_key"
 
@@ -1616,6 +1714,7 @@ main() {
     # -----------------------------------------------------------------
     # MOK enrollment (plan steps 16-17)
     # -----------------------------------------------------------------
+    json_phase mok "Staging Secure Boot MOK enrollment"
     if [[ "$skip_mok" == 1 ]]; then
         log "Skipping MOK enrollment (--skip-mok). Run 'snosi-install --restage-mok' before rebooting into the installed OS, or the MOK-signed boot chain will not be trusted."
     elif [[ "$allow_file" == 1 ]]; then
@@ -1641,6 +1740,8 @@ main() {
     # -----------------------------------------------------------------
     # Summary + reboot (plan steps 20-21)
     # -----------------------------------------------------------------
+    json_event --arg product "$channel" --arg version "$version" --arg disk "$RESOLVED_DISK_PATH" \
+        '{event:"done",product:$product,version:$version,disk:$disk}'
     log ""
     log "=== Install complete ==="
     log "Product:   $channel $version ($arch)"

--- a/test/native-installer-iso-test.sh
+++ b/test/native-installer-iso-test.sh
@@ -243,6 +243,23 @@ assert_contains "initrd contains gpgv (signed index verification)" "$(cat "$init
 # that happened to end in that literal string.
 assert_true "initrd contains cryptsetup" grep -q "usr/sbin/cryptsetup$" "$initrd_list"
 assert_true "initrd contains mokutil" grep -q "usr/bin/mokutil$" "$initrd_list"
+
+# --- graphical setup stack (T3, docs/plans/2026-07-17-graphical-installer-
+# plan.md): the kiosk pieces and the picker data files snosi-setup degrades
+# without. The live cage/GTK boot is the e2e --graphical leg, not this test.
+assert_true "initrd contains cage" grep -q "usr/bin/cage$" "$initrd_list"
+assert_true "initrd contains the snosi-setup launcher" grep -q "usr/bin/snosi-setup$" "$initrd_list"
+assert_true "initrd contains the setup_gui model" grep -q "usr/lib/snosi-setup/setup_gui/model.py$" "$initrd_list"
+assert_true "initrd contains python3-gi" grep -qE "usr/lib/python3/dist-packages/gi/__init__.py$" "$initrd_list"
+assert_true "initrd contains the Adw GIR typelib" grep -qE "Adw-1.typelib$" "$initrd_list"
+assert_true "initrd contains snosi-setup.service" grep -q "usr/lib/systemd/system/snosi-setup.service$" "$initrd_list"
+assert_true "initrd contains the snosi-setup static wants link" \
+    grep -q "usr/lib/systemd/system/multi-user.target.wants/snosi-setup.service$" "$initrd_list"
+assert_true "initrd contains Mesa DRI drivers (llvmpipe fallback)" grep -qE "dri/.*_dri.so|dri/libgallium" "$initrd_list"
+assert_true "initrd contains the locale picker data (locales SUPPORTED)" grep -q "usr/share/i18n/SUPPORTED$" "$initrd_list"
+assert_true "initrd contains the keyboard picker data (xkb evdev.lst)" grep -q "usr/share/X11/xkb/rules/evdev.lst$" "$initrd_list"
+assert_true "initrd contains zoneinfo (timezone picker)" grep -q "usr/share/zoneinfo/UTC$" "$initrd_list"
+assert_true "initrd contains Cantarell" grep -qE "fonts.*[Cc]antarell" "$initrd_list"
 assert_true "initrd contains the product-aware CLI installer" \
     grep -q "usr/libexec/snosi-install$" "$initrd_list"
 # cpio -t (no -v) lists names only, not symlink targets -- -tv is needed to

--- a/test/snosi-install-test.sh
+++ b/test/snosi-install-test.sh
@@ -272,6 +272,55 @@ run_installer "${BASE_ARGS[@]}" --hostname myhost --locale en_US.UTF-8 \
     --enable-feature tailscale
 assert_contains "valid system-settings args pass validation (reach root check)" "$RUN_OUT" "must run as root"
 
+# --- GUI contract query modes ---
+run_installer --print-defaults
+assert_eq "--print-defaults exits 0" "$RUN_RC" "0"
+PD_JSON="$RUN_OUT"
+assert_true "--print-defaults emits valid JSON" bash -c 'jq -e . >/dev/null <<<"$1"' _ "$PD_JSON"
+assert_eq "--print-defaults proto is 1" "$(jq -r .proto <<<"$PD_JSON")" "1"
+assert_eq "--print-defaults lists 3 products" "$(jq '.products | length' <<<"$PD_JSON")" "3"
+assert_eq "--print-defaults: cayo core flatpaks not allowed" \
+    "$(jq -r '.products[] | select(.name == "cayo-ab") | .core_flatpaks_allowed' <<<"$PD_JSON")" "false"
+assert_eq "--print-defaults: snow core flatpaks default on" \
+    "$(jq -r '.products[] | select(.name == "snow-ab") | .core_flatpaks_default' <<<"$PD_JSON")" "true"
+assert_eq "--print-defaults: snow minimum disk matches minimum_disk_bytes" \
+    "$(jq -r '.products[] | select(.name == "snow-ab") | .minimum_disk_bytes' <<<"$PD_JSON")" \
+    "$(call_fn minimum_disk_bytes snow)"
+assert_true "--print-defaults carries the username regex" \
+    bash -c "jq -e '.regexes.username | length > 0' >/dev/null <<<'$PD_JSON'"
+
+run_installer --list-disks-json
+assert_true "--list-disks-json without --product: exits non-zero" bash -c "[[ $RUN_RC -ne 0 ]]"
+assert_contains "--list-disks-json without --product: clear error" "$RUN_OUT" "requires --product"
+
+run_installer --list-disks-json --product bogus
+assert_contains "--list-disks-json bogus product rejected" "$RUN_OUT" "must be one of"
+
+# Minimal lsblk fixture, scoped to this block (the main disk-refusal fixture
+# is created later in this file).
+cat >"$WORK_DIR/ldj-lsblk.json" <<'LDJEOF'
+{"blockdevices": [
+  {"name": "sdz", "path": "/dev/sdz", "type": "disk", "model": "TestDisk",
+   "serial": "LDJ123", "size": 64000000000, "tran": "sata", "rm": false, "ro": false},
+  {"name": "sdy", "path": "/dev/sdy", "type": "disk", "model": "TinyDisk",
+   "serial": "LDJ124", "size": 2000000000, "tran": "usb", "rm": true, "ro": false}
+]}
+LDJEOF
+set +e
+LDJ_OUT="$(SNOSI_INSTALL_LSBLK_JSON="$WORK_DIR/ldj-lsblk.json" "$INSTALLER" --list-disks-json --product cayo-ab 2>/dev/null)"
+LDJ_RC=$?
+set -e
+assert_eq "--list-disks-json (fixture) exits 0" "$LDJ_RC" "0"
+assert_true "--list-disks-json emits a JSON array" bash -c 'jq -e "type == \"array\"" >/dev/null <<<"$1"' _ "$LDJ_OUT"
+assert_eq "--list-disks-json lists both fixture disks" "$(jq length <<<"$LDJ_OUT")" "2"
+assert_eq "--list-disks-json: big disk installable (refusal null)" \
+    "$(jq -r '.[] | select(.path == "/dev/sdz") | .refusal' <<<"$LDJ_OUT")" "null"
+assert_true "--list-disks-json: tiny disk carries a refusal reason" \
+    bash -c 'jq -e ".[] | select(.path == \"/dev/sdy\") | .refusal | length > 0" >/dev/null <<<"$1"' _ "$LDJ_OUT"
+
+run_installer --json-progress "${BASE_ARGS[@]}" --product bogus-product
+assert_contains "--json-progress: die emits an error event" "$RUN_OUT" '{"event":"error"'
+
 # --insecure-raw-var must NOT demand recovery-key-file/ack.
 mapfile -t ARGS_RAW_VAR < <(without_flag --recovery-key-file 1)
 run_installer "${ARGS_RAW_VAR[@]}" --insecure-raw-var

--- a/test/snosi-setup-boot-test.sh
+++ b/test/snosi-setup-boot-test.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Live QEMU smoke test for the graphical setup kiosk (T4,
+# docs/plans/2026-07-17-graphical-installer-plan.md): boots the REAL
+# network-installer ISO under enforced Secure Boot twice --
+#
+#   Leg 1 (virtio-vga attached): /dev/dri/card* exists, so
+#     snosi-setup.service must start cage, cage must be running the
+#     snosi-setup GTK app (llvmpipe -- no host GPU needed), and
+#     getty@tty1 must have yielded (Conflicts=). The serial console
+#     (serial-getty@ttyS0) must be untouched either way.
+#   Leg 2 (no display device): the unit's ConditionPathExistsGlob fails,
+#     snosi-setup must NOT run, and getty@tty1 must own tty1 -- the
+#     text-mode fallback the plan requires proven, not assumed.
+#
+# What this deliberately does NOT cover: driving the wizard pages (the
+# model test covers the logic; a human pass covers the pixels, checklist
+# §9), and the snosi.textmode=1 cmdline escape hatch (needs grub surgery;
+# covered by the same human pass).
+#
+# Requires: root, KVM, swtpm not needed (no install happens), OVMF secboot
+# firmware, and either an existing output/native-installer rootfs or ~8min
+# for a fresh mkosi build. Local-only (root/KVM), like every QEMU harness
+# in this repo -- not wired into validate.yml.
+#
+# Usage: sudo ./test/snosi-setup-boot-test.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SSH_PORT="${SSH_PORT:-2237}"
+
+PASS=0
+FAIL=0
+pass() { echo "ok - $1"; PASS=$((PASS + 1)); }
+fail() { echo "not ok - $1${2:+ ($2)}"; FAIL=$((FAIL + 1)); }
+assert_true() { local d="$1"; shift; if "$@"; then pass "$d"; else fail "$d"; fi; }
+assert_eq() { if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected '$3', got '$2'"; fi; }
+
+[[ $EUID -eq 0 ]] || { echo "Error: must run as root (KVM + loop devices)" >&2; exit 1; }
+for cmd in qemu-system-x86_64 ssh-keygen cpio zstd; do
+    command -v "$cmd" >/dev/null || { echo "Error: required command not found: $cmd" >&2; exit 1; }
+done
+OVMF_CODE=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd
+OVMF_VARS=/usr/share/OVMF/OVMF_VARS_4M.ms.fd
+[[ -f "$OVMF_CODE" && -f "$OVMF_VARS" ]] || { echo "Error: OVMF secboot firmware not found" >&2; exit 1; }
+
+WORK_DIR="$(mktemp -d /var/tmp/snosi-setup-boot-test.XXXXXX)"
+QEMU_PID=""
+cleanup() {
+    [[ -z "$QEMU_PID" ]] || kill "$QEMU_PID" 2>/dev/null || true
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Build the ISO with an ephemeral SSH key injected (same technique as
+# test/native-installer-e2e-test.sh -- the key must be in the packed rootfs).
+# ---------------------------------------------------------------------------
+ROOTFS="$ROOT_DIR/output/native-installer"
+if [[ ! -d "$ROOTFS" ]]; then
+    echo "Building the native-installer rootfs (no existing $ROOTFS)..."
+    (cd "$ROOT_DIR" && ./.mkosi/bin/mkosi --profile native-installer build >/dev/null)
+fi
+[[ -f "$ROOTFS/usr/bin/snosi-setup" || -L "$ROOTFS/usr/bin/snosi-setup" ]] ||
+    { echo "Error: rootfs predates the GUI stack (no /usr/bin/snosi-setup); rebuild it" >&2; exit 1; }
+# Staleness guard: a reused rootfs must carry the CURRENT activation design.
+# ExtraTrees changes do NOT reach an existing output/ tree (caught live: a
+# rerun against a pre-udev-rule rootfs tested yesterday's semantics), so
+# refuse rather than silently test the wrong artifact.
+[[ -L "$ROOTFS/usr/lib/systemd/system/multi-user.target.wants/snosi-setup.service" ]] ||
+    { echo "Error: rootfs predates the snosi-setup static wants link; run 'mkosi --profile native-installer clean' and rerun" >&2; exit 1; }
+
+ssh-keygen -t ed25519 -N "" -q -f "$WORK_DIR/id"
+install -d -m 700 "$ROOTFS/root/.ssh"
+install -m 600 "$WORK_DIR/id.pub" "$ROOTFS/root/.ssh/authorized_keys"
+
+VERSION="$(date -u +%Y%m%d%H%M%S)"
+echo "Assembling ISO ($VERSION)..."
+"$ROOT_DIR/shared/native-installer/tools/build-iso.sh" "$ROOTFS" "$WORK_DIR" "$VERSION" >/dev/null
+ISO="$WORK_DIR/snosi-native-installer_${VERSION}_x86-64.iso"
+[[ -f "$ISO" ]] || { echo "Error: ISO not produced" >&2; exit 1; }
+
+cp "$OVMF_VARS" "$WORK_DIR/vars.fd"
+
+boot_vm() { # extra qemu args...
+    qemu-system-x86_64 \
+        -machine q35,smm=on -enable-kvm -cpu host -smp 4 -m 4096 \
+        -vga none \
+        -global driver=cfi.pflash01,property=secure,value=on \
+        -drive "if=pflash,format=raw,readonly=on,file=$OVMF_CODE" \
+        -drive "if=pflash,format=raw,file=$WORK_DIR/vars.fd" \
+        -drive "file=$ISO,media=cdrom,readonly=on" \
+        -netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
+        -device virtio-net-pci,netdev=net0 \
+        -serial "file:$WORK_DIR/console.log" \
+        -pidfile "$WORK_DIR/qemu.pid" -daemonize "$@"
+    QEMU_PID="$(cat "$WORK_DIR/qemu.pid")"
+}
+
+vm_ssh() {
+    ssh -i "$WORK_DIR/id" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        -o ConnectTimeout=5 -o LogLevel=ERROR -p "$SSH_PORT" root@localhost "$@"
+}
+
+wait_ssh() {
+    local t=0
+    until vm_ssh true 2>/dev/null; do
+        sleep 5; t=$((t + 5))
+        [[ $t -lt 300 ]] || { echo "SSH timeout" >&2; tail -5 "$WORK_DIR/console.log" >&2; return 1; }
+    done
+}
+
+stop_vm() {
+    vm_ssh poweroff 2>/dev/null || true
+    local t=0
+    while kill -0 "$QEMU_PID" 2>/dev/null; do
+        sleep 2; t=$((t + 2))
+        [[ $t -lt 60 ]] || { kill "$QEMU_PID" 2>/dev/null || true; break; }
+    done
+    QEMU_PID=""
+}
+
+# ---------------------------------------------------------------------------
+# Leg 1: display attached -> kiosk must run
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Leg 1: virtio-vga attached (kiosk expected) ==="
+# -vga none in boot_vm suppresses QEMU's implicit default VGA (which would
+# otherwise give leg 2 a surprise /dev/dri/card0); virtio-vga here is then
+# the ONLY display adapter.
+boot_vm -device virtio-vga -display none
+wait_ssh
+assert_true "guest has a DRM device" vm_ssh 'ls /dev/dri/card* >/dev/null 2>&1'
+assert_eq "snosi-setup.service is active" "$(vm_ssh 'systemctl is-active snosi-setup.service' 2>/dev/null)" "active"
+assert_true "cage compositor is running" vm_ssh 'pgrep -x cage >/dev/null'
+# Bracket-trick the compositor's client so pgrep does not match its own
+# pattern-bearing command line; cage's cmdline is "cage -- /usr/bin/snosi-setup".
+assert_true "snosi-setup GTK app is running under cage" \
+    vm_ssh 'pgrep -f "[c]age -- /usr/bin/snosi-setup" >/dev/null && pgrep -af python3 | grep -q snosi-setup'
+assert_eq "getty@tty1 yielded to the kiosk (ExecStartPre stop)" \
+    "$(vm_ssh 'systemctl is-active getty@tty1.service' 2>/dev/null)" "inactive"
+assert_eq "serial-getty@ttyS0 untouched" \
+    "$(vm_ssh 'systemctl is-active serial-getty@ttyS0.service' 2>/dev/null)" "active"
+# The app must SURVIVE, not just start: a GTK/GI import crash respawns then
+# trips the start limit -- 10 seconds is beyond RestartSec*Burst churn.
+sleep 10
+assert_eq "snosi-setup.service still active after 10s (no crash loop)" \
+    "$(vm_ssh 'systemctl is-active snosi-setup.service' 2>/dev/null)" "active"
+assert_eq "no failed units with the kiosk up" "$(vm_ssh 'systemctl --failed --no-legend | wc -l' 2>/dev/null)" "0"
+stop_vm
+
+# ---------------------------------------------------------------------------
+# Leg 2: no display device -> text-mode fallback must hold
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Leg 2: no display device (getty fallback expected) ==="
+cp "$OVMF_VARS" "$WORK_DIR/vars.fd"   # fresh varstore; boot entry hygiene
+boot_vm -display none
+wait_ssh
+assert_true "guest has NO DRM device" vm_ssh '! ls /dev/dri/card* >/dev/null 2>&1'
+assert_eq "snosi-setup.service did not run (condition)" \
+    "$(vm_ssh 'systemctl is-active snosi-setup.service' 2>/dev/null)" "inactive"
+assert_true "snosi-setup Condition failed cleanly (no display, not a failure)" \
+    vm_ssh '[[ "$(systemctl show snosi-setup.service -p ConditionResult --value)" == no && "$(systemctl show snosi-setup.service -p Result --value)" == success ]]'
+assert_eq "getty@tty1 owns tty1" "$(vm_ssh 'systemctl is-active getty@tty1.service' 2>/dev/null)" "active"
+assert_eq "no failed units in text mode" "$(vm_ssh 'systemctl --failed --no-legend | wc -l' 2>/dev/null)" "0"
+stop_vm
+
+echo ""
+echo "# Results: $PASS passed, $FAIL failed, $((PASS + FAIL)) total"
+[[ "$FAIL" -eq 0 ]]

--- a/test/snosi-setup-model-test.py
+++ b/test/snosi-setup-model-test.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Static, non-root, no-GTK regression test for the snosi-setup frontend's
+# pure-logic core (shared/native-installer/setup-gui/setup_gui/model.py; T2,
+# docs/plans/2026-07-17-graphical-installer-plan.md). Covers:
+#
+#   - the --print-defaults document (parsed from an embedded FIXTURE that is
+#     a verbatim capture of the real script's output, plus a live-drift
+#     check against the in-tree snosi-install when it is runnable)
+#   - validation against the regexes the CLI itself enforces
+#   - install command assembly (exact argv, secrets only ever via --*-file)
+#   - --json-progress proto-1 event-stream parsing (start/phase/log/error/
+#     done, unknown-event and non-JSON tolerance)
+#   - --list-disks-json parsing with refusal handling
+#   - the typed-erase confirmation matcher (CLI confirm_typed_matches port)
+#   - secret tmpfile creation/permissions/cleanup
+#   - page-flow sequencing (core-flatpaks page dropped for cayo-ab)
+#   - py_compile of every setup-gui file (+ pyflakes when available)
+#
+# Usage: python3 test/snosi-setup-model-test.py
+
+import json
+import os
+import py_compile
+import stat
+import subprocess
+import sys
+import tempfile
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+SETUP_GUI_DIR = os.path.join(ROOT_DIR, "shared/native-installer/setup-gui")
+INSTALLER = os.path.join(ROOT_DIR,
+                         "shared/native-installer/tree/usr/libexec/"
+                         "snosi-install")
+
+sys.path.insert(0, SETUP_GUI_DIR)
+from setup_gui import data, model  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def ok(desc, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print("ok - %s" % desc)
+    else:
+        FAIL += 1
+        print("not ok - %s%s" % (desc, (" [%s]" % detail) if detail else ""))
+
+
+def eq(desc, actual, expected):
+    ok(desc, actual == expected,
+       "expected %r, got %r" % (expected, actual))
+
+
+# ---------------------------------------------------------------------------
+# FIXTURE: verbatim `snosi-install --print-defaults` output (captured
+# 2026-07-17 from shared/native-installer/tree/usr/libexec/snosi-install).
+# The live-drift check below fails when the real script diverges.
+# ---------------------------------------------------------------------------
+FIXTURE_DEFAULTS = r"""
+{
+  "proto": 1,
+  "products": [
+    {
+      "name": "cayo-ab",
+      "bare": "cayo",
+      "minimum_disk_bytes": 16642998272,
+      "core_flatpaks_default": false,
+      "core_flatpaks_allowed": false
+    },
+    {
+      "name": "snow-ab",
+      "bare": "snow",
+      "minimum_disk_bytes": 23085449216,
+      "core_flatpaks_default": true,
+      "core_flatpaks_allowed": true
+    },
+    {
+      "name": "snowfield-ab",
+      "bare": "snowfield",
+      "minimum_disk_bytes": 23085449216,
+      "core_flatpaks_default": true,
+      "core_flatpaks_allowed": true
+    }
+  ],
+  "defaults": {
+    "locale": "en_US.UTF-8",
+    "timezone": "UTC",
+    "keyboard": "us"
+  },
+  "origin_default": "https://repository.frostyard.org",
+  "mok_cert_default": "/usr/lib/snosi/mok.crt",
+  "regexes": {
+    "username": "^[a-z][a-z0-9_-]{0,31}$",
+    "hostname": "^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+    "locale": "^[A-Za-z][A-Za-z0-9_.@-]*$",
+    "timezone": "^[A-Za-z0-9_+-]+(/[A-Za-z0-9_+-]+){0,2}$",
+    "keyboard": "^[a-z0-9,]+(:[A-Za-z0-9,_-]*(:[A-Za-z0-9_-]+)?)?$",
+    "feature": "^[A-Za-z0-9._-]+$"
+  }
+}
+"""
+
+FIXTURE_DISKS = r"""
+[
+  {"path": "/dev/vda", "model": "TestDisk", "serial": "SER123",
+   "size_bytes": 34359738368, "transport": "virtio", "refusal": null},
+  {"path": "/dev/vdb", "model": "SmallDisk", "serial": "",
+   "size_bytes": 1073741824, "transport": "virtio",
+   "refusal": "smaller than the 15.5 GiB minimum for this product"},
+  {"path": "/dev/vdc", "model": "BootMedium", "serial": "ISOSER",
+   "size_bytes": 34359738368, "transport": "usb",
+   "refusal": "this is the installer's own boot medium"}
+]
+"""
+
+# ---------------------------------------------------------------------------
+# 0. py_compile every shipped file (+ pyflakes when available)
+# ---------------------------------------------------------------------------
+files = [
+    os.path.join(SETUP_GUI_DIR, "snosi-setup"),
+    os.path.join(SETUP_GUI_DIR, "setup_gui/__init__.py"),
+    os.path.join(SETUP_GUI_DIR, "setup_gui/__main__.py"),
+    os.path.join(SETUP_GUI_DIR, "setup_gui/model.py"),
+    os.path.join(SETUP_GUI_DIR, "setup_gui/data.py"),
+    os.path.join(SETUP_GUI_DIR, "setup_gui/pages.py"),
+    os.path.join(SETUP_GUI_DIR, "setup_gui/app.py"),
+]
+for f in files:
+    try:
+        py_compile.compile(f, doraise=True,
+                           cfile=os.path.join(tempfile.mkdtemp(), "c.pyc"))
+        ok("py_compile %s" % os.path.relpath(f, ROOT_DIR), True)
+    except py_compile.PyCompileError as e:
+        ok("py_compile %s" % os.path.relpath(f, ROOT_DIR), False, str(e))
+
+try:
+    import pyflakes  # noqa: F401
+    have_pyflakes = True
+except ImportError:
+    have_pyflakes = False
+if have_pyflakes:
+    r = subprocess.run([sys.executable, "-m", "pyflakes"] + files,
+                       capture_output=True, text=True)
+    ok("pyflakes clean", r.returncode == 0, r.stdout + r.stderr)
+else:
+    print("# pyflakes not available; skipping (not a failure)")
+
+# ---------------------------------------------------------------------------
+# 1. Defaults document
+# ---------------------------------------------------------------------------
+d = model.Defaults.from_json(FIXTURE_DEFAULTS)
+eq("defaults proto", d.proto, 1)
+eq("three products", d.product_names(), ["cayo-ab", "snow-ab",
+                                         "snowfield-ab"])
+eq("cayo core flatpaks not allowed",
+   d.product("cayo-ab").core_flatpaks_allowed, False)
+eq("snow core flatpaks default on",
+   d.product("snow-ab").core_flatpaks_default, True)
+eq("cayo min disk bytes", d.product("cayo-ab").minimum_disk_bytes,
+   16642998272)
+eq("snow bare name", d.product("snow-ab").bare, "snow")
+eq("origin default", d.origin_default, "https://repository.frostyard.org")
+try:
+    d.product("nope-ab")
+    ok("unknown product raises", False)
+except KeyError:
+    ok("unknown product raises", True)
+try:
+    model.Defaults({"proto": 2, "products": []})
+    ok("unknown proto rejected", False)
+except ValueError:
+    ok("unknown proto rejected", True)
+
+# Live drift check: the embedded fixture must equal the real script's
+# current output whenever the script is runnable on this host.
+try:
+    live = subprocess.run([INSTALLER, "--print-defaults"],
+                          capture_output=True, text=True, timeout=60)
+    runnable = live.returncode == 0
+except (OSError, subprocess.TimeoutExpired):
+    runnable = False
+if runnable:
+    eq("fixture matches live --print-defaults output",
+       json.loads(live.stdout), json.loads(FIXTURE_DEFAULTS))
+else:
+    print("# %s not runnable here; skipping live drift check" % INSTALLER)
+
+# ---------------------------------------------------------------------------
+# 2. Validation (regexes come from the fixture document, not hardcoded)
+# ---------------------------------------------------------------------------
+ok("username valid", d.valid_username("bjk"))
+ok("username valid with -_ digits", d.valid_username("a0_b-c"))
+ok("username rejects uppercase", not d.valid_username("Bjk"))
+ok("username rejects leading digit", not d.valid_username("0abc"))
+ok("username rejects empty", not d.valid_username(""))
+ok("username rejects 33 chars", not d.valid_username("a" * 33))
+ok("username accepts 32 chars", d.valid_username("a" * 32))
+ok("hostname valid", d.valid_hostname("snow"))
+ok("hostname valid single char", d.valid_hostname("a"))
+ok("hostname valid inner hyphen", d.valid_hostname("my-host-01"))
+ok("hostname rejects leading hyphen", not d.valid_hostname("-host"))
+ok("hostname rejects trailing hyphen", not d.valid_hostname("host-"))
+ok("hostname rejects 64 chars", not d.valid_hostname("a" * 64))
+ok("hostname accepts 63 chars", d.valid_hostname("a" * 63))
+ok("hostname rejects dot", not d.valid_hostname("a.b"))
+ok("locale valid", d.valid_locale("en_US.UTF-8"))
+ok("locale valid with @", d.valid_locale("ca_ES@valencia"))
+ok("locale rejects leading digit", not d.valid_locale("8bit"))
+ok("timezone UTC valid", d.valid_timezone("UTC"))
+ok("timezone Area/City valid", d.valid_timezone("America/New_York"))
+ok("timezone 3-part valid", d.valid_timezone("America/Argentina/Ushuaia"))
+ok("timezone rejects space", not d.valid_timezone("America/New York"))
+ok("timezone rejects 4 parts", not d.valid_timezone("a/b/c/d"))
+ok("keyboard layout valid", d.valid_keyboard("us"))
+ok("keyboard layout:variant valid", d.valid_keyboard("us:altgr-intl"))
+ok("keyboard triplet valid", d.valid_keyboard("us:altgr-intl:pc105"))
+ok("keyboard empty variant valid", d.valid_keyboard("de:"))
+ok("keyboard rejects uppercase layout", not d.valid_keyboard("US"))
+ok("feature valid", d.valid_feature("docker"))
+ok("feature valid dotted", d.valid_feature("1password-cli"))
+ok("feature rejects space", not d.valid_feature("doc ker"))
+ok("feature rejects slash", not d.valid_feature("a/b"))
+
+# ---------------------------------------------------------------------------
+# 3. Disk-list parsing + refusal handling
+# ---------------------------------------------------------------------------
+disks = model.parse_disks(FIXTURE_DISKS)
+eq("three disks parsed", len(disks), 3)
+ok("first disk installable", disks[0].installable)
+eq("first disk serial", disks[0].serial, "SER123")
+ok("small disk refused", not disks[1].installable)
+ok("refusal reason preserved", "minimum" in disks[1].refusal)
+ok("boot medium refused", not disks[2].installable)
+eq("installable subset", [x.path for x in disks if x.installable],
+   ["/dev/vda"])
+eq("human_bytes GiB", model.human_bytes(34359738368), "32.0 GiB")
+
+# ---------------------------------------------------------------------------
+# 4. Typed-confirmation matcher (CLI confirm_typed_matches port)
+# ---------------------------------------------------------------------------
+ok("confirm matches path", model.confirm_matches("/dev/vda", "/dev/vda",
+                                                 "SER123"))
+ok("confirm matches serial", model.confirm_matches("SER123", "/dev/vda",
+                                                   "SER123"))
+ok("confirm rejects other text", not model.confirm_matches("vda", "/dev/vda",
+                                                           "SER123"))
+ok("confirm rejects empty", not model.confirm_matches("", "/dev/vda",
+                                                      "SER123"))
+ok("confirm empty serial never matches",
+   not model.confirm_matches("", "/dev/vda", ""))
+ok("confirm serial exact only", not model.confirm_matches("ser123",
+                                                          "/dev/vda",
+                                                          "SER123"))
+
+# ---------------------------------------------------------------------------
+# 5. Command assembly
+# ---------------------------------------------------------------------------
+
+
+def full_state(product="snow-ab"):
+    st = model.SetupState()
+    st.product = d.product(product)
+    st.locale = "en_US.UTF-8"
+    st.timezone = "Europe/Berlin"
+    st.keyboard = "de:nodeadkeys"
+    st.hostname = "myhost"
+    st.username = "bjk"
+    st.user_fullname = "Brian K"
+    st.user_password = "hunter2secret"
+    st.features = ["docker", "tailscale"]
+    st.core_flatpaks = True
+    st.disk = disks[0]
+    st.confirm_text = "/dev/vda"
+    st.recovery_ack = True
+    st.recovery_key_file = "/root/snow-ab-recovery-key-20260717000000.txt"
+    st.mok_password = "mok-secret-word"
+    return st
+
+
+st = full_state()
+argv = model.build_install_argv(st, d, "/run/snosi-setup/userpw-x",
+                                "/run/snosi-setup/mok-x",
+                                installer="/usr/libexec/snosi-install")
+eq("full argv exact", argv, [
+    "/usr/libexec/snosi-install",
+    "--non-interactive",
+    "--json-progress",
+    "--product", "snow-ab",
+    "--disk", "/dev/vda",
+    "--confirm", "/dev/vda",
+    "--encrypt-var",
+    "--recovery-key-file", "/root/snow-ab-recovery-key-20260717000000.txt",
+    "--acknowledge-recovery-saved",
+    "--mok-password-file", "/run/snosi-setup/mok-x",
+    "--hostname", "myhost",
+    "--locale", "en_US.UTF-8",
+    "--timezone", "Europe/Berlin",
+    "--keyboard", "de:nodeadkeys",
+    "--username", "bjk",
+    "--user-password-file", "/run/snosi-setup/userpw-x",
+    "--user-fullname", "Brian K",
+    "--enable-feature", "docker",
+    "--enable-feature", "tailscale",
+    "--core-flatpaks",
+])
+ok("user password never on argv",
+   all("hunter2secret" not in a for a in argv))
+ok("mok password never on argv",
+   all("mok-secret-word" not in a for a in argv))
+
+st2 = full_state("cayo-ab")
+st2.username = None
+st2.user_password = None
+st2.user_fullname = ""
+st2.core_flatpaks = None
+st2.features = []
+st2.confirm_text = "SER123"          # serial-based confirmation
+argv2 = model.build_install_argv(st2, d, None, "/run/s/mok",
+                                 installer="/usr/libexec/snosi-install")
+ok("cayo argv has --no-create-user", "--no-create-user" in argv2)
+ok("cayo argv has no user flags", "--username" not in argv2 and
+   "--user-password-file" not in argv2 and "--user-fullname" not in argv2)
+ok("cayo argv forces --no-core-flatpaks", "--no-core-flatpaks" in argv2)
+ok("cayo argv never has --core-flatpaks", "--core-flatpaks" not in argv2)
+eq("serial confirm on argv", argv2[argv2.index("--confirm") + 1], "SER123")
+
+st3 = full_state()
+st3.core_flatpaks = False
+argv3 = model.build_install_argv(st3, d, "u", "m")
+ok("snow opt-out gives --no-core-flatpaks", "--no-core-flatpaks" in argv3)
+st4 = full_state()
+st4.core_flatpaks = None
+argv4 = model.build_install_argv(st4, d, "u", "m")
+ok("snow None leaves flatpak choice to the CLI",
+   "--core-flatpaks" not in argv4 and "--no-core-flatpaks" not in argv4)
+
+# Invalid states must raise, not build a broken command line.
+for mutate, desc in [
+    (lambda s: setattr(s, "recovery_ack", False), "missing recovery ack"),
+    (lambda s: setattr(s, "mok_password", None), "missing MOK password"),
+    (lambda s: setattr(s, "confirm_text", "nope"), "bad confirmation"),
+    (lambda s: setattr(s, "disk", disks[1]), "refused disk"),
+    (lambda s: setattr(s, "hostname", "-bad-"), "invalid hostname"),
+    (lambda s: setattr(s, "username", "Bad"), "invalid username"),
+    (lambda s: setattr(s, "features", ["ok", "no good"]),
+     "invalid feature"),
+    (lambda s: setattr(s, "core_flatpaks", True) or
+     setattr(s, "product", d.product("cayo-ab")),
+     "core flatpaks on cayo"),
+]:
+    s = full_state()
+    mutate(s)
+    try:
+        model.build_install_argv(s, d, "u", "m")
+        ok("StateError on %s" % desc, False)
+    except model.StateError:
+        ok("StateError on %s" % desc, True)
+
+# username without a password file is a hard error
+s = full_state()
+try:
+    model.build_install_argv(s, d, None, "m")
+    ok("StateError on missing user password file", False)
+except model.StateError:
+    ok("StateError on missing user password file", True)
+
+# ---------------------------------------------------------------------------
+# 6. --json-progress proto-1 event stream
+# ---------------------------------------------------------------------------
+p = model.ProgressParser()
+lines = [
+    '{"event":"phase","id":"index","title":"Fetching and verifying the '
+    'signed release index"}',
+    '{"event":"start","proto":1,"product":"snow-ab",'
+    '"version":"20260717010101"}',
+    '{"event":"log","level":"info","message":"Version: 20260717010101"}',
+    '{"event":"log","level":"warning","message":"No TPM device found"}',
+    "",                                   # blank: ignored
+    "not json at all",                    # non-JSON: ignored
+    '{"no_event_key": true}',             # JSON without event: ignored
+    '{"event":"progress","phase":"download","bytes":5,"total":10}',  # unknown
+    '{"event":"phase","id":"download","title":"Downloading and writing '
+    'the disk image"}',
+]
+kinds = [ev.kind if ev else None for ev in (p.feed_line(x) for x in lines)]
+eq("event kinds", kinds, ["phase", "start", "log", "log", None, None, None,
+                          "unknown", "phase"])
+ok("saw start", p.saw_start)
+eq("proto from start", p.proto, 1)
+eq("version from start", p.version, "20260717010101")
+eq("current phase id", p.phase_id, "download")
+eq("current phase title", p.phase_title,
+   "Downloading and writing the disk image")
+eq("log tail contents", p.log_tail,
+   ["Version: 20260717010101", "Warning: No TPM device found"])
+ok("not done yet", not p.succeeded and p.done is None and p.error is None)
+
+p.feed_line('{"event":"done","product":"snow-ab",'
+            '"version":"20260717010101","disk":"/dev/vda"}')
+ok("done recorded", p.done is not None and p.succeeded)
+eq("done disk", p.done["disk"], "/dev/vda")
+
+perr = model.ProgressParser()
+perr.feed_line('{"event":"error","message":"signature verification FAILED"}')
+perr.feed_line('{"event":"error","message":"second error"}')
+eq("first error wins", perr.error, "signature verification FAILED")
+ok("errored stream never succeeded", not perr.succeeded)
+perr.feed_line('{"event":"done","product":"x","version":"y","disk":"z"}')
+ok("done after error still not success", not perr.succeeded)
+
+pbound = model.ProgressParser()
+for i in range(model.ProgressParser.LOG_TAIL_MAX + 50):
+    pbound.feed_line(json.dumps({"event": "log", "level": "info",
+                                 "message": "line %d" % i}))
+eq("log tail bounded", len(pbound.log_tail), model.ProgressParser.LOG_TAIL_MAX)
+eq("log tail keeps newest", pbound.log_tail[-1],
+   "line %d" % (model.ProgressParser.LOG_TAIL_MAX + 49))
+
+# ---------------------------------------------------------------------------
+# 7. Page flow
+# ---------------------------------------------------------------------------
+seq_none = model.page_sequence(None)
+seq_snow = model.page_sequence(d.product("snow-ab"))
+seq_cayo = model.page_sequence(d.product("cayo-ab"))
+eq("full sequence has 15 pages", len(seq_none), 15)
+ok("snow sequence keeps flatpaks page", model.PAGE_FLATPAKS in seq_snow)
+ok("cayo sequence drops flatpaks page",
+   model.PAGE_FLATPAKS not in seq_cayo)
+eq("cayo sequence otherwise identical",
+   [x for x in seq_snow if x != model.PAGE_FLATPAKS], seq_cayo)
+eq("first page is welcome", seq_none[0], model.PAGE_WELCOME)
+eq("last pages are progress, done", seq_none[-2:],
+   [model.PAGE_PROGRESS, model.PAGE_DONE])
+ok("confirm comes after disk",
+   seq_none.index(model.PAGE_CONFIRM) > seq_none.index(model.PAGE_DISK))
+ok("recovery ack before progress",
+   seq_none.index(model.PAGE_RECOVERY) < seq_none.index(model.PAGE_PROGRESS))
+
+# ---------------------------------------------------------------------------
+# 8. Secret files
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    with model.SecretFiles(directory=td) as sf:
+        path = sf.add("s3cret", "mok")
+        ok("secret file exists", os.path.isfile(path))
+        eq("secret file mode 0600",
+           stat.S_IMODE(os.stat(path).st_mode), 0o600)
+        with open(path) as f:
+            eq("secret file content (newline-terminated for head -1)",
+               f.read(), "s3cret\n")
+        path2 = sf.add("other", "userpw")
+        ok("distinct secret paths", path != path2)
+    ok("secrets deleted on context exit",
+       not os.path.exists(path) and not os.path.exists(path2))
+
+env_backup = os.environ.get("XDG_RUNTIME_DIR")
+try:
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["XDG_RUNTIME_DIR"] = td
+        sdir = model.runtime_secrets_dir()
+        ok("secrets dir under XDG_RUNTIME_DIR", sdir.startswith(td))
+        eq("secrets dir mode 0700", stat.S_IMODE(os.stat(sdir).st_mode),
+           0o700)
+finally:
+    if env_backup is None:
+        os.environ.pop("XDG_RUNTIME_DIR", None)
+    else:
+        os.environ["XDG_RUNTIME_DIR"] = env_backup
+
+# ---------------------------------------------------------------------------
+# 9. Recovery key path + data.py sanity (fallbacks make these host-neutral)
+# ---------------------------------------------------------------------------
+rk = model.default_recovery_key_path("snow-ab", now=0)
+eq("recovery key path shape", rk,
+   "/root/snow-ab-recovery-key-19700101000000.txt")
+ok("recovery key path under /root", rk.startswith("/root/"))
+
+locales = data.load_locales()
+ok("locale table non-empty", len(locales) > 0)
+ok("locale table is UTF-8 only",
+   all(d.valid_locale(loc) for loc in locales[:50]))
+keyboards = data.load_keyboards()
+ok("keyboard table non-empty", len(keyboards) > 0)
+ok("keyboard specs satisfy the CLI regex",
+   all(d.valid_keyboard(spec) for spec, _ in keyboards))
+timezones = data.load_timezones()
+ok("timezone table non-empty", len(timezones) > 0)
+eq("UTC first", timezones[0], "UTC")
+ok("timezones satisfy the CLI regex",
+   all(d.valid_timezone(tz) for tz in timezones))
+matches, shortened = data.search_choices(keyboards, "us", limit=5)
+ok("search limits results", len(matches) <= 5)
+matches, _ = data.search_choices([("us", "English (US)")], "english us")
+eq("multi-term search matches", matches, [("us", "English (US)")])
+matches, _ = data.search_choices([("us", "English (US)")], "german")
+eq("non-matching search empty", matches, [])
+
+# ---------------------------------------------------------------------------
+print("\n%d passed, %d failed" % (PASS, FAIL))
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
Implements docs/plans/2026-07-17-graphical-installer-plan.md end to end.

**T1 — backend contract** (`snosi-install`): `--print-defaults` (products/capacity floors/core-flatpaks policy/regexes as JSON), `--list-disks-json` (installable disks + refusal reasons), `--json-progress` (line-delimited proto-1 event stream at main()'s section boundaries). +17 unit assertions.

**T2 — snosi-setup frontend** (`shared/native-installer/setup-gui/`, subagent-built): GTK4/libadwaita kiosk, GTK-free `model.py` (validation/argv/event-parsing) + `pages.py`/`app.py`, drives ONE `snosi-install --non-interactive --json-progress` and nothing else; secrets via 0600 `XDG_RUNTIME_DIR` tmpfiles. 124-assertion model test (incl. live-drift check), `--self-check` construction mode.

**T3 — ISO integration:** cage/GTK4/Mesa-llvmpipe/python3-gi/cantarell + picker data (locales/xkb-data/tzdata) into the profile; `snosi-setup.service`.

**T4 — tests:** `test/snosi-setup-boot-test.sh` boots the real ISO twice under enforced Secure Boot (virtio-vga kiosk / no-display getty fallback) — **13/13**; iso-test GUI-stack structural checks; model test wired into validate.yml.

**T5 — docs:** contracts §8, CLAUDE.md, publication runbook ISO-size note, checklist §9 hands-on graphical pass.

**Activation, root-caused live across four designs** (the boot harness is the proof): static wants + unit Conditions, with getty stopped in `ExecStartPre` not `Conflicts=` (Conflicts fires at transaction-build before Conditions, killing getty on the fallback boot). The udev device-pull alternative failed at coldplug — DRM add-then-bind drops `:systemd:` from CURRENT_TAGS. Text-mode serial flow is never affected.

Live graphical install (pixels/focus/keyboard) is the checklist §9 hands-on item — no automation sees that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)