### PR TITLE
feat: add pilothouse sysext (Snosi web administration console)

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -89,6 +89,15 @@ jobs:
             echo "lemonade_version=$LATEST_LEM" >> $GITHUB_OUTPUT
           fi
 
+          # Check Pilothouse (Snosi web administration console)
+          CURRENT_PH=$(jq -r '.pilothouse.version' "$CHECKSUMS")
+          LATEST_PH=$(gh_api https://api.github.com/repos/frostyard/pilothouse/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_PH" && "$LATEST_PH" != "null" ]] && ver_gt "$LATEST_PH" "$CURRENT_PH"; then
+            UPDATES="${UPDATES}pilothouse: $CURRENT_PH -> $LATEST_PH\n"
+            echo "pilothouse_update=true" >> $GITHUB_OUTPUT
+            echo "pilothouse_version=$LATEST_PH" >> $GITHUB_OUTPUT
+          fi
+
           # Check Microsoft Azure VPN Client
           CURRENT_AZ=$(jq -r '.["microsoft-azurevpnclient"].version' "$CHECKSUMS")
           LATEST_AZ=$(curl -fsSL --retry 3 --retry-delay 2 https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/ | grep -oP 'microsoft-azurevpnclient_\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
@@ -139,6 +148,8 @@ jobs:
           CODER_VERSION: ${{ steps.check.outputs.coder_version }}
           LEMONADE_UPDATE: ${{ steps.check.outputs.lemonade_update }}
           LEMONADE_VERSION: ${{ steps.check.outputs.lemonade_version }}
+          PILOTHOUSE_UPDATE: ${{ steps.check.outputs.pilothouse_update }}
+          PILOTHOUSE_VERSION: ${{ steps.check.outputs.pilothouse_version }}
           AZUREVPN_UPDATE: ${{ steps.check.outputs.azurevpn_update }}
           AZUREVPN_VERSION: ${{ steps.check.outputs.azurevpn_version }}
           EDGE_UPDATE: ${{ steps.check.outputs.edge_update }}
@@ -192,6 +203,18 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
               '.lemonade.url=$u | .lemonade.sha256=$s | .lemonade.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$PILOTHOUSE_UPDATE" == "true" ]]; then
+            VER="$PILOTHOUSE_VERSION"
+            URL="https://github.com/frostyard/pilothouse/releases/download/v${VER}/frostyard-pilothouse_${VER}_amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.pilothouse.url=$u | .pilothouse.sha256=$s | .pilothouse.version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 17 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, podman, tailscale, vscode).
+**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 18 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, pilothouse, podman, tailscale, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 17 sysexts
+just sysexts            # Build base + all 18 sysexts
 just snow               # Build snow desktop image
 just snowfield          # Build snowfield (Surface kernel)
 just cayo               # Build cayo server image
@@ -256,7 +256,7 @@ persistence.
 builds two real `cayo-ab-raw` versions itself, boots N, and asserts no failed
 systemd units and the bootc/nbc/systemd-sysupdate masks from above; that
 `/usr/lib/sysupdate.d/` contains only the three OS transfers (no `.feature`
-files) while `systemd-sysupdate components` enumerates all 17 shipped sysext
+files) while `systemd-sysupdate components` enumerates all 18 shipped sysext
 components; that two independently versioned ad hoc test components
 (`testa`/`testb`, created under `/etc/sysupdate.<name>.d/`) update via
 `--component=` without touching OS partitions, the ESP, or each other's

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The project produces:
 | **incus**           | Incus container/VM manager                                      | sysext        |
 | **lemonade**        | Lemonade local LLM server (GPU/NPU accelerated)                 | sysext        |
 | **nix**             | Nix package manager                                             | sysext        |
+| **pilothouse**      | Pilothouse local web administration console for Snosi           | sysext        |
 | **podman**          | Podman + Distrobox                                              | sysext        |
 | **tailscale**       | Tailscale VPN client                                            | sysext        |
 | **vscode**          | Visual Studio Code desktop application                          | sysext        |
@@ -425,7 +426,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, podman, tailscale, vscode)
+1. Builds the base image and all sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, pilothouse, podman, tailscale, vscode)
 2. Publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Uploads package manifests for version tracking
 

--- a/check-profile-dependencies.sh
+++ b/check-profile-dependencies.sh
@@ -14,6 +14,7 @@ sysexts=(
     docker
     incus
     nix
+    pilothouse
     podman
     tailscale
 )

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -15,6 +15,7 @@ Dependencies=base
              incus
              lemonade
              nix
+             pilothouse
              podman
              tailscale
              vscode

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.pilothouse.d/pilothouse.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.pilothouse.d/pilothouse.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=Pilothouse local web administration console for Snosi
+Documentation=https://github.com/frostyard/pilothouse
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.pilothouse.d/pilothouse.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.pilothouse.d/pilothouse.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=pilothouse
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/pilothouse/
+MatchPattern=pilothouse_@v_%w_%a.raw.zst \
+             pilothouse_@v_%w_%a.raw.xz \
+             pilothouse_@v_%w_%a.raw.gz \
+             pilothouse_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=pilothouse_@v_%w_%a.raw.zst \
+             pilothouse_@v_%w_%a.raw.xz \
+             pilothouse_@v_%w_%a.raw.gz \
+             pilothouse_@v_%w_%a.raw
+CurrentSymlink=pilothouse.raw

--- a/mkosi.images/pilothouse/mkosi.conf
+++ b/mkosi.images/pilothouse/mkosi.conf
@@ -1,0 +1,23 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=pilothouse
+Output=pilothouse
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+
+[Build]
+# Like coder, frostyard-pilothouse is not in Packages= — the deb is installed
+# by mkosi.postinst.chroot via verified_download + dpkg -i (GitHub release, no
+# apt repo). The postoutput script still resolves KEYPACKAGE from the merged
+# dpkg database. The deb declares no Depends (static Go binaries), so no
+# runtime packages are needed here.
+Environment=KEYPACKAGE=frostyard-pilothouse

--- a/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system-preset/40-pilothouse.preset
+++ b/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system-preset/40-pilothouse.preset
@@ -1,0 +1,2 @@
+enable pilothoused.service
+enable pilothouse.service

--- a/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-pilothouse.conf
+++ b/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-pilothouse.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=pilothoused.service pilothouse.service

--- a/mkosi.images/pilothouse/mkosi.extra/usr/lib/tmpfiles.d/pilothouse.conf
+++ b/mkosi.images/pilothouse/mkosi.extra/usr/lib/tmpfiles.d/pilothouse.conf
@@ -1,0 +1,4 @@
+# Copy the pilothouse PAM config from factory defaults (see mkosi.finalize);
+# pilothoused authenticates admin actions through the "pilothouse" PAM
+# service, and sysexts cannot ship /etc directly.
+C /etc/pam.d/pilothouse - - - - -

--- a/mkosi.images/pilothouse/mkosi.finalize
+++ b/mkosi.images/pilothouse/mkosi.finalize
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -euo pipefail
+
+# Capture the deb's PAM config to factory defaults for tmpfiles.d to restore
+# at boot. pilothoused authenticates admin actions via PAM ("pilothouse"
+# service name); sysexts cannot ship /etc, so the file is injected from
+# /usr/share/factory/etc when the sysext is merged.
+mkdir -p "$BUILDROOT/usr/share/factory/etc/pam.d"
+
+if [ -f "$BUILDROOT/etc/pam.d/pilothouse" ]; then
+    cp --archive --update=none "$BUILDROOT/etc/pam.d/pilothouse" \
+       "$BUILDROOT/usr/share/factory/etc/pam.d/"
+fi

--- a/mkosi.images/pilothouse/mkosi.postinst.chroot
+++ b/mkosi.images/pilothouse/mkosi.postinst.chroot
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "pilothouse" "$DEBS/pilothouse.deb"
+
+# The deb has no Depends (static Go binaries). It ships its own sysusers.d
+# fragment in /usr (creates the pilothouse user/group at boot) and a PAM
+# config at /etc/pam.d/pilothouse, which is stripped from the sysext delta —
+# mkosi.finalize captures it to factory defaults for tmpfiles to restore.
+dpkg -i "$DEBS/pilothouse.deb"

--- a/mkosi.images/pilothouse/required-paths.txt
+++ b/mkosi.images/pilothouse/required-paths.txt
@@ -1,0 +1,13 @@
+# pilothouse sysext: installed via verified_download + dpkg -i in postinst
+/usr/bin/pilothouse
+/usr/bin/pilothoused
+/usr/lib/systemd/system/pilothouse.service
+/usr/lib/systemd/system/pilothoused.service
+# Deb-shipped sysusers fragment (creates the pilothouse user/group at boot)
+/usr/lib/sysusers.d/pilothouse.conf
+# Factory copy of /etc/pam.d/pilothouse (injected at boot by tmpfiles)
+/usr/share/factory/etc/pam.d/pilothouse
+# Boot-time config injection and activation
+/usr/lib/tmpfiles.d/pilothouse.conf
+/usr/lib/systemd/system-preset/40-pilothouse.preset
+/usr/lib/systemd/system/multi-user.target.d/10-pilothouse.conf

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -33,5 +33,10 @@
     "url": "https://github.com/lemonade-sdk/lemonade/releases/download/v11.0.0/lemonade-server_11.0.0-debian13_amd64.deb",
     "sha256": "dd904bfead7ecc0a82fd8cd16b8ee482f909b39b97dd0051740f9730a79d7d3c",
     "version": "11.0.0"
+  },
+  "pilothouse": {
+    "url": "https://github.com/frostyard/pilothouse/releases/download/v0.2.0/frostyard-pilothouse_0.2.0_amd64.deb",
+    "sha256": "6a84312f1da684283e586a4cd1e71b93f6004d0484f2342c82428df7537066c2",
+    "version": "0.2.0"
   }
 }

--- a/test/native-ab-components-test.sh
+++ b/test/native-ab-components-test.sh
@@ -15,7 +15,7 @@
 # in QEMU, and validates in order:
 #
 #   1. No failed legacy updaters; bootc/nbc/sysupdate auto-update units masked.
-#   2. The OS default sysupdate.d target and the 17 shipped sysext components
+#   2. The OS default sysupdate.d target and the 18 shipped sysext components
 #      are structurally separate (component discovery via `systemd-sysupdate
 #      components`).
 #   3. Two ad hoc test sysext components (testa, testb; independently
@@ -525,7 +525,8 @@ assert_eq "/usr/lib/sysupdate.d/ contains exactly the OS transfers, no features"
     "$default_target_listing" "$expected_default_listing"
 
 expected_sysext_components=(1password 1password-cli azurevpn bitwarden claude-desktop
-    coder code-server debdev dev docker edge incus lemonade nix podman tailscale vscode)
+    coder code-server debdev dev docker edge incus lemonade nix pilothouse podman
+    tailscale vscode)
 
 components_raw="$(vm_ssh '/usr/lib/systemd/systemd-sysupdate components --no-legend')"
 echo "systemd-sysupdate components --no-legend:"

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -986,7 +986,7 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
-1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, podman, tailscale, vscode
+1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, pilothouse, podman, tailscale, vscode
 
 ## Architecture
 
@@ -996,10 +996,10 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 17 sysexts)
+mkosi.images/               # Image definitions (base + 18 sysexts)
   base/                     # Foundation image: systemd, bootc/ostree (frostyard debs), firmware, core utils
     mkosi.extra/            # Base filesystem overlay (dracut, systemd units/timers, sysupdate, tmpfiles, sysusers)
-      usr/lib/sysupdate.<name>.d/  # per-sysext .transfer + .feature component dirs (one pair each, 17 total)
+      usr/lib/sysupdate.<name>.d/  # per-sysext .transfer + .feature component dirs (one pair each, 18 total)
     mkosi.postinst.chroot   # Mount enablement, useradd home dir, bls-garbage-collect removal
     mkosi.finalize.chroot   # Masks systemd-networkd-wait-online
   docker/                   # Each sysext: mkosi.conf + optional extra/scripts
@@ -1293,7 +1293,7 @@ Use build-time enablement/presets for desired service state. For run-once runtim
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 17 sysexts
+just sysexts            # Build base + all 18 sysexts
 just snow               # Build snow desktop
 just snowfield          # Build snowfield (Surface)
 just cayo               # Build cayo server

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -31,6 +31,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **incus** | incus | Incus container/VM manager, QEMU/KVM, dnsmasq, OVMF, virt-viewer |
 | **lemonade** | lemonade-server | Lemonade local LLM server (lemond) — downloaded via `verified_download()` from lemonade-sdk/lemonade GitHub releases; libcpp-httplib0.41 dep from trixie-backports |
 | **nix** | nix-setup-systemd | Nix package manager with systemd integration |
+| **pilothouse** | frostyard-pilothouse | Pilothouse local web administration console for Snosi (pilothouse web UI + pilothoused root broker) — downloaded via `verified_download()` from frostyard/pilothouse GitHub releases |
 | **podman** | podman | Podman, distrobox, buildah, crun, slirp4netns |
 | **tailscale** | tailscale | Tailscale VPN client |
 | **vscode** | code | Visual Studio Code desktop application (from packages.microsoft.com) |
@@ -194,6 +195,14 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `usr/lib/systemd/system/multi-user.target.d/10-nix.conf` — `Upholds=nix.mount nix-daemon.socket nix-daemon.service` drop-in for reliable boot activation
 - `usr/lib/sysusers.d/nix.conf` — Nix user/group
 - `usr/lib/tmpfiles.d/nix.conf` — `/nix` hierarchy + factory config injection
+
+### pilothouse
+- `mkosi.postinst.chroot` — Downloads the frostyard-pilothouse .deb (GitHub release, no apt repo) via `verified_download()`, installs with `dpkg -i`. Static Go binaries (no Depends), everything ships natively under `/usr`; no relocation
+- `mkosi.finalize` — Captures `/etc/pam.d/pilothouse` to factory defaults; `pilothoused` authenticates admin actions through the "pilothouse" PAM service and sysexts cannot ship `/etc`
+- The deb's own `usr/lib/sysusers.d/pilothouse.conf` creates the `pilothouse` user/group at boot (ships in `/usr`, so it survives the delta — no extra sysusers fragment needed)
+- `usr/lib/tmpfiles.d/pilothouse.conf` — Factory PAM config injection
+- `usr/lib/systemd/system-preset/40-pilothouse.preset` — Enables `pilothoused.service` (root broker on `/run/pilothouse/broker.sock`) and `pilothouse.service` (web UI on 127.0.0.1:8888)
+- `usr/lib/systemd/system/multi-user.target.d/10-pilothouse.conf` — `Upholds=pilothoused.service pilothouse.service` drop-in for reliable boot activation
 
 ### tailscale
 - `mkosi.finalize` — Captures `/etc/default/tailscaled` to factory defaults (tailscaled requires the EnvironmentFile)


### PR DESCRIPTION
## Summary

Adds **pilothouse** as the 18th sysext, packaging [frostyard/pilothouse](https://github.com/frostyard/pilothouse) v0.2.0 (local web administration console: unprivileged `pilothouse` web process + root-only `pilothoused` action broker).

Follows the coder/lemonade GitHub-release-deb pattern:

- `mkosi.images/pilothouse/` — deb fetched via `verified_download()` (SHA-256 pinned from upstream `checksums.txt` and independently re-hashed) and installed with `dpkg -i`; `KEYPACKAGE=frostyard-pilothouse`. The deb declares **no Depends** (static Go binaries), so no `Packages=` additions.
- The deb's `/etc/pam.d/pilothouse` (PAM auth for admin actions) is captured to `/usr/share/factory/etc/pam.d/` in `mkosi.finalize` and injected at boot by a tmpfiles `C` rule — sysexts cannot ship `/etc`.
- `40-pilothouse.preset` enables both services; `multi-user.target.d/10-pilothouse.conf` ships the mandatory `Upholds=` drop-in for post-merge activation.
- The deb's own `usr/lib/sysusers.d/pilothouse.conf` (in `/usr`, survives the delta) creates the user/group at boot; no extra sysusers fragment needed.
- Registered in: root `mkosi.conf` `Dependencies=`, its own `sysupdate.pilothouse.d/` component (`Enabled=false`, no `X-Snosi-Products` — applicable to all products including cayo), `sysext-checksums.json`, the weekly `check-dependencies.yml` update check (downgrade-guarded, frostyard/pilothouse releases/latest), `check-profile-dependencies.sh`, `test/native-ab-components-test.sh`, and docs (CLAUDE.md / README.md / yeti — 17 → 18 everywhere).

## Verification

- `./check-duplicate-packages.sh` — pass
- `./check-runtime-etc-guard.sh` — pass (exit 0)
- CI-exact shellcheck sweep (`shellcheck -S warning -x` over shebang-discovered scripts) — pass
- `mkosi summary` — resolves 21 images including `pilothouse`; `./check-profile-dependencies.sh` — "Profile builds depend only on base."
- Full unprivileged `mkosi -f build` (base + all 18 sysexts) — **completed exit 0**; `output/pilothouse_0.2.0_13_x86-64.raw` (32 MiB) produced with the postoutput naming matching the transfer `MatchPattern`. Extracted the erofs delta and verified exact contents: both binaries, both units, preset, Upholds drop-in, sysusers, tmpfiles rule, factory PAM copy, extension-release — no `/etc` leakage, no icon cache.

Not verified here: a booted merge test (QEMU `native-ab-components-test.sh` was not run — needs root/KVM) and publication (happens via `build.yml` on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)