### PR TITLE
chore: bump pilothouse sysext to v0.2.2

### DIFF
--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -35,8 +35,8 @@
     "version": "11.0.0"
   },
   "pilothouse": {
-    "url": "https://github.com/frostyard/pilothouse/releases/download/v0.2.0/frostyard-pilothouse_0.2.0_amd64.deb",
-    "sha256": "6a84312f1da684283e586a4cd1e71b93f6004d0484f2342c82428df7537066c2",
-    "version": "0.2.0"
+    "url": "https://github.com/frostyard/pilothouse/releases/download/v0.2.2/frostyard-pilothouse_0.2.2_amd64.deb",
+    "sha256": "b3350b456a8bf5b7218ceeecab284a3b5e069e2b1b0e67d2bbff6b3375b8031f",
+    "version": "0.2.2"
   }
 }


### PR DESCRIPTION
## Summary

Bumps the pinned pilothouse sysext `.deb` from v0.2.0 to **v0.2.2** in `shared/download/sysext-checksums.json`.

v0.2.2 includes the null-vs-array fixes:
- inbound: `updex features check --json` terminal `null` accepted as "no updates" (v0.2.1);
- outbound: maintenance broker state slices serialize as `[]` not `null` (frostyard/pilothouse#29, v0.2.2).

## Verification

Checksum verified two ways — against the release's `checksums.txt` manifest **and** by independently downloading and hashing the asset:

```
frostyard-pilothouse_0.2.2_amd64.deb
sha256 b3350b456a8bf5b7218ceeecab284a3b5e069e2b1b0e67d2bbff6b3375b8031f
```

No `SYSEXT_REVISION` bump needed (the KEYPACKAGE version changed, so the sysext republishes). This is the same edit the weekly `check-dependencies.yml` job would generate automatically (it tracks `.pilothouse.version` against the latest release).

## Note on updex

`frostyard-updex` is APT-installed (unversioned pin), so snosi picks up the released updex fix automatically from the Frostyard APT repo — no snosi change required for it.