### PR TITLE
fix: installer keeps /etc/group world-readable (mktemp mode clobber)

### DIFF
--- a/shared/native-installer/tree/usr/libexec/snosi-install
+++ b/shared/native-installer/tree/usr/libexec/snosi-install
@@ -1006,6 +1006,14 @@ append_group_member() { # file group user
             if (!found) $NF = ($NF == "" ? u : $NF "," u)
         }
         { print }' "$file" >"$tmp"
+    # mktemp creates 0600 root:root; mv would then clobber the target's mode
+    # and owner. /etc/group must stay 0644 or NON-root group-name resolution
+    # breaks entirely (getent group empty, `id -nG` fails) even though numeric
+    # memberships survive -- shipped broken to a real install, 2026-07-17.
+    # gshadow must stay its root:shadow 0640. Carry the target's existing
+    # mode+owner onto the temp before the atomic rename.
+    chmod --reference="$file" "$tmp"
+    chown --reference="$file" "$tmp" 2>/dev/null || true
     mv "$tmp" "$file"
 }
 
@@ -1097,6 +1105,12 @@ seed_first_user() { # disk var_device bare_product version username password ful
     # /etc/skel is 0755, which silently undid the 0700 above (observed live
     # 2026-07-17: created home was world-readable).
     chmod 0700 "$varmnt/home/$username"
+
+    # Reassert the canonical account-db modes (defense in depth against any
+    # in-place rewrite above touching them -- see append_group_member).
+    chmod 0644 "$upper/passwd" "$upper/group"
+    chmod 0640 "$upper/shadow"
+    [[ ! -f "$upper/gshadow" ]] || chmod 0640 "$upper/gshadow"
 
     umount "$varmnt"; rmdir "$varmnt"
     umount "$rootmnt"; rmdir "$rootmnt"

--- a/test/snosi-install-test.sh
+++ b/test/snosi-install-test.sh
@@ -341,6 +341,34 @@ run_installer "${BASE_ARGS[@]}" --product bogus-product
 assert_contains "invalid --product value is rejected" "$RUN_OUT" "must be one of"
 
 # ===========================================================================
+# 2b. append_group_member preserves the target file's mode + membership
+#     (regression: mktemp+mv clobbered /etc/group to 0600, breaking all
+#     non-root group-name resolution on a real install, 2026-07-17)
+# ===========================================================================
+echo "=== append_group_member mode preservation ==="
+GRP_FIXTURE="$WORK_DIR/group-fixture"
+cat >"$GRP_FIXTURE" <<'GRPEOF'
+root:x:0:
+sudo:x:27:existing
+video:x:44:
+GRPEOF
+chmod 0644 "$GRP_FIXTURE"
+call_fn append_group_member "$GRP_FIXTURE" sudo claude
+call_fn append_group_member "$GRP_FIXTURE" sudo claude   # idempotent
+call_fn append_group_member "$GRP_FIXTURE" video claude
+call_fn append_group_member "$GRP_FIXTURE" nonexistent claude   # no-op
+assert_eq "append_group_member preserves 0644 mode (not mktemp's 0600)" \
+    "$(stat -c '%a' "$GRP_FIXTURE")" "644"
+assert_eq "append_group_member added claude to sudo (kept existing member)" \
+    "$(awk -F: '$1=="sudo"{print $NF}' "$GRP_FIXTURE")" "existing,claude"
+assert_eq "append_group_member did not duplicate on re-add" \
+    "$(grep -c 'claude,claude\|claude.*claude' "$GRP_FIXTURE" || true)" "0"
+assert_eq "append_group_member added claude to an empty-member group" \
+    "$(awk -F: '$1=="video"{print $NF}' "$GRP_FIXTURE")" "claude"
+assert_eq "append_group_member is a no-op for an absent group" \
+    "$(grep -c '^nonexistent' "$GRP_FIXTURE" || true)" "0"
+
+# ===========================================================================
 # 3. restage-mok argument handling
 # ===========================================================================
 echo "=== restage-mok argument handling ==="


### PR DESCRIPTION
**Symptom (found on a real snow install, 10.0.1.174):** as a normal user, no group name resolves — `getent group sudo` is empty, `id -nG` fails, even the user's own gid has no name — yet `id` shows the correct numeric supplementary memberships (sudo, adm, video, …). `/etc/passwd` resolves fine.

**Root cause:** `seed_first_user`'s `append_group_member` appends each membership via `mktemp` (which creates `0600 root:root`) + `mv`, clobbering the installer's `0644 /etc/group` down to `0600`. Non-root can no longer read it, so name resolution dies while numeric memberships (established from the file at an earlier moment) persist. `/etc/passwd` is never passed through `append_group_member`, so it stayed `0644` — exactly why usernames resolve but group names don't.

**Fix:** `chmod/chown --reference` the temp from the target before the atomic rename (keeps group `0644`, gshadow `root:shadow 0640`), plus a defensive reassert of all four account-db modes at the end of `seed_first_user`. New regression test covers mode preservation + membership semantics. 134/134.

**Existing installs:** `sudo chmod 0644 /etc/group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)