### PR TITLE
fix: parse updex features list as JSON in snosi-firstboot

### DIFF
--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -66,7 +66,7 @@ completeness and excluded from the contract catalog below.
 ```
 updex ──CLI(--json)──────────► pilothouse   (features check / list / update / enable / disable)
 updex ──Go SDK───────────────► chairlift    (Features / CheckFeatures / Enable / Disable / UpdateFeatures)
-updex ──CLI(text table)──────► snosi-firstboot (features list, features enable --now)
+updex ──CLI(--json)──────────► snosi-firstboot (features list --json, features enable --now)
 updex ──.feature/.transfer───► systemd-sysupdate + updex itself (component discovery)
 
 systemd-sysupdate ──CLI──────► snosi-sysupdate-stage, snosi-update-status
@@ -245,19 +245,19 @@ Each entry: **Producer** → **Consumer**, transport, contract, fragility.
 - **Contract:** SDK signatures `Features/Components/EnableFeature/DisableFeature/UpdateFeatures/CheckFeatures`. Version lockstep matters: chairlift must track updex's SDK API, not just its CLI.
 - **Fragility:** 🟢 for shape; 🟡 for version coupling (a breaking SDK change requires a coordinated chairlift bump).
 
-### 4.3 updex CLI text table → snosi-firstboot
-- **Producer:** `updex --silent features list` (human table, **not** JSON).
-- **Consumer:** `snosi/shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot:55`
-  — `awk 'NR > 1 {print $1}'` (skip header, take column 1).
-- **Contract (implicit):** first line is a discardable header; feature name is
-  whitespace-delimited column 1. Empty list and command failure are
-  deliberately conflated (`|| true`, `known=""` disables the stale check).
-  Also depends on `updex features enable "$f" --now` exit code (0=ok,
-  nonzero=retry next boot) — `snosi-firstboot:63`.
-- **Fragility:** 🔴 — pure text-table dependency; breaks if updex reorders
-  columns, drops the header, or prints diagnostics to stdout before the header.
-  **Recommendation:** migrate to `updex --silent features list --json` (which
-  is `[]`-safe) and parse with `jq`.
+### 4.3 updex CLI JSON → snosi-firstboot
+- **Producer:** `updex --silent features list --json` (array of `{name,...}` objects; `[]`-safe when empty, §3.1).
+- **Consumer:** `snosi/shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot:59`
+  — `jq -r '.[]?.name'` (extract every feature name).
+- **Contract:** JSON array of feature objects, each with a `name` field. Empty
+  list (`[]`), missing/`null`, or a non-JSON blob from a transient failure all
+  collapse to empty `known` via `2>/dev/null || true`, which disables the
+  stale-feature pre-check (fail-open). Also depends on
+  `updex features enable "$f" --now` exit code (0=ok, nonzero=retry next boot)
+  — `snosi-firstboot:67`.
+- **Fragility:** 🟢 — array-typed JSON on a stable field; the previous 🔴
+  text-table dependency (`awk 'NR>1'` on the header + column 1) was retired in
+  favor of `--json` + `jq`.
 
 ### 4.4 .feature / .transfer files → updex + systemd-sysupdate
 - **Producer:** snosi base image ships `usr/lib/sysupdate.<name>.d/<name>.{feature,transfer}` per sysext (`snosi/mkosi.images/base/mkosi.extra/...`).
@@ -399,9 +399,9 @@ staged_at=<iso-8601>          staged_at=<iso-8601>
 3. **Adopt an ecosystem convention:** *producers always emit `[]`, never
    `null`; consumers always accept both.* snosi's `first-boot.json` producer and
    `setup-gui` consumer already model this — hold them up as the standard.
-4. **Migrate snosi-firstboot off the text table (§4.3).** Use
-   `updex --silent features list --json` (already `[]`-safe) + `jq` instead of
-   `awk 'NR>1'`, removing a 🔴 implicit column/header dependency.
+4. **~~Migrate snosi-firstboot off the text table (§4.3).~~ Done** — it now
+   uses `updex --silent features list --json` (`[]`-safe) + `jq -r '.[]?.name'`
+   instead of `awk 'NR>1'`, removing the 🔴 column/header dependency.
 5. **Version-couple carefully:** the updex ≥1.3.0 component-discovery
    requirement (§4.4) and the chairlift↔updex SDK lockstep (§4.2) are ordering
    constraints that need coordinated releases — keep them in each repo's

--- a/shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot
+++ b/shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot
@@ -52,7 +52,11 @@ mapfile -t features < <(jq -r '.features[]? // empty' "$SEED")
 # enable failures (network, download) still count and still retry.
 # `|| true`: an updex that cannot even list (transient) must not abort the
 # whole provisioning under set -e/pipefail -- empty known = skip the check.
-known="$(updex --silent features list 2>/dev/null | awk 'NR > 1 {print $1}' || true)"
+# Parse `features list --json` (an array of {name,...} objects) rather than
+# the human table: the JSON contract is stable (always an array, `[]` when
+# empty) whereas the table's header/columns are not. jq tolerates empty/`[]`
+# output; a non-JSON blob from a transient failure yields empty `known`.
+known="$(updex --silent features list --json 2>/dev/null | jq -r '.[]?.name' 2>/dev/null || true)"
 for f in "${features[@]+"${features[@]}"}"; do
     [[ "$f" =~ ^[A-Za-z0-9._-]+$ ]] || { warn "skipping invalid feature name: $f"; continue; }
     if [[ -n "$known" ]] && ! grep -qx "$f" <<<"$known"; then

--- a/test/snosi-firstboot-test.sh
+++ b/test/snosi-firstboot-test.sh
@@ -32,14 +32,16 @@ cat >"$WORK_DIR/bin/updex" <<EOF
 #!/bin/bash
 echo "updex \$*" >>"$WORK_DIR/calls.log"
 [[ ! -f "$WORK_DIR/updex-fail" ]] || exit 1
-# "features list" answers with a fixed known set (header + names), so the
-# script's unknown-feature pre-check has something real to match against.
+# "features list --json" answers with a fixed known set as a JSON array of
+# {name,...} objects (the real updex --json shape), so the script's
+# unknown-feature pre-check has something real to match against.
 # (No backticks in this unquoted heredoc -- they would command-substitute.)
 if [[ "\$*" == *"features list"* ]]; then
-    printf 'FEATURE  DESCRIPTION  ENABLED  TRANSFERS\n'
-    printf 'docker   Docker       no       -\n'
-    printf 'tailscale Tailscale   no       -\n'
-    printf 'incus    Incus        no       -\n'
+    if [[ -f "$WORK_DIR/updex-empty" ]]; then
+        printf '[]\n'
+    else
+        printf '[{"name":"docker","enabled":false},{"name":"tailscale","enabled":false},{"name":"incus","enabled":false}]\n'
+    fi
 fi
 EOF
 cat >"$WORK_DIR/bin/flatpak" <<EOF
@@ -127,6 +129,20 @@ assert_eq "unknown feature: ghost-feature never passed to enable" \
     "$(grep -c 'enable ghost-feature' "$WORK_DIR/calls.log" || true)" "0"
 assert_contains "unknown feature: warning names it" "$RUN_OUT" "ghost-feature"
 rm -f "$WORK_DIR/done"
+
+echo "=== empty catalog fail-open (updex lists []) ==="
+rm -f "$WORK_DIR/done"
+touch "$WORK_DIR/updex-empty"
+cat >"$WORK_DIR/seed4.json" <<'EOF4'
+{"features": ["docker"], "core_flatpaks": false}
+EOF4
+run_fb "$WORK_DIR/seed4.json"
+# known="" (empty []) disables the stale-feature pre-check: the seeded feature
+# is passed straight to `enable` (fail-open), rather than being skipped.
+assert_eq "empty catalog: exit 0" "$RUN_RC" "0"
+assert_eq "empty catalog: feature still enabled (pre-check disabled)" \
+    "$(grep -c '^updex --silent features enable docker --now$' "$WORK_DIR/calls.log")" "1"
+rm -f "$WORK_DIR/updex-empty" "$WORK_DIR/done"
 
 echo "=== features-only seed (cayo shape) ==="
 cat >"$WORK_DIR/seed2.json" <<'EOF'


### PR DESCRIPTION
## Summary

`snosi-firstboot` built its known-feature set by scraping the human table from `updex features list` (`awk 'NR > 1 {print $1}'` — skip header, take column 1). That is a fragile, unversioned contract flagged 🔴 in `docs/integration-contracts.md` §4.3: it breaks if updex reorders columns, drops the header, or prints diagnostics before the header.

This migrates it to `updex --silent features list --json` + `jq -r '.[]?.name'` — the last of the "do-it-now" recommendations from the integration contract map (§8 #4).

## Changes

- **`shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot`** — replace the `awk` text-table scrape with `jq -r '.[]?.name'` over `features list --json` (a stable array of `{name,...}` objects, always `[]` when empty on updex ≥1.3.0). Empty/`null`/non-JSON all collapse to empty `known` via `2>/dev/null || true`, preserving the exact fail-open behavior byte-for-byte (empty `known` disables the stale-feature pre-check). No new dependency — jq is already a hard dep of this script.
- **`test/snosi-firstboot-test.sh`** — stub now emits the real `--json` array shape; added an empty-catalog (`[]`) fail-open scenario. 25/25 pass.
- **`docs/integration-contracts.md`** — §4.3 retitled and re-rated 🔴→🟢 with corrected line refs, the edge diagram updated, and the §8 #4 recommendation marked done.

## Verification

- `bash test/snosi-firstboot-test.sh` → 25 passed, 0 failed.
- `shellcheck -x shared/outformat/ab-root/tree/usr/libexec/snosi-firstboot` → clean.
- Adversarially reviewed: fail-open preserved across updex missing/error/empty/garbage; no new abort path under `set -euo pipefail` (whole pipeline wrapped in `|| true`); `.[]?.name` verified against empty array, null, and malformed input.

## Context

Third of three coordinated "always `[]`, never `null` / stable machine contract" fixes across the ecosystem, alongside frostyard/updex#134 (merged, released) and frostyard/pilothouse#29.