### PR TITLE
test: exercise the shipped vendor pubring (.pgp) trust path in the secure-boot harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,18 +424,33 @@ stager's probe) reference it explicitly; existing broken installs remediate
 with `cp /usr/lib/systemd/import-pubring.gpg /etc/systemd/import-pubring.gpg`
 (remove that copy after crossing to a fixed build — it shadows the vendor
 ring across future key rotations). `test/native-ab-static-test.sh` asserts
-both ExtraTrees pairs.
-The committed public keyring is a DEV-only ed25519 key
-(`shared/native-ab/keys/import-pubring.gpg`, see
-`shared/native-ab/keys/README.md`); its private half is
-`.snosi-private/os-update-signing.key` (gitignored, never committed, never
-printed — nothing in-repo signs with it yet, since dev/local `SHA256SUMS`
-stay unsigned per `docs/native-ab-contracts.md` §7). This satisfies
-`check-native-publication-guard.sh`'s pubring-committed check ahead of the
-real Phase 7 signing pipeline; QEMU update tests generate their own
-ephemeral keys and are unaffected. **Rotate this key before first production
-publication** — see the README and contract §7 for the real key-ceremony
-procedure.
+both ExtraTrees pairs. The shipped-vendor-keyring trust path is now also
+exercised LIVE by `test/native-ab-secure-boot-test.sh` — the only harness
+that can: the `.pgp`-reading systemd 261 runs only on the production
+profiles it boots, while Trixie's systemd 257 (what `cayo-ab-raw` boots,
+i.e. every other update harness including `native-ab-publication-test.sh`'s
+existing no-override leg) still reads the OLD `/usr` `.gpg` name (verified
+via `strings` on `systemd-pull`) and so structurally cannot cover the
+`.pgp` link. That harness installs NO `/etc/systemd/import-pubring.*`
+override; it bakes its ephemeral test keyring over the committed pair at
+BOTH `/usr` names via two mkosi CLI `--extra-tree` flags (CLI list-setting
+values append after config-file values and ExtraTrees overwrite in install
+order — needed because the committed pubring is the production key, whose
+private half is offline-only), asserts the swap and the `/etc`-override
+absence in-guest, verifies its Step 6 signed update hop through the vendor
+`.pgp` path, and proves enforcement by rejecting a wrong-key-signed index
+through the same shipped ring (Step 6c). Its `SKIP_BUILD=1` mode therefore
+also requires `SIGNING_GNUPGHOME` (the homedir whose key the prebuilt
+images embed).
+The committed public keyring carries the PRODUCTION update-signing key
+(`shared/native-ab/keys/import-pubring.gpg`, ed25519; fingerprint, custody,
+and rotation procedure in `shared/native-ab/keys/README.md`); its private
+half is offline-only (for CI, the `native-promotion` environment's
+`NATIVE_UPDATE_SIGNING_KEY` secret) and is never committed and never placed
+in `.snosi-private/`. QEMU update tests generate their own ephemeral keys —
+injected at `/etc/systemd/import-pubring.gpg` (the `cayo-ab-raw` harnesses)
+or baked over the `/usr` pair at build time
+(`test/native-ab-secure-boot-test.sh`, above) — and never need this key.
 
 **Accepted risk — unsigned sysexts on native installs:** native production
 candidates (`cayo-ab`, `snow-ab`, `snowfield-ab`) ship every sysext transfer

--- a/docs/superpowers/plans/2026-07-17-shipped-pubring-trust-leg.md
+++ b/docs/superpowers/plans/2026-07-17-shipped-pubring-trust-leg.md
@@ -1,0 +1,115 @@
+# Shipped Vendor Keyring Trust Leg Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a QEMU update-harness leg that performs a sysupdate hop with NO `/etc/systemd/import-pubring.*` override, so systemd-sysupdate must verify the signed index using ONLY the shipped `/usr/lib/systemd/import-pubring.pgp` vendor keyring — closing the last untested link that let the 2026-07-17 signature-verification outage (commit 91718d7) ship.
+
+**Architecture:** The leg goes in `test/native-ab-secure-boot-test.sh` — the ONLY harness that boots the production profiles running Forky systemd 261, whose vendor keyring path is `import-pubring.pgp`. This is load-bearing: Trixie's systemd 257 (verified on this host: `strings /usr/lib/systemd/systemd-pull` shows only `.gpg` paths) still reads the OLD `/usr/lib/systemd/import-pubring.gpg` name, so every `cayo-ab-raw`-based harness (updateux, components, update-test, publication-test — including publication-test's existing "never touch /etc, verify against the stock shipped pubring" leg) structurally CANNOT exercise the `.pgp` link, which is exactly why the outage slipped past all of them. Because the committed pubring is now the PRODUCTION key (private half offline-only, per `shared/native-ab/keys/README.md`), the harness bakes its ephemeral TEST keyring into the built images at BOTH `/usr/lib/systemd` names via two mkosi CLI `--extra-tree` flags — CLI list-setting values append AFTER config-file values (`.mkosi/mkosi/config.py` `finalize_value`: `return cfg_value + v`) and `install_extra_trees` copies in list order with overwriting `cp`, so the ephemeral pair wins over `shared/outformat/ab-root/mkosi.conf`'s committed pair. The `/etc/systemd/import-pubring.gpg` scp override is removed entirely; the existing Step 6 secure update hop becomes the positive shipped-trust-path proof, and a new Step 6c proves the negative: an index signed by a valid-but-untrusted key is rejected (the outage's exact failure-mode class, `gpg: Can't check signature: No public key`).
+
+**Tech Stack:** bash, mkosi (pinned `.mkosi` checkout), gpg/gpgv, QEMU/OVMF/swtpm, systemd-sysupdate 261.
+
+## Global Constraints
+
+- The shipped default trust configuration is never weakened: the committed production pubring file `shared/native-ab/keys/import-pubring.gpg` is never modified on disk; the swap happens only in test-built image content via `--extra-tree`.
+- Verification property (frozen): systemd-sysupdate must verify using ONLY `/usr/lib/systemd/import-pubring.pgp` — no `/etc/systemd/import-pubring.*` file may exist in the guest (asserted).
+- Version grammar `^[0-9]{14}$`; fabricated newer versions use the hardlink trick from `test/native-ab-updateux-test.sh` Step 4 (no extra mkosi build).
+- Default-mode assertion flow before Step 6 is unchanged; `--full-window` continues to work (Step 6c restores the origin's known-good N+1 index before returning).
+- `set -euo pipefail`, shellcheck-clean (validate.yml runs shellcheck).
+
+---
+
+### Task 1: Harness changes in `test/native-ab-secure-boot-test.sh`
+
+**Files:**
+- Modify: `test/native-ab-secure-boot-test.sh`
+
+**Interfaces:**
+- Consumes: `$WORK_DIR/gnupg` (ephemeral signing homedir), `publish_dest` global set by `publish_version`, helpers `assert_eq`/`assert_true`/`assert_false`/`assert_contains`, `vm_ssh`, `guest_version`.
+- Produces: env var `SIGNING_GNUPGHOME` (required with `SKIP_BUILD=1`), `$WORK_DIR/import-pubring.gpg` (exported ephemeral public ring, now created BEFORE builds), Step 6c.
+
+- [ ] **Step 1: Move ephemeral keygen before the builds; add `SIGNING_GNUPGHOME`**
+
+Add `: "${SIGNING_GNUPGHOME:=}"` to the env-default block (after `BUILD_N3_DIR`). Insert after the `mkdir -p "$WORK_DIR/..."`/`chmod 700 "$WORK_DIR/gnupg"` lines, before the `SKIP_BUILD` build block:
+
+```bash
+# The ephemeral update-signing key must exist BEFORE the builds:
+# build_profile bakes its public keyring into every built image over the
+# committed production pubring (whose private half is offline-only --
+# shared/native-ab/keys/README.md), so it can no longer be generated
+# lazily at publish time. With SKIP_BUILD=1 the prebuilt images already
+# contain SOME baked ring, so the matching homedir must be supplied.
+if [[ "$SKIP_BUILD" == 1 ]]; then
+    [[ -n "$SIGNING_GNUPGHOME" ]] || {
+        echo "Error: SKIP_BUILD=1 requires SIGNING_GNUPGHOME (the gnupg homedir whose key was baked into the prebuilt images)" >&2
+        exit 1
+    }
+    cp -a "$SIGNING_GNUPGHOME/." "$WORK_DIR/gnupg/"
+else
+    gpg --homedir "$WORK_DIR/gnupg" --batch --passphrase '' --quick-generate-key \
+        'snosi native A/B secure-boot test <native-ab-secure-boot-test@invalid>' ed25519 sign 0
+fi
+gpg --homedir "$WORK_DIR/gnupg" --batch --export > "$WORK_DIR/import-pubring.gpg"
+```
+
+Delete the old keygen block in Step 6 (the `gpg --quick-generate-key` + `--export` pair above `publish_version "$BUILD_N1_DIR"`), leaving a one-line comment pointing at the pre-build location.
+
+- [ ] **Step 2: Bake the ring in `build_profile`**
+
+```bash
+    "$MKOSI" --profile "$PROFILE" \
+        --extra-tree "$WORK_DIR/import-pubring.gpg:/usr/lib/systemd/import-pubring.gpg" \
+        --extra-tree "$WORK_DIR/import-pubring.gpg:/usr/lib/systemd/import-pubring.pgp" \
+        build
+```
+
+with a comment explaining the CLI-appends-after-config + overwrite-in-order mechanism (verified in `.mkosi/mkosi/config.py` `finalize_value` and `__init__.py` `install_extra_trees`).
+
+- [ ] **Step 3: Remove the `/etc` pubring override; add shipped-trust-path assertions**
+
+In Step 6: change `vm_ssh 'mkdir -p /etc/sysupdate.d /etc/systemd'` to `vm_ssh 'mkdir -p /etc/sysupdate.d'`; delete the second scp (`import-pubring.gpg` → `/etc/systemd/import-pubring.gpg`). After the transfers scp, add:
+
+```bash
+assert_false "no /etc/systemd/import-pubring.gpg override (shipped trust path only)" \
+    vm_ssh 'test -e /etc/systemd/import-pubring.gpg'
+assert_false "no /etc/systemd/import-pubring.pgp override (shipped trust path only)" \
+    vm_ssh 'test -e /etc/systemd/import-pubring.pgp'
+ephemeral_ring_hash="$(sha256sum "$WORK_DIR/import-pubring.gpg")"
+ephemeral_ring_hash="${ephemeral_ring_hash%% *}"
+guest_pgp_hash="$(vm_ssh 'sha256sum /usr/lib/systemd/import-pubring.pgp' | awk '{print $1}' || true)"
+assert_eq "shipped /usr/lib/systemd/import-pubring.pgp is the baked ephemeral test ring" \
+    "$guest_pgp_hash" "$ephemeral_ring_hash"
+guest_gpg_hash="$(vm_ssh 'sha256sum /usr/lib/systemd/import-pubring.gpg' | awk '{print $1}' || true)"
+assert_eq "shipped /usr/lib/systemd/import-pubring.gpg twin matches the baked ring" \
+    "$guest_gpg_hash" "$ephemeral_ring_hash"
+pull_refs_pgp="$(vm_ssh "grep -al 'import-pubring.pgp' /usr/lib/systemd/systemd-pull /usr/lib/systemd/systemd-sysupdate 2>/dev/null" || true)"
+assert_true "guest systemd's import machinery references the vendor .pgp name (261 semantics)" \
+    bash -c "[[ -n '$pull_refs_pgp' ]]"
+```
+
+(with the block comment explaining WHY this harness, and why the 257-based ones can't carry this.)
+
+- [ ] **Step 4: Add Step 6c (wrong-key negative) after Step 6b's health check, before the `FULL_WINDOW` gate**
+
+Save `SHA256SUMS`/`SHA256SUMS.gpg`, hardlink N+1's published root/verity/efi under `wrong_fake_version=$(printf '%014d' $((n1_version + 1)))`, append their hashes to `SHA256SUMS`, sign with a fresh `$WORK_DIR/gnupg-wrong` key, `gpg --verify` sanity-check the wrong-key signature is itself valid, run the stager: assert rc!=0, `outcome=failed`, no `/run/snosi/update-staged`, no `${IMAGE_ID}_${wrong_fake_version}_r` partition, running version still N+1. Then remove the fake hardlinks and restore the saved index pair. (Full code in the implementation; mirrors updateux Step 4's structure.)
+
+- [ ] **Step 5: Update the harness header** (step 6 narrative, new step 6c, env-overrides list gains `SIGNING_GNUPGHOME`) and run `shellcheck test/native-ab-secure-boot-test.sh`.
+
+- [ ] **Step 6: Commit** `test: secure-boot harness exercises the shipped vendor pubring (.pgp) trust path`
+
+### Task 2: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (".pgp fix 2026-07-17" paragraph + secure-boot harness description)
+- Modify: `yeti/testing.md` (secure-boot test section)
+- Modify: `yeti/OVERVIEW.md` (publication-test paragraph over-claims "exactly the same trust path a secure production profile would" — correct with the 257-vs-261 vendor-path distinction)
+- Modify: `shared/native-ab/keys/README.md` ("QEMU tests are unaffected" bullet)
+
+- [ ] **Step 1: Apply the four doc updates** — each states: 261 reads `.pgp` (no /usr `.gpg` fallback), 257 reads `.gpg`, only secure-boot-test boots 261, it now bakes the ephemeral ring at both /usr names via CLI `--extra-tree` and runs with NO `/etc` override, positive + wrong-key negative.
+
+- [ ] **Step 2: Commit** `docs: record the shipped-pubring trust-path coverage`
+
+### Task 3: Verification
+
+- [ ] **Step 1:** `shellcheck test/native-ab-secure-boot-test.sh` — clean. *(0 findings)*
+- [ ] **Step 2:** `bash -n test/native-ab-secure-boot-test.sh` — parses. *(pass)*
+- [ ] **Step 3:** Full run: `sudo PROFILE=cayo-ab test/native-ab-secure-boot-test.sh` (default mode, ~1h: two cayo-ab builds + QEMU SB/TPM boot + Step 6/6b/6c). Expect prior 47 assertions + 6 new Step-6 trust asserts + 6 new Step-6c asserts, 0 failed. **Result: 59/59 passed, 0 failed** (N=20260718014753 → N+1=20260718015500; includes +1 for the pre-existing conditional cayo netdev-owner assert). Baked-ring swap verified in-guest by sha256; systemd 261 `.pgp` string canary confirmed on systemd-pull; wrong-key index rejected with `outcome=failed`, nothing staged.

--- a/docs/superpowers/plans/2026-07-17-shipped-pubring-trust-leg.md
+++ b/docs/superpowers/plans/2026-07-17-shipped-pubring-trust-leg.md
@@ -27,7 +27,7 @@
 - Consumes: `$WORK_DIR/gnupg` (ephemeral signing homedir), `publish_dest` global set by `publish_version`, helpers `assert_eq`/`assert_true`/`assert_false`/`assert_contains`, `vm_ssh`, `guest_version`.
 - Produces: env var `SIGNING_GNUPGHOME` (required with `SKIP_BUILD=1`), `$WORK_DIR/import-pubring.gpg` (exported ephemeral public ring, now created BEFORE builds), Step 6c.
 
-- [ ] **Step 1: Move ephemeral keygen before the builds; add `SIGNING_GNUPGHOME`**
+- [x] **Step 1: Move ephemeral keygen before the builds; add `SIGNING_GNUPGHOME`**
 
 Add `: "${SIGNING_GNUPGHOME:=}"` to the env-default block (after `BUILD_N3_DIR`). Insert after the `mkdir -p "$WORK_DIR/..."`/`chmod 700 "$WORK_DIR/gnupg"` lines, before the `SKIP_BUILD` build block:
 
@@ -53,7 +53,7 @@ gpg --homedir "$WORK_DIR/gnupg" --batch --export > "$WORK_DIR/import-pubring.gpg
 
 Delete the old keygen block in Step 6 (the `gpg --quick-generate-key` + `--export` pair above `publish_version "$BUILD_N1_DIR"`), leaving a one-line comment pointing at the pre-build location.
 
-- [ ] **Step 2: Bake the ring in `build_profile`**
+- [x] **Step 2: Bake the ring in `build_profile`**
 
 ```bash
     "$MKOSI" --profile "$PROFILE" \
@@ -64,7 +64,7 @@ Delete the old keygen block in Step 6 (the `gpg --quick-generate-key` + `--expor
 
 with a comment explaining the CLI-appends-after-config + overwrite-in-order mechanism (verified in `.mkosi/mkosi/config.py` `finalize_value` and `__init__.py` `install_extra_trees`).
 
-- [ ] **Step 3: Remove the `/etc` pubring override; add shipped-trust-path assertions**
+- [x] **Step 3: Remove the `/etc` pubring override; add shipped-trust-path assertions**
 
 In Step 6: change `vm_ssh 'mkdir -p /etc/sysupdate.d /etc/systemd'` to `vm_ssh 'mkdir -p /etc/sysupdate.d'`; delete the second scp (`import-pubring.gpg` → `/etc/systemd/import-pubring.gpg`). After the transfers scp, add:
 
@@ -88,13 +88,13 @@ assert_true "guest systemd's import machinery references the vendor .pgp name (2
 
 (with the block comment explaining WHY this harness, and why the 257-based ones can't carry this.)
 
-- [ ] **Step 4: Add Step 6c (wrong-key negative) after Step 6b's health check, before the `FULL_WINDOW` gate**
+- [x] **Step 4: Add Step 6c (wrong-key negative) after Step 6b's health check, before the `FULL_WINDOW` gate**
 
 Save `SHA256SUMS`/`SHA256SUMS.gpg`, hardlink N+1's published root/verity/efi under `wrong_fake_version=$(printf '%014d' $((n1_version + 1)))`, append their hashes to `SHA256SUMS`, sign with a fresh `$WORK_DIR/gnupg-wrong` key, `gpg --verify` sanity-check the wrong-key signature is itself valid, run the stager: assert rc!=0, `outcome=failed`, no `/run/snosi/update-staged`, no `${IMAGE_ID}_${wrong_fake_version}_r` partition, running version still N+1. Then remove the fake hardlinks and restore the saved index pair. (Full code in the implementation; mirrors updateux Step 4's structure.)
 
-- [ ] **Step 5: Update the harness header** (step 6 narrative, new step 6c, env-overrides list gains `SIGNING_GNUPGHOME`) and run `shellcheck test/native-ab-secure-boot-test.sh`.
+- [x] **Step 5: Update the harness header** (step 6 narrative, new step 6c, env-overrides list gains `SIGNING_GNUPGHOME`) and run `shellcheck test/native-ab-secure-boot-test.sh`.
 
-- [ ] **Step 6: Commit** `test: secure-boot harness exercises the shipped vendor pubring (.pgp) trust path`
+- [x] **Step 6: Commit** `test: secure-boot harness exercises the shipped vendor pubring (.pgp) trust path`
 
 ### Task 2: Documentation
 
@@ -104,12 +104,12 @@ Save `SHA256SUMS`/`SHA256SUMS.gpg`, hardlink N+1's published root/verity/efi und
 - Modify: `yeti/OVERVIEW.md` (publication-test paragraph over-claims "exactly the same trust path a secure production profile would" — correct with the 257-vs-261 vendor-path distinction)
 - Modify: `shared/native-ab/keys/README.md` ("QEMU tests are unaffected" bullet)
 
-- [ ] **Step 1: Apply the four doc updates** — each states: 261 reads `.pgp` (no /usr `.gpg` fallback), 257 reads `.gpg`, only secure-boot-test boots 261, it now bakes the ephemeral ring at both /usr names via CLI `--extra-tree` and runs with NO `/etc` override, positive + wrong-key negative.
+- [x] **Step 1: Apply the four doc updates** — each states: 261 reads `.pgp` (no /usr `.gpg` fallback), 257 reads `.gpg`, only secure-boot-test boots 261, it now bakes the ephemeral ring at both /usr names via CLI `--extra-tree` and runs with NO `/etc` override, positive + wrong-key negative.
 
-- [ ] **Step 2: Commit** `docs: record the shipped-pubring trust-path coverage`
+- [x] **Step 2: Commit** `docs: record the shipped-pubring trust-path coverage`
 
 ### Task 3: Verification
 
-- [ ] **Step 1:** `shellcheck test/native-ab-secure-boot-test.sh` — clean. *(0 findings)*
-- [ ] **Step 2:** `bash -n test/native-ab-secure-boot-test.sh` — parses. *(pass)*
-- [ ] **Step 3:** Full run: `sudo PROFILE=cayo-ab test/native-ab-secure-boot-test.sh` (default mode, ~1h: two cayo-ab builds + QEMU SB/TPM boot + Step 6/6b/6c). Expect prior 47 assertions + 6 new Step-6 trust asserts + 6 new Step-6c asserts, 0 failed. **Result: 59/59 passed, 0 failed** (N=20260718014753 → N+1=20260718015500; includes +1 for the pre-existing conditional cayo netdev-owner assert). Baked-ring swap verified in-guest by sha256; systemd 261 `.pgp` string canary confirmed on systemd-pull; wrong-key index rejected with `outcome=failed`, nothing staged.
+- [x] **Step 1:** `shellcheck -S warning -x test/native-ab-secure-boot-test.sh` — clean at CI severity (3 pre-existing info-level findings, unchanged from before the edit).
+- [x] **Step 2:** `bash -n test/native-ab-secure-boot-test.sh` — parses.
+- [x] **Step 3:** Full run `sudo PROFILE=cayo-ab test/native-ab-secure-boot-test.sh` (default mode). **Result: 58 passed, 0 failed** (2026-07-17, N=20260717130251 → N+1=20260717130613) — the prior cayo-ab baseline of 47 plus the 11 new assertions (5 Step-6 shipped-keyring asserts, 6 Step-6c wrong-key asserts). Host-side pre-check on the built N artifact independently confirmed both `/usr` names carry the baked ephemeral ring and differ from the committed production ring. The first run attempt failed in `publish_version` on a PRE-EXISTING main breakage (the #430 feature catalog became a required publication artifact but no QEMU harness stages it); fixed here for this harness (`46a719f`), the other three harnesses flagged as a separate task.

--- a/shared/native-ab/keys/README.md
+++ b/shared/native-ab/keys/README.md
@@ -19,9 +19,16 @@ index. It carries the **production** update-signing public key and satisfies
   image via a `file:target` `ExtraTrees=` pair in the generic
   `shared/outformat/ab-root/mkosi.conf` fragment (consumed by all native
   profiles, including the never-published `cayo-ab-raw` dev fixture).
-- **QEMU tests are unaffected:** `test/native-ab-update-test.sh` and the
-  other QEMU harnesses generate and inject their own ephemeral signing keys
-  via `--definitions` overrides; they never rely on this key.
+- **QEMU tests never need the private half:** every harness generates its
+  own ephemeral signing key. The `cayo-ab-raw`-based harnesses
+  (`test/native-ab-update-test.sh` etc.) inject the ephemeral public ring
+  at `/etc/systemd/import-pubring.gpg` (systemd's documented user
+  override); `test/native-ab-secure-boot-test.sh` instead bakes its
+  ephemeral ring OVER this committed file's in-image copies at both
+  `/usr/lib/systemd` names via mkosi CLI `--extra-tree` flags — the
+  committed file itself is never modified — so its update hop verifies
+  through systemd 261's real vendor path
+  (`/usr/lib/systemd/import-pubring.pgp`) with no `/etc` override at all.
 
 **Rotation** follows `docs/native-ab-contracts.md` §7 / the runbook's overlap
 window: export both the outgoing and incoming public keys into this same

--- a/test/native-ab-secure-boot-test.sh
+++ b/test/native-ab-secure-boot-test.sh
@@ -90,15 +90,28 @@
 #      relocation-symlink, and the NvPCR journal check all remain
 #      unconditional profile-neutral assertions regardless of HAS_DESKTOP.
 #   6. Secure update hop: publish N+1 through the real publication pipeline
-#      to a local HTTP origin signed with an ephemeral GPG key (the guest
-#      trusts it via the documented /etc/systemd/import-pubring.gpg
-#      override, same mechanism as test/native-ab-updateux-test.sh), run
+#      to a local HTTP origin signed with an ephemeral GPG key that the
+#      guest trusts via its SHIPPED vendor keyring ONLY -- the ephemeral
+#      public ring is baked into the built images at build time over the
+#      committed production pubring, at BOTH /usr/lib/systemd names, via
+#      two mkosi CLI --extra-tree flags (see build_profile), and NO
+#      /etc/systemd/import-pubring.* override is ever installed (asserted).
+#      This makes the hop verify through systemd 261's real vendor path,
+#      /usr/lib/systemd/import-pubring.pgp -- the exact link the 2026-07-17
+#      outage proved untested (commit 91718d7): every other harness boots
+#      cayo-ab-raw, whose Trixie systemd 257 still reads the old .gpg
+#      vendor name, and/or injects the /etc override. Then run
 #      /usr/libexec/snosi-sysupdate-stage, reboot with zero serial input
 #      (proving the signed PCR 11 policy survives a real UKI change -- the
 #      entire point of signed-vs-raw PCR policy), and assert N+1 booted
 #      under enforced Secure Boot with TPM auto-unlock intact, /etc upper +
 #      /var persistence markers survived, and the N rollback entry is still
 #      present (InstancesMax=2).
+#      6c. Negative half of the shipped-trust-path proof: a fabricated
+#      newer-version index signed by a VALID but untrusted key (fresh
+#      ephemeral "wrong" key) must be rejected through that same shipped
+#      keyring -- stager fails closed (outcome=failed, nothing staged,
+#      version unchanged), then the origin is restored to N+1's good index.
 #   7. Recovery unlock check (non-destructive): the recovery keyslot still
 #      opens the volume via `cryptsetup open --test-passphrase`.
 #
@@ -160,7 +173,10 @@
 # IMAGE_ID/CHANNEL (derived from PROFILE by default), SSH_PORT (2225),
 # SOURCE_PORT (18095), SSH_TIMEOUT/BOOT_TIMEOUT (300s), VM_MEMORY (4096),
 # VM_CPUS (4), KEEP_VM (0), SKIP_BUILD/BUILD_N_DIR/BUILD_N1_DIR (reuse
-# prebuilt artifacts, same contract as test/native-ab-updateux-test.sh),
+# prebuilt artifacts, same contract as test/native-ab-updateux-test.sh --
+# but SKIP_BUILD=1 here ALSO requires SIGNING_GNUPGHOME, the gnupg homedir
+# from the run that built those artifacts, since its public keyring is
+# baked into them; KEEP_VM=1 preserves it at <workdir>/gnupg),
 # BUILD_N2_DIR/BUILD_N3_DIR (same SKIP_BUILD=1 reuse contract, only
 # consulted with --full-window).
 set -euo pipefail
@@ -192,6 +208,7 @@ done
 : "${BUILD_N1_DIR:=}"
 : "${BUILD_N2_DIR:=}"
 : "${BUILD_N3_DIR:=}"
+: "${SIGNING_GNUPGHOME:=}"
 
 : "${PROFILE:=snow-ab}"
 if [[ -z "${IMAGE_ID:-}" ]]; then
@@ -362,7 +379,19 @@ build_profile() { # dest_dir
     mkdir -p "$dest"
     echo "Building $PROFILE -> $dest (started $(date -u +%FT%TZ))"
     "$MKOSI" clean -ff
-    "$MKOSI" --profile "$PROFILE" build
+    # Bake the ephemeral TEST keyring over the committed production pubring
+    # at BOTH shipped names (see the "shipped vendor keyring" comment in
+    # Step 6): CLI list-setting values append AFTER config-file values
+    # (.mkosi/mkosi/config.py finalize_value: `cfg_value + v`) and
+    # install_extra_trees copies trees in list order with plain overwriting
+    # `cp`, so these two pairs win over the committed pair from
+    # shared/outformat/ab-root/mkosi.conf. The committed file itself is
+    # never touched; the guest asserts the swap took (sha256 comparison)
+    # before the first stage.
+    "$MKOSI" --profile "$PROFILE" \
+        --extra-tree "$WORK_DIR/import-pubring.gpg:/usr/lib/systemd/import-pubring.gpg" \
+        --extra-tree "$WORK_DIR/import-pubring.gpg:/usr/lib/systemd/import-pubring.pgp" \
+        build
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.manifest" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.raw" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.efi" "$dest/"
@@ -832,6 +861,27 @@ trap cleanup EXIT
 WORK_DIR="$(mktemp -d /var/tmp/native-ab-secure-boot-test.XXXXXX)"
 mkdir -p "$WORK_DIR/mnt" "$WORK_DIR/gnupg" "$WORK_DIR/publish-out" "$WORK_DIR/overrides" "$WORK_DIR/tests"
 chmod 700 "$WORK_DIR/gnupg"
+
+# The ephemeral update-signing key must exist BEFORE the builds:
+# build_profile bakes its public keyring into every built image over the
+# committed production pubring (whose private half is offline-only --
+# shared/native-ab/keys/README.md -- so the fixture origin can no longer be
+# signed with a key the stock shipped ring trusts). See the "shipped vendor
+# keyring" comment in Step 6 for the full trust-path rationale. With
+# SKIP_BUILD=1 the prebuilt images already contain SOME baked ring, so the
+# matching gnupg homedir must be supplied instead of generating a fresh key
+# that could never verify against them.
+if [[ "$SKIP_BUILD" == 1 ]]; then
+    [[ -n "$SIGNING_GNUPGHOME" ]] || {
+        echo "Error: SKIP_BUILD=1 requires SIGNING_GNUPGHOME (the gnupg homedir whose key was baked into the prebuilt images)" >&2
+        exit 1
+    }
+    cp -a "$SIGNING_GNUPGHOME/." "$WORK_DIR/gnupg/"
+else
+    gpg --homedir "$WORK_DIR/gnupg" --batch --passphrase '' --quick-generate-key \
+        'snosi native A/B secure-boot test <native-ab-secure-boot-test@invalid>' ed25519 sign 0
+fi
+gpg --homedir "$WORK_DIR/gnupg" --batch --export > "$WORK_DIR/import-pubring.gpg"
 
 echo "=== Step 0: build N and N+1 (this takes tens of minutes) ==="
 if [[ "$SKIP_BUILD" == 1 ]]; then
@@ -1402,14 +1452,9 @@ echo "=== Step 6: secure update hop (publish N+1, stage, reboot) ==="
 vm_ssh 'echo native-ab-secure-boot-test-var-marker > /var/lib/native-ab-secure-boot-test.marker'
 vm_ssh "printf '\nnative-ab-secure-boot-test etc marker\n' >> /etc/issue"
 
-# The ephemeral signing key MUST exist before publish_version's sign_sums
-# call below (it gpg-signs SHA256SUMS with whatever default secret key is
-# in this gnupg homedir) -- generate it first (observed live: publishing
-# before generating the key fails "no default secret key").
-gpg --homedir "$WORK_DIR/gnupg" --batch --passphrase '' --quick-generate-key \
-    'snosi native A/B secure-boot test <native-ab-secure-boot-test@invalid>' ed25519 sign 0
-gpg --homedir "$WORK_DIR/gnupg" --batch --export > "$WORK_DIR/import-pubring.gpg"
-
+# The ephemeral signing key already exists: it is generated (or restored
+# from SIGNING_GNUPGHOME under SKIP_BUILD=1) BEFORE the Step 0 builds, since
+# build_profile bakes its public half into every built image.
 publish_version "$BUILD_N1_DIR"
 
 cat > "$WORK_DIR/overrides/10-root-verity.transfer" <<EOF
@@ -1473,14 +1518,48 @@ TriesDone=0
 InstancesMax=2
 EOF
 
-vm_ssh 'mkdir -p /etc/sysupdate.d /etc/systemd'
+vm_ssh 'mkdir -p /etc/sysupdate.d'
 scp "${SSH_OPTS[@]}" -i "$SSH_KEY" -P "$SSH_PORT" \
     "$WORK_DIR/overrides/10-root-verity.transfer" \
     "$WORK_DIR/overrides/20-root.transfer" \
     "$WORK_DIR/overrides/90-uki.transfer" \
     root@localhost:/etc/sysupdate.d/
-scp "${SSH_OPTS[@]}" -i "$SSH_KEY" -P "$SSH_PORT" \
-    "$WORK_DIR/import-pubring.gpg" root@localhost:/etc/systemd/import-pubring.gpg
+
+# ---------------------------------------------------------------------------
+# Shipped vendor keyring (the reason THIS harness, not a cayo-ab-raw one,
+# carries this coverage): systemd 261 -- which only the production profiles
+# run -- reads the vendor update keyring at
+# /usr/lib/systemd/import-pubring.pgp, with NO legacy .gpg fallback for the
+# /usr path (commit 91718d7). Trixie's systemd 257, which cayo-ab-raw
+# boots, still reads the OLD /usr/lib/systemd/import-pubring.gpg name, so
+# no cayo-ab-raw harness (updateux/components/update/publication) can
+# exercise this link -- which is exactly how shipping only .gpg produced a
+# total signature-verification outage on real installs while every QEMU
+# harness passed via its /etc/systemd/import-pubring.gpg override. This
+# harness therefore installs NO /etc pubring override at all: the upcoming
+# stage must verify using ONLY the /usr vendor keyring baked at build time
+# (see build_profile), and Step 6c proves the negative (a wrong-key-signed
+# index is rejected through the same shipped ring).
+# ---------------------------------------------------------------------------
+assert_false "no /etc/systemd/import-pubring.gpg override (shipped trust path only)" \
+    vm_ssh 'test -e /etc/systemd/import-pubring.gpg'
+assert_false "no /etc/systemd/import-pubring.pgp override (shipped trust path only)" \
+    vm_ssh 'test -e /etc/systemd/import-pubring.pgp'
+ephemeral_ring_hash="$(sha256sum "$WORK_DIR/import-pubring.gpg")"
+ephemeral_ring_hash="${ephemeral_ring_hash%% *}"
+guest_pgp_hash="$(vm_ssh 'sha256sum /usr/lib/systemd/import-pubring.pgp 2>/dev/null' | awk '{print $1}' || true)"
+assert_eq "shipped /usr/lib/systemd/import-pubring.pgp is the baked ephemeral test ring" \
+    "$guest_pgp_hash" "$ephemeral_ring_hash"
+guest_gpg_hash="$(vm_ssh 'sha256sum /usr/lib/systemd/import-pubring.gpg 2>/dev/null' | awk '{print $1}' || true)"
+assert_eq "shipped /usr/lib/systemd/import-pubring.gpg twin matches the baked ring" \
+    "$guest_gpg_hash" "$ephemeral_ring_hash"
+# Canary for the 261 semantic itself: the import machinery that sysupdate
+# spawns must reference the vendor .pgp name. If a future systemd renames
+# the vendor path yet again, this pinpoints it instead of leaving only an
+# opaque verification failure.
+pull_refs_pgp="$(vm_ssh "grep -al 'import-pubring.pgp' /usr/lib/systemd/systemd-pull /usr/lib/systemd/systemd-sysupdate 2>/dev/null" || true)"
+assert_true "guest systemd's import machinery references the vendor .pgp name (261 semantics)" \
+    bash -c "[[ -n '$pull_refs_pgp' ]]"
 
 # Serve publish_dest itself (.../$IMAGE_ID/x86-64) as the HTTP root under
 # an "os" symlink so it matches the transfer files' Path=.../os/ exactly
@@ -1539,6 +1618,78 @@ assert_eq "N's root partition slot (rollback target) is still present" "$n_root_
 health="$(vm_ssh 'systemctl is-system-running --wait' || true)"
 assert_true "system health is running or degraded after the secure update" \
     bash -c "[[ '$health' == running || '$health' == degraded ]]"
+
+# ===========================================================================
+# Step 6c: wrong-key-signed index fails closed through the SAME shipped
+# vendor keyring. Negative half of the shipped-trust-path proof: Step 6
+# proved a pull verifies with no /etc override; this proves that success
+# was actual signature enforcement, not verification silently not
+# happening. This is the 2026-07-17 outage's exact failure-mode class -- a
+# structurally valid signature that no key in the effective keyring can
+# check ("gpg: Can't check signature: No public key").
+# ===========================================================================
+echo ""
+echo "=== Step 6c: index signed by an untrusted key is rejected via the shipped keyring ==="
+
+cp "$publish_dest/SHA256SUMS" "$WORK_DIR/sha256sums.n1-good"
+cp "$publish_dest/SHA256SUMS.gpg" "$WORK_DIR/sha256sums.gpg.n1-good"
+
+# Fabricate a version newer than the running N+1 by hardlinking N+1's own
+# published bytes under new names (test/native-ab-updateux-test.sh's Step 4
+# trick: no extra multi-gigabyte build, and check-new MUST attempt to trust
+# the index rather than silently no-opping as "nothing newer").
+wrong_fake_version="$(printf '%014d' "$((n1_version + 1))")"
+n1_root_real="$(find "$publish_dest" -maxdepth 1 -name "${CHANNEL}_${n1_version}_*.root.raw.xz")"
+n1_verity_real="$(find "$publish_dest" -maxdepth 1 -name "${CHANNEL}_${n1_version}_*.root-verity.raw.xz")"
+wrong_root_uuid="$(basename "$n1_root_real" | sed -E "s/^${CHANNEL}_${n1_version}_([0-9a-fA-F-]+)\.root\.raw\.xz\$/\\1/")"
+wrong_verity_uuid="$(basename "$n1_verity_real" | sed -E "s/^${CHANNEL}_${n1_version}_([0-9a-fA-F-]+)\.root-verity\.raw\.xz\$/\\1/")"
+ln "$n1_root_real" "$publish_dest/${CHANNEL}_${wrong_fake_version}_${wrong_root_uuid}.root.raw.xz"
+ln "$n1_verity_real" "$publish_dest/${CHANNEL}_${wrong_fake_version}_${wrong_verity_uuid}.root-verity.raw.xz"
+ln "$publish_dest/${CHANNEL}_${n1_version}.efi" "$publish_dest/${CHANNEL}_${wrong_fake_version}.efi"
+(cd "$publish_dest" && sha256sum \
+    "${CHANNEL}_${wrong_fake_version}_${wrong_root_uuid}.root.raw.xz" \
+    "${CHANNEL}_${wrong_fake_version}_${wrong_verity_uuid}.root-verity.raw.xz" \
+    "${CHANNEL}_${wrong_fake_version}.efi") >> "$publish_dest/SHA256SUMS"
+
+mkdir -p "$WORK_DIR/gnupg-wrong"
+chmod 700 "$WORK_DIR/gnupg-wrong"
+gpg --homedir "$WORK_DIR/gnupg-wrong" --batch --passphrase '' --quick-generate-key \
+    'snosi secure-boot test WRONG key <native-ab-secure-boot-test-wrong@invalid>' ed25519 sign 0
+gpg --homedir "$WORK_DIR/gnupg-wrong" --batch --yes --detach-sign \
+    -o "$publish_dest/SHA256SUMS.gpg" "$publish_dest/SHA256SUMS"
+# Distinguish this leg from a corrupted-bytes tamper case (updateux Step 4):
+# the signature must be cryptographically VALID -- just made by a key the
+# shipped vendor keyring does not contain.
+assert_true "wrong-key signature is itself a valid signature (by the wrong key)" \
+    gpg --homedir "$WORK_DIR/gnupg-wrong" --verify \
+    "$publish_dest/SHA256SUMS.gpg" "$publish_dest/SHA256SUMS"
+
+stager_out=""
+stager_rc=0
+stager_out="$(vm_ssh '/usr/libexec/snosi-sysupdate-stage' 2>&1)" || stager_rc=$?
+echo "$stager_out"
+assert_true "stager exits non-zero on the wrong-key-signed index" \
+    bash -c "[[ $stager_rc -ne 0 ]]"
+check_content="$(vm_ssh 'cat /run/snosi/update-check' 2>/dev/null || true)"
+assert_contains "update-check reports outcome=failed on the wrong-key index" \
+    "$check_content" "outcome=failed"
+assert_false "nothing staged from the wrong-key index" \
+    vm_ssh 'test -e /run/snosi/update-staged'
+layout_after_wrong_key="$(vm_ssh 'lsblk -J -o PARTLABEL' || echo "{}")"
+wrong_fake_count="$(jq --arg l "${IMAGE_ID}_${wrong_fake_version}_r" \
+    '[.. | objects | select(.partlabel? == $l)] | length' <<<"$layout_after_wrong_key")"
+assert_eq "no partition labeled with the wrong-key fake version" "$wrong_fake_count" "0"
+still_n1="$(guest_version)"
+assert_eq "running version unchanged after the wrong-key rejection" "$still_n1" "$n1_version"
+
+# Restore the origin to its known-good N+1 state: --full-window continues
+# from here (publish_version for N+2 would regenerate the index anyway, but
+# the fake hardlinks must not linger in the served directory either).
+rm -f "$publish_dest/${CHANNEL}_${wrong_fake_version}_${wrong_root_uuid}.root.raw.xz" \
+    "$publish_dest/${CHANNEL}_${wrong_fake_version}_${wrong_verity_uuid}.root-verity.raw.xz" \
+    "$publish_dest/${CHANNEL}_${wrong_fake_version}.efi"
+mv "$WORK_DIR/sha256sums.n1-good" "$publish_dest/SHA256SUMS"
+mv "$WORK_DIR/sha256sums.gpg.n1-good" "$publish_dest/SHA256SUMS.gpg"
 
 # ===========================================================================
 # Steps 8-11 (--full-window only): N+2, N+3, explicit rollback, boot-count

--- a/test/native-ab-secure-boot-test.sh
+++ b/test/native-ab-secure-boot-test.sh
@@ -397,6 +397,11 @@ build_profile() { # dest_dir
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.efi" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.${IMAGE_ID}_@v.root.raw.raw" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.${IMAGE_ID}_@v.root-verity.raw.raw" "$dest/"
+    # The product-curated feature catalog (features-catalog.finalize) is a
+    # REQUIRED publication artifact since the sysext feature catalog landed
+    # (prepare-native-publication.sh hard-fails without it). The build emits
+    # it as <IMAGE_ID>.features.json, not <Output>-prefixed.
+    cp "$ROOT_DIR/output/${IMAGE_ID}.features.json" "$dest/$PROFILE.features.json"
     echo "Build done -> $dest (finished $(date -u +%FT%TZ))"
 }
 
@@ -411,6 +416,10 @@ publish_version() { # build_dir -> sets publish_dest
     for suffix in manifest raw efi "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
         ln -s "$build_dir/$PROFILE.$suffix" "$stage/$CHANNEL.$suffix"
     done
+    # The feature catalog is looked up as <product>.features.json, where
+    # product is the manifest's .config.name (= IMAGE_ID) -- NOT the
+    # channel-prefixed name the other staged artifacts use.
+    ln -s "$build_dir/$PROFILE.features.json" "$stage/${IMAGE_ID}.features.json"
     "$ROOT_DIR/shared/native-ab/publish/prepare-native-publication.sh" --xz \
         "$stage" "$CHANNEL" "$WORK_DIR/publish-out"
     publish_dest="$WORK_DIR/publish-out/$IMAGE_ID/x86-64"
@@ -898,7 +907,7 @@ else
     build_profile "$BUILD_N1_DIR"
 fi
 
-for f in manifest raw efi "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
+for f in manifest raw efi features.json "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
     [[ -f "$BUILD_N_DIR/$PROFILE.$f" ]] || { echo "Error: missing N artifact: $f" >&2; exit 1; }
     [[ -f "$BUILD_N1_DIR/$PROFILE.$f" ]] || { echo "Error: missing N+1 artifact: $f" >&2; exit 1; }
 done
@@ -1718,7 +1727,7 @@ if [[ "$FULL_WINDOW" == 1 ]]; then
         build_profile "$BUILD_N2_DIR"
         build_profile "$BUILD_N3_DIR"
     fi
-    for f in manifest raw efi "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
+    for f in manifest raw efi features.json "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
         [[ -f "$BUILD_N2_DIR/$PROFILE.$f" ]] || { echo "Error: missing N+2 artifact: $f" >&2; exit 1; }
         [[ -f "$BUILD_N3_DIR/$PROFILE.$f" ]] || { echo "Error: missing N+3 artifact: $f" >&2; exit 1; }
     done

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -212,10 +212,20 @@ than the secure `cayo-ab` profile: `shared/native-ab/keys/README.md`
 documents that the update-signing pubring ships at `/usr/lib/systemd/import-pubring.gpg`
 on **every** native A/B image via the shared `shared/outformat/ab-root/
 mkosi.conf` fragment, `cayo-ab-raw` included, so booting it and never
-touching `/etc/systemd/import-pubring.gpg` exercises exactly the same
+touching `/etc/systemd/import-pubring.gpg` exercises the
 "verify a promotion signature against the stock shipped pubring" trust path
-a secure production profile would, without paying for OVMF Secure Boot + MOK
-enrollment (orthogonal Phase 6 machinery). The QEMU leg: boot N, `/etc/
+without paying for OVMF Secure Boot + MOK enrollment (orthogonal Phase 6
+machinery). CAVEAT (learned from the 2026-07-17 `.pgp` outage, commit
+91718d7): this is NOT byte-identical to a production profile's trust path —
+`cayo-ab-raw` runs Trixie's systemd 257, whose vendor keyring is the OLD
+`/usr/lib/systemd/import-pubring.gpg` name, while the production profiles'
+Forky systemd 261 reads `/usr/lib/systemd/import-pubring.pgp` with no
+`/usr` `.gpg` fallback. This leg therefore proves the promotion-signature
+half (signed index vs. shipped ring) but could not, and did not, catch
+shipping the ring under only the 257 name; the 261 `.pgp` vendor path is
+covered by `test/native-ab-secure-boot-test.sh`, which bakes an ephemeral
+ring over both `/usr` names at build time and runs with no `/etc` override
+(see `yeti/testing.md`). The QEMU leg: boot N, `/etc/
 sysupdate.d` origin override (same documented whole-file-replacement
 mechanism as `native-ab-updateux-test.sh`) pointed at the local rehearsal
 origin, stage promoted N+1 via `snosi-sysupdate-stage`, reboot, assert N+1.

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -370,13 +370,38 @@ image(s))" otherwise).
 
 The secure update hop publishes N+1 through the real
 `prepare-native-publication.sh --xz` pipeline to a local HTTP origin signed
-with an ephemeral GPG key (same `/etc/systemd/import-pubring.gpg` override
-mechanism as `native-ab-updateux-test.sh`), runs
-`/usr/libexec/snosi-sysupdate-stage`, and reboots with zero serial input —
-proving the signed PCR 11 policy survives a REAL UKI change (the entire point
-of signed-vs-raw PCR policy), that `/var` and `/etc`-overlay persistence
-markers survive, and that the N rollback entry is still present
-(`InstancesMax=2`). Finishes with a non-destructive recovery-keyslot check
+with an ephemeral GPG key that the guest trusts via its SHIPPED vendor
+keyring ONLY — since 2026-07-17 this harness installs NO
+`/etc/systemd/import-pubring.*` override (the mechanism every other update
+harness uses). The ephemeral public ring is baked into the built images at
+build time over the committed production pubring (whose private half is
+offline-only), at BOTH `/usr/lib/systemd/import-pubring.{gpg,pgp}` names,
+via two mkosi CLI `--extra-tree` flags in `build_profile` (CLI list-setting
+values append AFTER config-file values and ExtraTrees overwrite in install
+order, so the ephemeral pair wins; the committed file is never modified).
+This is the ONLY harness that can exercise the `.pgp` vendor path that
+commit 91718d7's outage proved untested: systemd 261 (production profiles)
+reads `/usr/lib/systemd/import-pubring.pgp` with no `/usr` `.gpg` fallback,
+while Trixie's systemd 257 (`cayo-ab-raw`, i.e. every other update harness
+including `native-ab-publication-test.sh`'s no-override leg) still reads
+the old `.gpg` name (verified via `strings` on `systemd-pull`). Before
+staging, the harness asserts no `/etc` override exists, both `/usr` names
+match the baked ring by sha256, and the guest's import binaries reference
+the `.pgp` name (a canary against a future vendor-path rename). It then
+runs `/usr/libexec/snosi-sysupdate-stage` and reboots with zero serial
+input — proving the signed PCR 11 policy survives a REAL UKI change (the
+entire point of signed-vs-raw PCR policy), that `/var` and `/etc`-overlay
+persistence markers survive, and that the N rollback entry is still present
+(`InstancesMax=2`). Step 6c then proves the positive result was actual
+signature enforcement: a fabricated newer-version index (updateux's
+hardlink trick) signed by a VALID but untrusted key — the outage's exact
+failure-mode class — must fail closed through the same shipped ring
+(stager rc!=0, `outcome=failed`, nothing staged, version unchanged),
+after which the origin is restored to the good N+1 index. Because the
+baked ring must match the signing key, `SKIP_BUILD=1` additionally
+requires `SIGNING_GNUPGHOME` (the gnupg homedir of the run that built the
+artifacts; `KEEP_VM=1` preserves it at `<workdir>/gnupg`). Finishes with a
+non-destructive recovery-keyslot check
 (`cryptsetup open --test-passphrase`), never a destructive token wipe.
 **NvPCR journal errors are asserted per boot** via a shared
 `assert_nvpcr_journal_clean` helper called after EVERY boot that reaches SSH


### PR DESCRIPTION
## Summary

Closes the last untested link in the update trust chain — the one that let the [#431](https://github.com/frostyard/snosi/pull/431) signature-verification outage ship: every QEMU update harness overrode the trust root at `/etc/systemd/import-pubring.gpg`, so the SHIPPED vendor keyring path was never exercised.

- **The leg lives in `test/native-ab-secure-boot-test.sh`, deliberately:** Trixie's systemd 257 (what `cayo-ab-raw` — i.e. every other update harness, including `native-ab-publication-test.sh`'s existing no-override leg — boots) still reads the OLD `/usr/lib/systemd/import-pubring.gpg` vendor name (verified via `strings` on `systemd-pull`). Only the production profiles' Forky systemd 261 reads `import-pubring.pgp`, so this is the one harness that can cover it.
- **Ephemeral ring baked at build time, no `/etc` override:** the committed pubring is now the production key (private half offline), so the harness generates its ephemeral key before the builds and bakes the public ring over BOTH `/usr/lib/systemd` names via two mkosi CLI `--extra-tree` flags (CLI list values append after config values and overwrite in install order — the committed file is never touched). The `/etc/systemd/import-pubring.gpg` scp is removed entirely.
- **Positive proof (Step 6):** asserts no `/etc/systemd/import-pubring.*` exists, both `/usr` names match the baked ring by sha256, and the guest import binaries reference `.pgp` (canary against a future vendor-path rename); the N→N+1 stage then verifies through the real 261 vendor path.
- **Negative proof (new Step 6c):** a fabricated newer-version index signed by a VALID but untrusted key — the outage's exact failure-mode class — must fail closed through the same shipped ring (`outcome=failed`, nothing staged, no fake-version partition, version unchanged), then the origin is restored.
- **`SKIP_BUILD=1` now requires `SIGNING_GNUPGHOME`** (the homedir whose key the prebuilt images embed).

Also fixes a pre-existing main breakage surfaced by the verification run: #430 made `prepare-native-publication.sh` hard-require `<IMAGE_ID>.features.json` in its staged dir, but only the synthetic-fixture tests were updated — this harness's `publish_version` now stages it. `native-ab-updateux-test.sh`, `native-ab-components-test.sh`, and `native-ab-publication-test.sh` have the same publish-time breakage and need the equivalent fix separately.

Docs updated (CLAUDE.md, yeti/testing.md, yeti/OVERVIEW.md, keys README), including two stale claims: CLAUDE.md still described the committed pubring as a DEV key with its private half in `.snosi-private/`, and yeti/OVERVIEW.md claimed the publication test's no-override leg exercises "exactly the same" trust path as a production profile (disproven by the outage).

## Test plan

- `shellcheck -S warning -x` clean; `bash -n` clean.
- Full live run: `sudo PROFILE=cayo-ab test/native-ab-secure-boot-test.sh` (default mode) — **58 passed, 0 failed** (2026-07-17, N=20260717130251 → N+1=20260717130613): the prior 47-assertion cayo-ab baseline plus the 11 new assertions, under enforced Secure Boot with TPM auto-unlock.
- Host-side pre-check on the built N artifact independently confirmed both `/usr` names carry the baked ephemeral ring and differ from the committed production ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)