### PR TITLE
fix: installer GUI ships the SVG icon loader + desktop schemas (broken icons)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -947,8 +947,12 @@ emit an `add` then a `bind` uevent and the `bind` drops `:systemd:` from the
 device's CURRENT_TAGS at coldplug, so the `.device` unit never pulled the
 kiosk on a real boot (it worked only on a manual `udevadm trigger`). The ISO
 gains the cage/GTK4/Mesa-llvmpipe/python3-gi/cantarell stack plus the picker
-data files (`locales`/`xkb-data`/`tzdata`, else the pickers silently degrade),
-taking it to ~1.1–1.3 GB. `test/snosi-setup-boot-test.sh` (local, root+KVM,
+data files (`locales`/`xkb-data`/`tzdata`, else the pickers silently degrade).
+The ~1.6 GB uncompressed rootfs zstd-compresses to a ~590 MB packed
+initramfs, so the GUI ISO is ~700 MB — only ~100 MB more than the ~600 MB
+text-only ISO. **ISO size is NOT a reliable text-vs-GUI discriminator**
+(they are ~100 MB apart); check for `usr/bin/snosi-setup` in the packed
+initramfs instead. `test/snosi-setup-boot-test.sh` (local, root+KVM,
 not in CI) boots the real ISO twice under enforced Secure Boot — virtio-vga
 (kiosk up: cage + the GTK app, getty yielded, no crash loop) and no-display
 (getty fallback, Condition-skipped cleanly) — 13/13; the serial text flow is

--- a/docs/native-ab-publication.md
+++ b/docs/native-ab-publication.md
@@ -218,8 +218,10 @@ sees.
 ## Installer ISO publication
 
 > **Size note:** since the graphical setup wizard landed (GTK4/cage/Mesa
-> stack + picker data), the ISO is roughly 1.1–1.3 GB rather than the
-> original ~550 MB. Candidate upload, `verify-remote`'s full re-download,
+> stack + picker data), the ISO is ~700 MB rather than the ~600 MB
+> text-only ISO (the ~1.6 GB rootfs zstd-compresses hard; size is NOT a
+> reliable text-vs-GUI check — the two are only ~100 MB apart). Candidate
+> upload, `verify-remote`'s full re-download,
 > and promotion re-hashing all scale with it; budget CI time accordingly.
 
 The network-installer ISO (`docs/native-ab-contracts.md` "Installer ISO",

--- a/docs/plans/2026-07-17-graphical-installer-plan.md
+++ b/docs/plans/2026-07-17-graphical-installer-plan.md
@@ -37,7 +37,7 @@ The serial console keeps the exact text-mode flow that exists today.
 | 1 | Compositor | **cage** (Wayland kiosk) | runs exactly one client, no session infra, tiny; crash → respawn, no display → getty as today |
 | 2 | Toolkit | **GTK4 + libadwaita + Python/GI** | matches first-setup, whose language/keyboard/timezone views and localegen data port nearly verbatim |
 | 3 | Frontend↔backend contract | GUI collects everything, then runs one `snosi-install --non-interactive … --json-progress` | single source of truth for validation + operations; progress rendered from a line-delimited JSON event stream |
-| 4 | ISO budget | accept ~0.5 GB growth (~550 MB → ~1.1 GB) | user-approved; python3 is NOT currently on the ISO, so the stack is Mesa + cage + GTK4/libadwaita + python3(-gi) + fonts |
+| 4 | ISO budget | ~+100 MB (text ~600 MB → GUI ~700 MB; measured, the earlier ~1.1 GB estimate was the *uncompressed* rootfs, not the zstd-packed ISO) | Mesa + cage + GTK4/libadwaita + python3(-gi) + fonts + librsvg + icon themes/schemas |
 | 5 | Code location | **in-tree**: `shared/native-installer/setup-gui/` | frontend and backend flags stay atomically in sync while the surface stabilizes; can graduate to a package later |
 
 ## Architecture

--- a/shared/native-installer/mkosi.conf
+++ b/shared/native-installer/mkosi.conf
@@ -250,5 +250,18 @@ Packages=cage
          locales
          xkb-data
          tzdata
+# Icon rendering + settings the GTK4/libadwaita app needs but that are NOT
+# pulled by the libraries above: libgtk-4-1 Depends adwaita-icon-theme +
+# hicolor-icon-theme (present) but only RECOMMENDS librsvg2-common -- and
+# mkosi builds recommends-off, so the gdk-pixbuf SVG loader was absent and
+# EVERY symbolic (SVG) icon rendered broken (found live 2026-07-17 in the
+# QEMU graphical install). adwaita/hicolor listed explicitly per the
+# forky-drift rule (a transitive Depends can vanish). gsettings-desktop-
+# schemas provides org.gnome.desktop.interface, which libadwaita reads for
+# the icon theme + color-scheme (its absence also spams schema warnings).
+         adwaita-icon-theme
+         hicolor-icon-theme
+         librsvg2-common
+         gsettings-desktop-schemas
 
 PostInstallationScripts=%D/shared/native-installer/postinst/mkosi.postinst.chroot

--- a/shared/native-installer/setup-gui/setup_gui/pages.py
+++ b/shared/native-installer/setup-gui/setup_gui/pages.py
@@ -182,7 +182,7 @@ class NetworkPage(Page):
         self.spinner.stop()
         self.spinner.set_visible(False)
         if ok:
-            self.status.set_icon_name("emblem-ok-symbolic")
+            self.status.set_icon_name("object-select-symbolic")
             self.status.set_title("Download server reachable")
             self.state.network_skipped = False
             self.window.set_ready(True)
@@ -841,7 +841,7 @@ class ProgressPage(Page):
         self._stdout_eof = False
         self._exited = False
         self._exit_ok = False
-        self.status = Adw.StatusPage(icon_name="emblem-synchronizing-symbolic",
+        self.status = Adw.StatusPage(icon_name="content-loading-symbolic",
                                      title="Installing…", description="")
         self.progress = Gtk.ProgressBar(show_text=False)
         buf = Gtk.TextBuffer()
@@ -1003,7 +1003,7 @@ class DonePage(Page):
     no_next_button = True
 
     def build(self):
-        self.status = Adw.StatusPage(icon_name="emblem-ok-symbolic",
+        self.status = Adw.StatusPage(icon_name="object-select-symbolic",
                                      title="Installation Complete",
                                      description="")
         self.key_label = Gtk.Label(label="", selectable=True, wrap=True,

--- a/test/native-installer-iso-test.sh
+++ b/test/native-installer-iso-test.sh
@@ -272,6 +272,18 @@ assert_true "initrd contains org.gnome.desktop.interface schema (libadwaita sett
     grep -qE "org.gnome.desktop.interface.gschema.xml$" "$initrd_list"
 assert_true "initrd contains compiled gsettings schemas" \
     grep -qE "glib-2.0/schemas/gschemas.compiled$" "$initrd_list"
+# Every symbolic icon-name the wizard references MUST resolve to a real icon
+# in the packed Adwaita theme -- a stale name (e.g. the dropped emblem-ok-
+# symbolic / emblem-synchronizing-symbolic) renders as a blank/broken icon
+# with no error, invisible to every test but a human's eyes (found live
+# 2026-07-17 on the "Download server reachable" page). This closes that gap:
+# it fails the build if the code names an icon the shipped theme lacks.
+missing_icons=""
+while IFS= read -r icon; do
+    [[ -n "$icon" ]] || continue
+    grep -qE "icons/Adwaita/.*/${icon}\.(svg|png)$" "$initrd_list" || missing_icons+=" $icon"
+done < <(grep -rohE "[a-z0-9-]+-symbolic" "$ROOT_DIR/shared/native-installer/setup-gui/setup_gui/pages.py" | sort -u)
+assert_eq "every snosi-setup icon-name resolves in the packed Adwaita theme" "${missing_icons# }" ""
 assert_true "initrd contains the product-aware CLI installer" \
     grep -q "usr/libexec/snosi-install$" "$initrd_list"
 # cpio -t (no -v) lists names only, not symlink targets -- -tv is needed to

--- a/test/native-installer-iso-test.sh
+++ b/test/native-installer-iso-test.sh
@@ -260,6 +260,18 @@ assert_true "initrd contains the locale picker data (locales SUPPORTED)" grep -q
 assert_true "initrd contains the keyboard picker data (xkb evdev.lst)" grep -q "usr/share/X11/xkb/rules/evdev.lst$" "$initrd_list"
 assert_true "initrd contains zoneinfo (timezone picker)" grep -q "usr/share/zoneinfo/UTC$" "$initrd_list"
 assert_true "initrd contains Cantarell" grep -qE "fonts.*[Cc]antarell" "$initrd_list"
+# Icon rendering: the Adwaita theme, and CRITICALLY the gdk-pixbuf SVG loader
+# (librsvg2-common) -- without it every symbolic (SVG) icon in the GTK4/Adw
+# app renders broken (found live 2026-07-17; librsvg is only a libgtk-4-1
+# Recommends and mkosi builds recommends-off). Loader is libpixbufloader_svg
+# (underscore) on trixie.
+assert_true "initrd contains the Adwaita icon theme" grep -qE "usr/share/icons/Adwaita/index.theme$" "$initrd_list"
+assert_true "initrd contains the gdk-pixbuf SVG loader (symbolic icons)" \
+    grep -qE "gdk-pixbuf-2.0/.*/loaders/libpixbufloader_svg.so$" "$initrd_list"
+assert_true "initrd contains org.gnome.desktop.interface schema (libadwaita settings)" \
+    grep -qE "org.gnome.desktop.interface.gschema.xml$" "$initrd_list"
+assert_true "initrd contains compiled gsettings schemas" \
+    grep -qE "glib-2.0/schemas/gschemas.compiled$" "$initrd_list"
 assert_true "initrd contains the product-aware CLI installer" \
     grep -q "usr/libexec/snosi-install$" "$initrd_list"
 # cpio -t (no -v) lists names only, not symlink targets -- -tv is needed to


### PR DESCRIPTION
**Symptom:** in the QEMU graphical install, every icon rendered broken.

**Root cause (confirmed by clean-build inspection):** the GTK4/libadwaita libraries and the Adwaita/hicolor icon *themes* were present (hard `libgtk-4-1` Depends), but `librsvg2-common` — the gdk-pixbuf **SVG loader** — is only a `libgtk-4-1` *Recommends*, and mkosi builds recommends-off. libadwaita's UI icons are almost all *symbolic SVG*, so with no SVG loader they all draw broken. Secondary gap: `gsettings-desktop-schemas` (`org.gnome.desktop.interface`) was absent, which libadwaita reads for icon theme + color scheme.

Invisible to the model tests and to `snosi-setup --self-check` because those ran on a dev host with a full GNOME desktop.

**Fix:** add `librsvg2-common` + `gsettings-desktop-schemas`; list `adwaita-icon-theme`/`hicolor-icon-theme` explicitly (forky-drift rule). Clean rebuild verified: `libpixbufloader_svg.so` present + registered in `loaders.cache`, desktop schema + `gschemas.compiled` present. `native-installer-iso-test.sh` now guards all four.

~+15 MB to the ISO. The visual confirmation (icons actually rendering) is a hands-on pass — offered to the user in QEMU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)