### PR TITLE
feat: add paseo sysext

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -89,6 +89,15 @@ jobs:
             echo "lemonade_version=$LATEST_LEM" >> $GITHUB_OUTPUT
           fi
 
+          # Check Paseo desktop app
+          CURRENT_PASEO=$(jq -r '.paseo.version' "$CHECKSUMS")
+          LATEST_PASEO=$(gh_api https://api.github.com/repos/getpaseo/paseo/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_PASEO" && "$LATEST_PASEO" != "null" ]] && ver_gt "$LATEST_PASEO" "$CURRENT_PASEO"; then
+            UPDATES="${UPDATES}paseo: $CURRENT_PASEO -> $LATEST_PASEO\n"
+            echo "paseo_update=true" >> $GITHUB_OUTPUT
+            echo "paseo_version=$LATEST_PASEO" >> $GITHUB_OUTPUT
+          fi
+
           # Check Pilothouse (Snosi web administration console)
           CURRENT_PH=$(jq -r '.pilothouse.version' "$CHECKSUMS")
           LATEST_PH=$(gh_api https://api.github.com/repos/frostyard/pilothouse/releases/latest | jq -r '.tag_name' | sed 's/^v//')
@@ -148,6 +157,8 @@ jobs:
           CODER_VERSION: ${{ steps.check.outputs.coder_version }}
           LEMONADE_UPDATE: ${{ steps.check.outputs.lemonade_update }}
           LEMONADE_VERSION: ${{ steps.check.outputs.lemonade_version }}
+          PASEO_UPDATE: ${{ steps.check.outputs.paseo_update }}
+          PASEO_VERSION: ${{ steps.check.outputs.paseo_version }}
           PILOTHOUSE_UPDATE: ${{ steps.check.outputs.pilothouse_update }}
           PILOTHOUSE_VERSION: ${{ steps.check.outputs.pilothouse_version }}
           AZUREVPN_UPDATE: ${{ steps.check.outputs.azurevpn_update }}
@@ -203,6 +214,18 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
               '.lemonade.url=$u | .lemonade.sha256=$s | .lemonade.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$PASEO_UPDATE" == "true" ]]; then
+            VER="$PASEO_VERSION"
+            URL="https://github.com/getpaseo/paseo/releases/download/v${VER}/Paseo-${VER}-amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.paseo.url=$u | .paseo.sha256=$s | .paseo.version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 18 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, pilothouse, podman, tailscale, vscode).
+**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 19 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 18 sysexts
+just sysexts            # Build base + all 19 sysexts
 just snow               # Build snow desktop image
 just snowfield          # Build snowfield (Surface kernel)
 just cayo               # Build cayo server image
@@ -256,7 +256,7 @@ persistence.
 builds two real `cayo-ab-raw` versions itself, boots N, and asserts no failed
 systemd units and the bootc/nbc/systemd-sysupdate masks from above; that
 `/usr/lib/sysupdate.d/` contains only the three OS transfers (no `.feature`
-files) while `systemd-sysupdate components` enumerates all 18 shipped sysext
+files) while `systemd-sysupdate components` enumerates all 19 shipped sysext
 components; that two independently versioned ad hoc test components
 (`testa`/`testb`, created under `/etc/sysupdate.<name>.d/`) update via
 `--component=` without touching OS partitions, the ESP, or each other's

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The project produces:
 | **incus**           | Incus container/VM manager                                      | sysext        |
 | **lemonade**        | Lemonade local LLM server (GPU/NPU accelerated)                 | sysext        |
 | **nix**             | Nix package manager                                             | sysext        |
+| **paseo**           | Paseo coding agent workspace desktop application                | sysext        |
 | **pilothouse**      | Pilothouse local web administration console for Snosi           | sysext        |
 | **podman**          | Podman + Distrobox                                              | sysext        |
 | **tailscale**       | Tailscale VPN client                                            | sysext        |
@@ -194,7 +195,7 @@ sudo test/native-ab-update-test.sh \
              sysexts                         profiles
     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
     │    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
-  1pass azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge incus lemonade nix podman tailscale vscode │         │
+  1pass azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge incus lemonade nix paseo podman tailscale vscode │         │
                                      snow            cayo
                                       │
                                   snowfield
@@ -227,6 +228,7 @@ Sysexts are overlay images that extend the base system without modifying it. The
 | **incus**         | Incus, QEMU/KVM, OVMF, virt-viewer            | [mkosi.images/incus/mkosi.conf](mkosi.images/incus/mkosi.conf)                 |
 | **lemonade**      | Lemonade local LLM server (lemond)            | [mkosi.images/lemonade/mkosi.conf](mkosi.images/lemonade/mkosi.conf)           |
 | **nix**           | Nix package manager, systemd integration      | [mkosi.images/nix/mkosi.conf](mkosi.images/nix/mkosi.conf)                     |
+| **paseo**         | Paseo desktop app (Electron)                  | [mkosi.images/paseo/mkosi.conf](mkosi.images/paseo/mkosi.conf)                 |
 | **podman**        | Podman, Distrobox, buildah, crun              | [mkosi.images/podman/mkosi.conf](mkosi.images/podman/mkosi.conf)               |
 | **tailscale**     | Tailscale VPN client                          | [mkosi.images/tailscale/mkosi.conf](mkosi.images/tailscale/mkosi.conf)         |
 
@@ -277,6 +279,7 @@ shared/
 │   ├── azurevpn/mkosi.conf    ← Azure VPN Client
 │   ├── vscode/mkosi.conf      ← Visual Studio Code
 │   ├── bitwarden/mkosi.conf   ← Bitwarden password manager
+│   ├── paseo/mkosi.conf       ← Paseo desktop app
 │   ├── docker-onimage/        ← Docker CE for baked-in images
 │   ├── virt-base/mkosi.conf   ← Headless Incus virtualization
 │   └── virt/mkosi.conf        ← Incus virtualization
@@ -426,7 +429,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, pilothouse, podman, tailscale, vscode)
+1. Builds the base image and all sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode)
 2. Publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Uploads package manifests for version tracking
 

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -15,6 +15,7 @@ Dependencies=base
              incus
              lemonade
              nix
+             paseo
              pilothouse
              podman
              tailscale

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.paseo.d/paseo.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.paseo.d/paseo.feature
@@ -1,0 +1,5 @@
+[Feature]
+Description=Paseo coding agent workspace desktop application
+Documentation=https://paseo.sh
+Enabled=false
+X-Snosi-Products=snow,snowfield

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.paseo.d/paseo.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.paseo.d/paseo.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=paseo
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/paseo/
+MatchPattern=paseo_@v_%w_%a.raw.zst \
+             paseo_@v_%w_%a.raw.xz \
+             paseo_@v_%w_%a.raw.gz \
+             paseo_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=paseo_@v_%w_%a.raw.zst \
+             paseo_@v_%w_%a.raw.xz \
+             paseo_@v_%w_%a.raw.gz \
+             paseo_@v_%w_%a.raw
+CurrentSymlink=paseo.raw

--- a/mkosi.images/paseo/mkosi.conf
+++ b/mkosi.images/paseo/mkosi.conf
@@ -1,0 +1,26 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=paseo
+Output=paseo
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+# Downloads the pinned Paseo .deb via verified_download, relocates
+# /opt/Paseo -> /usr/lib/Paseo, repoints the update-alternatives symlink and
+# the desktop file Exec
+PostInstallationScripts=%D/shared/packages/paseo/mkosi.postinst.d/paseo.chroot
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+
+[Include]
+# Runtime deps for the Paseo .deb
+Include=%D/shared/packages/paseo/mkosi.conf
+
+[Build]
+Environment=KEYPACKAGE=paseo

--- a/mkosi.images/paseo/required-paths.txt
+++ b/mkosi.images/paseo/required-paths.txt
@@ -1,0 +1,10 @@
+# paseo sysext: Paseo desktop app, relocated from /opt to /usr/lib
+/usr/lib/Paseo/Paseo
+/usr/lib/Paseo/chrome-sandbox
+/usr/lib/Paseo/resources/bin/paseo
+/usr/bin/Paseo
+/usr/bin/paseo
+# Desktop integration: launcher entry and hicolor icon (see yeti/sysexts.md
+# "Desktop Applications in Sysexts")
+/usr/share/applications/Paseo.desktop
+/usr/share/icons/hicolor/128x128/apps/Paseo.png

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -34,6 +34,11 @@
     "sha256": "cd7448b1b577815a75b4596a9611d29a37db737c036dd9bc9b18d258ddd4204e",
     "version": "11.5.0"
   },
+  "paseo": {
+    "url": "https://github.com/getpaseo/paseo/releases/download/v0.2.1/Paseo-0.2.1-amd64.deb",
+    "sha256": "83209d71839e2916e6204e4993ce9c3cb7e09a23feb1abca6ae6aadfc07877b0",
+    "version": "0.2.1"
+  },
   "pilothouse": {
     "url": "https://github.com/frostyard/pilothouse/releases/download/v0.6.0/frostyard-pilothouse_0.6.0_amd64.deb",
     "sha256": "17a18dfefd7f788cbe2d8d6994c6271d29d6e69e0071720a8105ad70a9d647c6",

--- a/shared/packages/paseo/mkosi.conf
+++ b/shared/packages/paseo/mkosi.conf
@@ -1,0 +1,14 @@
+[Content]
+# Runtime deps from the Paseo .deb's Depends (installed via mkosi's host-side
+# apt so dpkg -i in the postinst can install the .deb; the sysext build's base
+# chroot has none of them). libappindicator3-1 is only Recommends and does not
+# exist in Trixie (superseded by libayatana-appindicator3-1), so it is omitted.
+Packages=libatspi2.0-0
+         libgtk-3-0
+         libnotify4
+         libnss3
+         libsecret-1-0
+         libuuid1
+         libxss1
+         libxtst6
+         xdg-utils

--- a/shared/packages/paseo/mkosi.postinst.d/paseo.chroot
+++ b/shared/packages/paseo/mkosi.postinst.d/paseo.chroot
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Post-install script for the paseo sysext
+# Installs the pinned Paseo .deb and relocates it out of /opt.
+
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+if [[ "${UID}" == "0" ]]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "paseo" "$DEBS/paseo.deb"
+
+dpkg -i "$DEBS/paseo.deb"
+
+# /opt is a bind mount to /var/opt at runtime and is shadowed by sysext
+# overlays, so the Electron bundle must live under /usr.
+${SUDO} mv /opt/Paseo /usr/lib/Paseo
+# /opt itself must stay: it is the mountpoint for opt.mount (bind to /var/opt)
+${SUDO} rm -rf /opt/Paseo
+${SUDO} mkdir -p /usr/bin
+
+# The deb's postinst registers /usr/bin/Paseo through update-alternatives, so
+# it points into /etc/alternatives — which is STRIPPED from a sysext (sysexts
+# carry only /usr) and would dangle on the target system. Repoint it at the
+# real binary, exactly like the edge sysext does.
+${SUDO} ln -sf /usr/lib/Paseo/Paseo /usr/bin/Paseo
+# Lowercase CLI entry point: the bundled wrapper resolves symlinks back into
+# the app bundle, so a plain symlink is enough.
+${SUDO} ln -sf /usr/lib/Paseo/resources/bin/paseo /usr/bin/paseo
+
+${SUDO} chmod 4755 /usr/lib/Paseo/chrome-sandbox
+${SUDO} sed -i 's|^Exec=/opt/Paseo/Paseo|Exec=/usr/bin/Paseo|' /usr/share/applications/Paseo.desktop

--- a/test/native-ab-components-test.sh
+++ b/test/native-ab-components-test.sh
@@ -15,7 +15,7 @@
 # in QEMU, and validates in order:
 #
 #   1. No failed legacy updaters; bootc/nbc/sysupdate auto-update units masked.
-#   2. The OS default sysupdate.d target and the 18 shipped sysext components
+#   2. The OS default sysupdate.d target and the 19 shipped sysext components
 #      are structurally separate (component discovery via `systemd-sysupdate
 #      components`).
 #   3. Two ad hoc test sysext components (testa, testb; independently
@@ -525,7 +525,7 @@ assert_eq "/usr/lib/sysupdate.d/ contains exactly the OS transfers, no features"
     "$default_target_listing" "$expected_default_listing"
 
 expected_sysext_components=(1password 1password-cli azurevpn bitwarden claude-desktop
-    coder code-server debdev dev docker edge incus lemonade nix pilothouse podman
+    coder code-server debdev dev docker edge incus lemonade nix paseo pilothouse podman
     tailscale vscode)
 
 components_raw="$(vm_ssh '/usr/lib/systemd/systemd-sysupdate components --no-legend')"

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -999,7 +999,7 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
-1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, pilothouse, podman, tailscale, vscode
+1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode
 
 ## Architecture
 
@@ -1009,7 +1009,7 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 18 sysexts)
+mkosi.images/               # Image definitions (base + 19 sysexts)
   base/                     # Foundation image: systemd, bootc/ostree (frostyard debs), firmware, core utils
     mkosi.extra/            # Base filesystem overlay (dracut, systemd units/timers, sysupdate, tmpfiles, sysusers)
       usr/lib/sysupdate.<name>.d/  # per-sysext .transfer + .feature component dirs (one pair each, 18 total)
@@ -1306,7 +1306,7 @@ Use build-time enablement/presets for desired service state. For run-once runtim
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 18 sysexts
+just sysexts            # Build base + all 19 sysexts
 just snow               # Build snow desktop
 just snowfield          # Build snowfield (Surface)
 just cayo               # Build cayo server

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -31,6 +31,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **incus** | incus | Incus container/VM manager, QEMU/KVM, dnsmasq, OVMF, virt-viewer |
 | **lemonade** | lemonade-server | Lemonade local LLM server (lemond) — downloaded via `verified_download()` from lemonade-sdk/lemonade GitHub releases; libcpp-httplib0.41 dep from trixie-backports |
 | **nix** | nix-setup-systemd | Nix package manager with systemd integration |
+| **paseo** | paseo | Paseo coding agent workspace desktop app (pinned .deb via verified_download from getpaseo/paseo GitHub releases, relocated from /opt) |
 | **pilothouse** | frostyard-pilothouse | Pilothouse local web administration console for Snosi (pilothouse web UI + pilothoused root broker) — downloaded via `verified_download()` from frostyard/pilothouse GitHub releases |
 | **podman** | podman | Podman, distrobox, buildah, crun, slirp4netns |
 | **tailscale** | tailscale | Tailscale VPN client |
@@ -110,7 +111,7 @@ installed" at build time, contributes nothing to the delta, and its paths will
 always fail the check even though they exist at runtime — caught live when
 `wget` in debdev's list failed CI on the first run.
 
-`code-server`, `coder`, `edge`, `bitwarden`, and `azurevpn` are the current exceptions to the `Packages=` line: it downloads a pinned upstream `.deb` in `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` and installs it with `dpkg -i`. It still sets `KEYPACKAGE=code-server`, and the shared postoutput script resolves that version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file Exec rewrite, deps via `Include=`.
+`code-server`, `coder`, `edge`, `bitwarden`, `paseo`, and `azurevpn` are the current exceptions to the `Packages=` line: it downloads a pinned upstream `.deb` in `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` and installs it with `dpkg -i`. It still sets `KEYPACKAGE=code-server`, and the shared postoutput script resolves that version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file Exec rewrite, deps via `Include=`. `paseo` is the same shape again (`shared/packages/paseo/`), plus the `edge`-style update-alternatives repointing (its deb registers `/usr/bin/Paseo` through `/etc/alternatives`, which a sysext never ships).
 
 ## Sysext-Specific Extra Files
 
@@ -135,6 +136,14 @@ Some sysexts include extra files via `mkosi.extra/`:
 - No `mkosi.extra/` — everything comes from the shared package fragment and postinst script (`shared/packages/bitwarden/`)
 - Desktop app with no systemd service: no preset, no `Upholds=` drop-in
 - Ships hicolor icons — depends on the no-icon-cache pattern (see Desktop Applications in Sysexts below)
+
+### paseo
+- No `mkosi.extra/` — everything comes from the shared package fragment and postinst script (`shared/packages/paseo/`)
+- Electron app: `/opt/Paseo` relocated to `/usr/lib/Paseo`, SUID `chrome-sandbox`, desktop-file `Exec=` rewritten off `/opt`
+- The deb's postinst registers `/usr/bin/Paseo` via `update-alternatives` (i.e. through `/etc/alternatives`, stripped from a sysext), so the postinst repoints it straight at `/usr/lib/Paseo/Paseo` — same fix as `edge`
+- `/usr/bin/paseo` symlinks the bundled CLI wrapper (`resources/bin/paseo`), which resolves symlinks back into the bundle itself
+- Its postinst's AppArmor block is a no-op in the buildroot, and would only write to `/etc` (stripped) anyway
+- Desktop app with no systemd service: no preset, no `Upholds=` drop-in; ships hicolor icons → `sysext-strip-icon-cache.sh` required
 
 ### claude-desktop
 - No `mkosi.extra/` and no postinst — the Anthropic `claude-desktop` deb (apt repo at `downloads.claude.ai/claude-desktop/apt/stable`, registered in `mkosi.sandbox`) installs natively under `/usr` (`/usr/lib/claude-desktop` + `/usr/bin/claude-desktop` symlink), so no relocation is needed


### PR DESCRIPTION
Adds a sysext for [Paseo](https://paseo.sh) — an Electron desktop app for driving coding agents in git worktrees — pinned at v0.2.1.

## Shape

Paseo ships as a GitHub-release `.deb` with no apt repo, so this follows the existing `bitwarden`/`edge` pattern:

- `mkosi.images/paseo/` — sysext definition (`KEYPACKAGE=paseo`) + `required-paths.txt`
- `shared/packages/paseo/mkosi.conf` — runtime deps from the deb's `Depends` (`libappindicator3-1` is only `Recommends` and doesn't exist in Trixie, so it's omitted)
- `shared/packages/paseo/mkosi.postinst.d/paseo.chroot` — `verified_download()` + `dpkg -i`, then relocation
- `shared/download/sysext-checksums.json` — pinned URL + SHA-256

`/opt/Paseo` is relocated to `/usr/lib/Paseo` (sysext overlays shadow `/opt`, which is a bind mount to `/var/opt`), `chrome-sandbox` keeps its SUID bit, and `Paseo.desktop`'s hardcoded `/opt` `Exec=` is rewritten.

Two upstream-postinst details needed handling:

- The deb registers `/usr/bin/Paseo` through `update-alternatives`, i.e. via `/etc/alternatives` — which a sysext never ships, so it would dangle on the target. The symlink is repointed straight at `/usr/lib/Paseo/Paseo`, the same fix `edge` already carries.
- `/usr/bin/paseo` symlinks the bundled CLI wrapper (`resources/bin/paseo`); it resolves symlinks back into the bundle itself, so no wrapper of our own is needed.

The deb's postinst AppArmor block is a no-op in the buildroot and would only write to `/etc` (stripped) anyway.

## Registration

- `mkosi.conf` dependency, so `just sysexts` builds it
- `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.paseo.d/{paseo.transfer,paseo.feature}` — own component dir per the current layout; `Enabled=false`, `X-Snosi-Products=snow,snowfield` (desktop app)
- `check-dependencies.yml` — weekly upstream release check + checksum refresh
- Docs (`CLAUDE.md`, `README.md`, `yeti/OVERVIEW.md`, `yeti/sysexts.md`) and the sysext-count/component list in `test/native-ab-components-test.sh` bumped 18 → 19

## Validation

- `mkosi summary` resolves the new image cleanly; `check-profile-dependencies.sh`, `check-runtime-etc-guard.sh`, `check-native-publication-guard.sh`, `test/native-ab-static-test.sh` all pass
- `shellcheck -S warning -x` clean on the new script; `actionlint` reports no new findings
- Deb contents/`Depends`/postinst and the pinned SHA-256 were verified against the real v0.2.1 artifact

Not run: an actual `just sysexts` build — that needs root on the build host, which wasn't available here. CI's build will be the first real end-to-end exercise of the relocation and the `required-paths.txt` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)