### PR TITLE
fix: mask hanging native Plymouth unit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,13 @@ with the bootc profiles), so `shared/outformat/ab-root/tree/usr/lib/systemd/{sys
 masks each one with a same-named `/dev/null` symlink — the same mechanism used for
 `systemd-growfs-root.service`. Upstream's own `bootc-fetch-apply-updates.*` ships
 inside the `bootc` deb itself, which native profiles never install, so those two
-units need no mask. `test/native-ab-static-test.sh` asserts every mask exists.
+units need no mask. Native also masks `plymouth-read-write.service`: root is
+permanently read-only EROFS, so its `plymouth update-root-fs --read-write`
+notification is meaningless, and on minisnow it intermittently blocked forever
+before `sysinit.target` (solid cursor, no network, runtime watchdog still fed,
+Magic SysRq responsive). Failed boots started the unit without finishing it;
+successful boots completed it in 40-53 ms. `test/native-ab-static-test.sh`
+asserts every mask exists.
 `test/native-ab-update-test.sh` validates N to N+1 to N+2 to N+3 with four real
 mkosi builds: signed-manifest acceptance/rejection, missing UKI/verity and bad
 checksum rejection, inactive-slot reuse, dm-verity boot, explicit rollback,

--- a/shared/outformat/ab-root/tree/usr/lib/systemd/system/plymouth-read-write.service
+++ b/shared/outformat/ab-root/tree/usr/lib/systemd/system/plymouth-read-write.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/test/native-ab-static-test.sh
+++ b/test/native-ab-static-test.sh
@@ -291,6 +291,11 @@ assert_masked() { # relpath-under-tree
     }
 }
 
+# Native root is permanently read-only EROFS. The distro unit's Plymouth
+# notification can block forever before sysinit.target while waiting for a
+# root transition that never exists (reproduced on minisnow, 2026-07-17).
+assert_masked system/plymouth-read-write.service
+
 for unit in system/bootc-update-stage.timer system/bootc-update-stage.service \
     system/nbc-update-download.timer system/nbc-update-download.service; do
     base_unit="$root/mkosi.images/base/mkosi.extra/usr/lib/systemd/$unit"

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -358,7 +358,14 @@ units unconditionally for the bootc profiles, and on native boot (no
 `ConditionKernelCommandLine=!composefs` is true, so nbc would otherwise run
 against a GPT layout it does not understand. Upstream's own
 `bootc-fetch-apply-updates.*` ships inside the `bootc` deb, which native
-profiles never install, so it needs no mask. The installer grows only the final `var` partition. OS transfers use `Verify=yes`,
+profiles never install, so it needs no mask. The same native tree masks
+`plymouth-read-write.service`: native root is permanently read-only EROFS, and
+the distro unit's infinite-timeout `plymouth update-root-fs --read-write`
+occasionally blocked before `sysinit.target` on minisnow (2026-07-17). PID 1
+continued feeding the hardware watchdog and the kernel handled Magic SysRq,
+but no later target was dispatched; every failed boot lacked the unit's
+completion message while successful boots completed it in 40-53 ms. The
+installer grows only the final `var` partition. OS transfers use `Verify=yes`,
 but unattended updates stay disabled until the dedicated OS OpenPGP keyring
 and signed publication pipeline exist. Partition payloads use XZ because the
 Debian systemd 257 `systemd-pull` build does not support Zstandard; unsupported


### PR DESCRIPTION
## Summary
- mask `plymouth-read-write.service` on native A/B images, whose EROFS root never transitions to writable
- guard the native mask in `native-ab-static-test.sh`
- document the live failure signature and rationale

## Root cause
`plymouth update-root-fs --read-write` intermittently blocked forever before `sysinit.target` on minisnow. Failed boots showed a solid cursor and no network while PID 1 kept feeding the runtime watchdog and Magic SysRq remained responsive. Every failed journal started `plymouth-read-write.service` without completing it; successful boots completed it in 40-53 ms.

## Validation
- `./test/native-ab-static-test.sh`
- `shellcheck -S warning -x test/native-ab-static-test.sh`
- five consecutive live reboots with the mask, all reaching `graphical.target` in 52-55 seconds with zero failed units