### PR TITLE
fix: add libmtp-runtime to graphical package set (missing mtp-probe)

### DIFF
--- a/shared/packages/snow/mkosi.conf
+++ b/shared/packages/snow/mkosi.conf
@@ -53,6 +53,14 @@ Packages=adwaita-icon-theme
 # CLI. Graphical images only — cayo (server) has no desktop session.
 Packages=libnotify-bin
 
+# MTP device probing: gvfs-backends pulls libmtp9t64 -> libmtp-common, whose
+# udev rule (69-libmtp.rules) calls /usr/lib/udev/mtp-probe — but that binary
+# lives in libmtp-runtime, which is only a Recommends and never installed.
+# Without it every USB hotplug logs a udev-worker callout failure and MTP
+# devices (Android phones) miss ID_MTP_DEVICE tagging, breaking gvfs MTP
+# automount in Files. Graphical images only — cayo has no gvfs/libmtp at all.
+Packages=libmtp-runtime
+
 
 # nspawn
 Packages=systemd-container

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -110,6 +110,21 @@ Consumers of the update state:
   observed on the first real desktop bootc host 2026-07-07); the per-digest ack
   keeps the repeat triggers harmless.
 
+**Recommends-split companion binaries (recurring pattern):** the image build
+installs without Recommends, so a transitively-pulled library package can ship
+config that references a helper binary living in a Recommends-only companion
+package — which silently never installs. Two confirmed instances: `libnotify4`
+vs `libnotify-bin` (above), and `libmtp-common` (pulled via `gvfs-backends` →
+`libmtp9t64`) whose udev rule `69-libmtp.rules` calls
+`/usr/lib/udev/mtp-probe` from the never-installed `libmtp-runtime` — every
+USB hotplug logged a udev-worker "Failed to find and pin callout binary"
+error and MTP devices missed `ID_MTP_DEVICE` tagging, breaking gvfs MTP
+automount (root-caused live on a snow-ab install 2026-07-20; fixed by adding
+`libmtp-runtime` to the graphical package set). When a shipped udev rule,
+unit, or script references a binary, verify the binary's owning package is
+actually in the package set — `Recommends:` in a dependent package is not
+enough.
+
 This mirrors the previous nbc-style download-only semantics: the staged deployment applies at the next normal reboot. The podman transfer path is also the current workaround for bootc registry-transport composefs pull failures noted in `docs/plans/2026-07-03-bootc-update-validation-plan.md`.
 
 Runtime units shipped in `mkosi.extra/` must not self-disable, call `systemctl preset`, or otherwise delete shipped `/etc` state. For run-once behavior, use a persistent `/var` marker (`ConditionPathExists=!/var/lib/<unit>.done` and a final `touch`) so bootc can merge `/etc` cleanly when the next staged deployment finalizes.


### PR DESCRIPTION
## Summary
- Add `libmtp-runtime` to the graphical package set (`shared/packages/snow/mkosi.conf`, snow + snowfield, bootc and native alike).
- Record the recurring "Recommends-split companion binary" pattern in `yeti/build-pipeline.md`.

## Problem
`gvfs-backends` → `libmtp9t64` → `libmtp-common` ships the udev rule `69-libmtp.rules`, which invokes `/usr/lib/udev/mtp-probe` — but that binary lives in `libmtp-runtime`, which `libmtp9t64` only *Recommends*, so the image build never installs it. Confirmed live on a booted snow-ab install:

- every USB hotplug logs `(udev-worker): Failed to find and pin callout binary '/usr/lib/udev/mtp-probe': No such file or directory`
- MTP devices (Android phones) miss `ID_MTP_DEVICE` tagging, breaking gvfs MTP automount in GNOME Files

Verified against the Debian Trixie file list that `libmtp-runtime` ships the binary at exactly that path.

## Scope
Desktop-only by construction: `gvfs-backends` is the sole reverse dependency of `libmtp9t64`, and cayo ships no gvfs/libmtp at all — so the dangling rule never existed there and the fix correctly lives in the graphical set (same file as the analogous `libnotify-bin` case).

No var-audit map changes needed: `libmtp-runtime` ships only the binary, udev support files, and a manpage — no `/var` state.

## Test plan
- [x] Dependency chain verified via `apt-cache` (rdepends of `libmtp9t64`/`libmtp-common`) and Debian package file list
- [x] Bug reproduced live on a snow install (rule present, binary absent)
- [ ] CI image build (next `snow` build ships the binary; udev error disappears on hotplug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)