### PR TITLE
test: stage the feature catalog in the QEMU publish harnesses (required since #430)

### DIFF
--- a/test/native-ab-components-test.sh
+++ b/test/native-ab-components-test.sh
@@ -177,6 +177,11 @@ build_profile() { # dest_dir
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.efi" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.${IMAGE_ID}_@v.root.raw.raw" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.${IMAGE_ID}_@v.root-verity.raw.raw" "$dest/"
+    # The product-curated feature catalog (features-catalog.finalize) is a
+    # REQUIRED publication artifact since the sysext feature catalog landed
+    # (prepare-native-publication.sh hard-fails without it). The build emits
+    # it as <IMAGE_ID>.features.json, not <Output>-prefixed.
+    cp "$ROOT_DIR/output/${IMAGE_ID}.features.json" "$dest/$PROFILE.features.json"
     echo "Build done -> $dest (finished $(date -u +%FT%TZ))"
 }
 
@@ -231,7 +236,7 @@ else
     build_profile "$BUILD_N1_DIR"
 fi
 
-for f in manifest raw efi "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
+for f in manifest raw efi features.json "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
     [[ -f "$BUILD_N_DIR/$PROFILE.$f" ]] || { echo "Error: missing N artifact: $f" >&2; exit 1; }
     [[ -f "$BUILD_N1_DIR/$PROFILE.$f" ]] || { echo "Error: missing N+1 artifact: $f" >&2; exit 1; }
 done
@@ -259,6 +264,10 @@ echo "N=$n_version  N+1=$n1_version"
 for suffix in manifest raw efi "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
     ln -s "$BUILD_N1_DIR/$PROFILE.$suffix" "$WORK_DIR/publish-src/$CHANNEL.$suffix"
 done
+# The feature catalog is looked up as <product>.features.json, where product
+# is the manifest's .config.name (= IMAGE_ID) -- NOT the channel-prefixed
+# name the other staged artifacts use.
+ln -s "$BUILD_N1_DIR/$PROFILE.features.json" "$WORK_DIR/publish-src/${IMAGE_ID}.features.json"
 "$ROOT_DIR/shared/native-ab/publish/prepare-native-publication.sh" --xz \
     "$WORK_DIR/publish-src" "$CHANNEL" "$WORK_DIR/publish-out"
 

--- a/test/native-ab-publication-test.sh
+++ b/test/native-ab-publication-test.sh
@@ -200,6 +200,11 @@ build_profile() {
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.efi" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.${IMAGE_ID}_@v.root.raw.raw" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.${IMAGE_ID}_@v.root-verity.raw.raw" "$dest/"
+    # The product-curated feature catalog (features-catalog.finalize) is a
+    # REQUIRED publication artifact since the sysext feature catalog landed
+    # (prepare-native-publication.sh hard-fails without it). The build emits
+    # it as <IMAGE_ID>.features.json, not <Output>-prefixed.
+    cp "$ROOT_DIR/output/${IMAGE_ID}.features.json" "$dest/$PROFILE.features.json"
     echo "Build done -> $dest (finished $(date -u +%FT%TZ))"
 }
 
@@ -213,6 +218,10 @@ prepare_version() {
     for suffix in manifest raw efi "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
         ln -s "$build_dir/$PROFILE.$suffix" "$stage/$CHANNEL.$suffix"
     done
+    # The feature catalog is looked up as <product>.features.json, where
+    # product is the manifest's .config.name (= IMAGE_ID) -- NOT the
+    # channel-prefixed name the other staged artifacts use.
+    ln -s "$build_dir/$PROFILE.features.json" "$stage/${IMAGE_ID}.features.json"
     "$PUBLISH_DIR/prepare-native-publication.sh" --xz "$stage" "$CHANNEL" "$dest_root" >&2
     echo "$dest_root/$IMAGE_ID/x86-64"
 }
@@ -326,7 +335,7 @@ else
     build_profile "$BUILD_N1_DIR"
 fi
 
-for f in manifest raw efi "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
+for f in manifest raw efi features.json "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
     [[ -f "$BUILD_N_DIR/$PROFILE.$f" ]] || { echo "Error: missing N artifact: $f" >&2; exit 1; }
     [[ -f "$BUILD_N1_DIR/$PROFILE.$f" ]] || { echo "Error: missing N+1 artifact: $f" >&2; exit 1; }
 done

--- a/test/native-ab-updateux-test.sh
+++ b/test/native-ab-updateux-test.sh
@@ -205,6 +205,11 @@ build_profile() {
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.efi" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.${IMAGE_ID}_@v.root.raw.raw" "$dest/"
     cp --sparse=always "$ROOT_DIR/output/$PROFILE.${IMAGE_ID}_@v.root-verity.raw.raw" "$dest/"
+    # The product-curated feature catalog (features-catalog.finalize) is a
+    # REQUIRED publication artifact since the sysext feature catalog landed
+    # (prepare-native-publication.sh hard-fails without it). The build emits
+    # it as <IMAGE_ID>.features.json, not <Output>-prefixed.
+    cp "$ROOT_DIR/output/${IMAGE_ID}.features.json" "$dest/$PROFILE.features.json"
     echo "Build done -> $dest (finished $(date -u +%FT%TZ))"
 }
 
@@ -225,6 +230,10 @@ publish_version() {
     for suffix in manifest raw efi "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
         ln -s "$build_dir/$PROFILE.$suffix" "$stage/$CHANNEL.$suffix"
     done
+    # The feature catalog is looked up as <product>.features.json, where
+    # product is the manifest's .config.name (= IMAGE_ID) -- NOT the
+    # channel-prefixed name the other staged artifacts use.
+    ln -s "$build_dir/$PROFILE.features.json" "$stage/${IMAGE_ID}.features.json"
     "$ROOT_DIR/shared/native-ab/publish/prepare-native-publication.sh" --xz \
         "$stage" "$CHANNEL" "$WORK_DIR/publish-out"
     publish_dest="$WORK_DIR/publish-out/$IMAGE_ID/x86-64"
@@ -275,7 +284,7 @@ else
     build_profile "$BUILD_N1_DIR" SNOSI_NATIVE_AUTOSTAGE=1
 fi
 
-for f in manifest raw efi "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
+for f in manifest raw efi features.json "${IMAGE_ID}_@v.root.raw.raw" "${IMAGE_ID}_@v.root-verity.raw.raw"; do
     [[ -f "$BUILD_N_DIR/$PROFILE.$f" ]] || { echo "Error: missing N artifact: $f" >&2; exit 1; }
     [[ -f "$BUILD_N1_DIR/$PROFILE.$f" ]] || { echo "Error: missing N+1 artifact: $f" >&2; exit 1; }
 done

--- a/test/native-installer-e2e-test.sh
+++ b/test/native-installer-e2e-test.sh
@@ -252,6 +252,14 @@ copy_build_artifacts() { # profile image_id dest
     for suffix in manifest raw efi "${image_id}_@v.root.raw.raw" "${image_id}_@v.root-verity.raw.raw"; do
         cp --sparse=always "$OUTPUT_DIR/$profile.$suffix" "$dest/"
     done
+    # The product-curated feature catalog (features-catalog.finalize) is a
+    # REQUIRED publication artifact since the sysext feature catalog landed
+    # (prepare-native-publication.sh hard-fails without it). The build emits
+    # it as <image_id>.features.json, and since $dest doubles as the
+    # publisher's source dir here, keep that exact name -- the publisher
+    # looks it up as <product>.features.json (product = manifest
+    # .config.name = image_id).
+    cp "$OUTPUT_DIR/${image_id}.features.json" "$dest/"
 }
 
 if [[ "$SKIP_CAYO_BUILD" != 1 ]]; then

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -128,6 +128,22 @@ build output is never itself named `cayo-ab`. Both scripts default to
 byte-equivalent behavior against `cayo`/`cayo-ab-raw`/`cayo-ab` when run with
 no overrides.
 
+Every harness that runs build outputs through
+`shared/native-ab/publish/prepare-native-publication.sh` (updateux,
+components, publication, secure-boot, installer-e2e) must stage the
+product-curated feature catalog alongside the split artifacts: since the
+sysext feature catalog landed (#430, df7bc6e) the publisher hard-fails
+without `<product>.features.json` in its source dir. The build emits it as
+`output/<IMAGE_ID>.features.json` (NOT `<Output>`-prefixed like the other
+split artifacts), and the staged name must be IMAGE_ID-based, not
+CHANNEL-based — the publisher derives product from the manifest's
+`.config.name`. Each harness's `build_profile` copies it as
+`$PROFILE.features.json` next to the other artifacts and its
+publish-staging step links it into the stage as
+`${IMAGE_ID}.features.json` (`native-installer-e2e-test.sh` is the
+exception: its build dir doubles as the publisher source dir, so
+`copy_build_artifacts` keeps the `<image_id>.features.json` name as-is).
+
 `native-ab-update-test.sh` uses four real `cayo-ab-raw` builds to exercise signed
 manifest rejection, N through N+3 updates, slot reuse, rollback, and boot-count
 fallback in QEMU.


### PR DESCRIPTION
## Summary

#430 (df7bc6e, sysext feature catalog) made `prepare-native-publication.sh` hard-fail without `<product>.features.json` in its staged source dir, but only the synthetic-fixture tests (`native-publication-pipeline-test.sh`, `native-publish-test.sh`) were updated. Every QEMU harness that stages build outputs for the publisher broke at publish time.

This applies the same fix the secure-boot harness got on `feat/shipped-pubring-leg` (46a719f) to the remaining four:

- **`test/native-ab-updateux-test.sh`**, **`test/native-ab-components-test.sh`**, **`test/native-ab-publication-test.sh`**: `build_profile` copies `output/<IMAGE_ID>.features.json` to `$dest/$PROFILE.features.json`; the publish staging links it into the stage as `<IMAGE_ID>.features.json` (IMAGE_ID-based, not CHANNEL-based — the publisher derives product from the manifest's `.config.name`); the post-build artifact-existence check loops now assert it.
- **`test/native-installer-e2e-test.sh`**: broken the same way (its build dir doubles as the publisher source dir) — `copy_build_artifacts` now copies the catalog, keeping the `<image_id>.features.json` name as-is.

`native-ab-update-test.sh` is unaffected (hand-rolled naming, never calls the publisher). `build_fake_prepared_dir` in the publication harness needs no change — downstream scripts enumerate objects from the SHA256SUMS it writes itself. Also documents the staging requirement in `yeti/testing.md`.

## Verification

- `bash -n` + `shellcheck -S warning` clean on all four scripts
- `test/native-publish-test.sh` 55/55 (publisher fixture contract)
- **`sudo test/native-ab-updateux-test.sh` end to end: 53/53 green** (N=20260717133929 → N+1=20260717134243, tamper case rejected); the log shows both builds emitting the catalog and the publisher writing `cayo-ab_<version>.features.json` for N and N+1 — the exact hard-fail point this fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)