### PR TITLE
fix: ship the vendor update pubring as import-pubring.pgp (systemd 261 name)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,11 +406,25 @@ shipped NvPCR definition plus the product/login writers. Keep TPM SRK setup and
 the signed-PCR-11 LUKS path enabled. Do not delete/recreate the anchor or TPM NV
 indexes as a key-rotation shortcut; that changes the attestation baseline.
 
-**Dev update signing pubring (Phase 3):** every native image (including
-`cayo-ab-raw`) ships `/usr/lib/systemd/import-pubring.gpg` via a `file:target`
-`ExtraTrees=` pair in `shared/outformat/ab-root/mkosi.conf` (the pinned
-mkosi's `install_tree()` copies a single file when a target is given, not
-only directories/tar archives — confirmed in `.mkosi/mkosi/__init__.py`).
+**Update signing pubring (Phase 3; .pgp fix 2026-07-17):** every native image
+(including `cayo-ab-raw`) ships the committed pubring at BOTH
+`/usr/lib/systemd/import-pubring.gpg` AND `/usr/lib/systemd/import-pubring.pgp`
+via `file:target` `ExtraTrees=` pairs in `shared/outformat/ab-root/mkosi.conf`
+(the pinned mkosi's `install_tree()` copies a single file when a target is
+given — confirmed in `.mkosi/mkosi/__init__.py`). **The `.pgp` name is the one
+systemd 261 actually reads** (meson: `VENDOR_KEYRING_PATH =
+libexecdir/import-pubring.pgp`; pull verification has NO legacy `.gpg`
+fallback for the /usr path — only `/etc/systemd/import-pubring.gpg` keeps a
+legacy name). Shipping only `.gpg` made every REAL `systemd-sysupdate` pull
+fail with `gpg: Can't check signature: No public key` — root-caused live on
+minisnow 2026-07-17, the first-ever pull against the real origin; every QEMU
+harness injects the `/etc` legacy override and so never saw it. The `.gpg`
+copy stays because snosi's own tools (`snosi-update-status --check`, the
+stager's probe) reference it explicitly; existing broken installs remediate
+with `cp /usr/lib/systemd/import-pubring.gpg /etc/systemd/import-pubring.gpg`
+(remove that copy after crossing to a fixed build — it shadows the vendor
+ring across future key rotations). `test/native-ab-static-test.sh` asserts
+both ExtraTrees pairs.
 The committed public keyring is a DEV-only ed25519 key
 (`shared/native-ab/keys/import-pubring.gpg`, see
 `shared/native-ab/keys/README.md`); its private half is

--- a/docs/native-ab-contracts.md
+++ b/docs/native-ab-contracts.md
@@ -287,7 +287,10 @@ lockdown.
 
 The public update key is committed in-repo at
 `shared/native-ab/keys/import-pubring.gpg` and shipped at
-`/usr/lib/systemd/import-pubring.gpg`. (This path was created in Phase 3 as a
+`/usr/lib/systemd/import-pubring.gpg` AND `/usr/lib/systemd/import-pubring.pgp`
+(the latter is the name systemd 261's pull verification actually reads --
+its vendor path has no legacy `.gpg` fallback; both ship from the same
+committed source). (This path was created in Phase 3 as a
 DEV-only key — see `shared/native-ab/keys/README.md` — to unblock the
 publication guard ahead of schedule; the protected signing pipeline that
 replaces it with the real production key lands in Phase 7.)

--- a/shared/outformat/ab-root/mkosi.conf
+++ b/shared/outformat/ab-root/mkosi.conf
@@ -80,6 +80,17 @@ ExtraTrees=%D/shared/outformat/ab-root/tree
 # the never-published cayo-ab-raw dev fixture) ships this file; the QEMU
 # update tests use their own ephemeral keys and are unaffected.
 ExtraTrees=%D/shared/native-ab/keys/import-pubring.gpg:/usr/lib/systemd/import-pubring.gpg
+# ALSO shipped as import-pubring.pgp: systemd 261 renamed the vendor keyring
+# (meson.build: VENDOR_KEYRING_PATH = libexecdir/import-pubring.pgp) and its
+# pull verification has NO legacy .gpg fallback for the /usr path -- only the
+# /etc user override retains a legacy name. Shipping only .gpg made every
+# real systemd-sysupdate pull fail signature verification with "No public
+# key" (root-caused live on minisnow, 2026-07-17: the first-ever pull against
+# the real origin; every QEMU harness injects /etc/systemd/import-pubring.gpg,
+# which IS still honored, masking this). The .gpg copy stays because snosi's
+# own tools (snosi-update-status, snosi-sysupdate-stage's probe,
+# snosi-install docs) reference it explicitly.
+ExtraTrees=%D/shared/native-ab/keys/import-pubring.gpg:/usr/lib/systemd/import-pubring.pgp
 FinalizeScripts=%D/shared/outformat/ab-root/finalize/mkosi.finalize.chroot
 # Sysext feature catalog (non-chroot; reads $BUILDROOT, writes the in-image
 # /usr/share/snosi/features.json AND the $OUTPUTDIR/<IMAGE_ID>.features.json

--- a/test/native-ab-static-test.sh
+++ b/test/native-ab-static-test.sh
@@ -33,6 +33,12 @@ pubring="$root/shared/native-ab/keys/import-pubring.gpg"
 [[ -s "$pubring" ]]
 grep -q '^ExtraTrees=%D/shared/native-ab/keys/import-pubring.gpg:/usr/lib/systemd/import-pubring.gpg$' \
     "$ab/mkosi.conf"
+# systemd 261 renamed the vendor keyring to import-pubring.pgp with NO legacy
+# .gpg fallback for the /usr path (only /etc keeps a legacy name) -- shipping
+# only .gpg made every real systemd-sysupdate pull fail "No public key"
+# (minisnow, 2026-07-17). Both names must ship from the same committed source.
+grep -q '^ExtraTrees=%D/shared/native-ab/keys/import-pubring.gpg:/usr/lib/systemd/import-pubring.pgp$' \
+    "$ab/mkosi.conf"
 [[ -f "$root/shared/native-ab/keys/README.md" ]]
 
 # Regression guard (Task 3.2): the ExtraTrees= shadow of 30-bootc-standard.conf


### PR DESCRIPTION
**Every real `systemd-sysupdate` pull was failing** `gpg: Can't check signature: No public key` — found on minisnow attempting the first-ever update from the live origin, despite the shipped ring containing the correct production key.

**Root cause (systemd v261 source, meson.build:318-322 + pull-common.c:473-478):** the vendor keyring was renamed to `import-pubring.pgp`, and pull verification has **no legacy `.gpg` fallback for the /usr path** — gpg gets `--keyring=/usr/lib/systemd/import-pubring.pgp`, which we never shipped. The `/etc` user override is the only place the legacy `.gpg` name survives — **exactly why every QEMU update harness passed** (they all inject `/etc/systemd/import-pubring.gpg`) while production failed. snosi's own gpgv tools reference `.gpg` explicitly, so `snosi-update-status --check` verified fine and masked it further.

**Fix:** ship the committed pubring at **both** names (second `file:target` ExtraTrees pair); `.gpg` stays for snosi's own tools. Static test asserts both pairs. Docs updated (CLAUDE.md, contracts).

**Existing installs** (minisnow + anything installed from current images): `sudo cp /usr/lib/systemd/import-pubring.gpg /etc/systemd/import-pubring.gpg` unblocks updates immediately via the honored legacy path — remove that copy after crossing onto a fixed build (it shadows the vendor ring across future key rotations).

**Test-gap honesty:** no automated harness exercises the shipped /usr trust path — they all override at /etc. A follow-up should make one QEMU update-test leg run WITHOUT the /etc override against a fixture origin signed by the dev key the image actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)