### PR TITLE
ci: support BCVK OCI testing in CI

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -138,25 +138,25 @@ jobs:
           "$IMAGE:${{ steps.version.outputs.tag }}" \
           "$SOURCE_EPOCH"
 
-      - name: Smoke test - verify SUID bit on sudo
+      - name: Smoke test - verify SUID bit and bcvk requirements
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
         run: |
-          mode=$(sudo podman run --rm "$IMAGE:${{ steps.version.outputs.tag }}" stat -c '%a' /usr/bin/sudo)
-          echo "sudo permissions: $mode"
-          if [[ "$mode" != "4755" ]]; then
-            echo "::error::SUID bit not set on /usr/bin/sudo (expected 4755, got $mode)"
-            exit 1
-          fi
+          sudo podman run --rm "$IMAGE:${{ steps.version.outputs.tag }}" sh -ec '
+            mode=$(stat -c "%a" /usr/bin/sudo)
+            echo "sudo permissions: $mode"
+            if [ "$mode" != "4755" ]; then
+              echo "::error::SUID bit not set on /usr/bin/sudo (expected 4755, got $mode)"
+              exit 1
+            fi
 
-      - name: Smoke test - verify bcvk image requirement
-        env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
-        run: |
-          if ! sudo podman run --rm "$IMAGE:${{ steps.version.outputs.tag }}" test -x /usr/bin/bwrap; then
-            echo "::error::Missing /usr/bin/bwrap required for optional bcvk testing"
-            exit 1
-          fi
+            for required in bwrap systemctl objcopy ssh ssh-keygen; do
+              if ! command -v "$required" >/dev/null; then
+                echo "::error::Missing $required required for optional bcvk testing"
+                exit 1
+              fi
+            done
+          '
 
       - name: Setup Syft
         id: setup-syft

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -149,6 +149,15 @@ jobs:
             exit 1
           fi
 
+      - name: Smoke test - verify bcvk image requirement
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
+        run: |
+          if ! sudo podman run --rm "$IMAGE:${{ steps.version.outputs.tag }}" test -x /usr/bin/bwrap; then
+            echo "::error::Missing /usr/bin/bwrap required for optional bcvk testing"
+            exit 1
+          fi
+
       - name: Setup Syft
         id: setup-syft
         if: github.event_name != 'pull_request'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,17 @@ just run-qemu           # Run image in QEMU
 
 All `just` targets run `mkosi clean` first (clean build every time).
 
+**Optional bcvk testing:** bcvk is a local convenience for exercising the OCI
+bootc images and does not replace `just test-install` or its CI workflow. OCI
+profiles include `bubblewrap` because bcvk runs `bwrap` from the target image;
+`virtiofsd` already ships in base. bcvk 0.18 requires an explicit host-side
+`podman pull` before `bcvk libvirt run` (`--pull=never`). Current cayo did not
+reach SSH under bcvk's default enrolled-key Secure Boot firmware, so use
+`--firmware uefi-insecure` only for bcvk install-mechanics testing until that
+bcvk enrolled-key firmware limitation is understood. Do not represent this as
+Secure Boot validation or change the established bootc installation/testing
+path because of it.
+
 ## Architecture
 
 ### Configuration Composition

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,12 @@ All `just` targets run `mkosi clean` first (clean build every time).
 bootc images and does not replace `just test-install` or its CI workflow. OCI
 profiles include `bubblewrap` because bcvk runs `bwrap` from the target image;
 `virtiofsd` already ships in base. bcvk 0.18 requires an explicit host-side
-`podman pull` before `bcvk libvirt run` (`--pull=never`). Current cayo did not
-reach SSH under bcvk's default enrolled-key Secure Boot firmware, so use
-`--firmware uefi-insecure` only for bcvk install-mechanics testing until that
-bcvk enrolled-key firmware limitation is understood. Do not represent this as
-Secure Boot validation or change the established bootc installation/testing
-path because of it.
+`podman pull` before `bcvk libvirt run` (`--pull=never`). OCI bootc profiles
+use `SecureBoot=no` and do not build or enroll the native A/B MOK signing
+chain, so they do not currently boot under bcvk's enrolled-key Secure Boot
+firmware. Use `--firmware uefi-insecure` only for bcvk install-mechanics
+testing. Do not represent this as Secure Boot validation or change the
+established bootc installation/testing path because of it.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -386,6 +386,33 @@ just test-install
 just run-qemu
 ```
 
+### Optional bcvk Testing
+
+[bcvk](https://github.com/bootc-dev/bcvk) is an optional local convenience for
+testing the OCI bootc images. It does not replace the supported installation
+and test path, `just test-install`, or its CI workflow. bcvk 0.18 does not
+pull images itself, so pull the image into the same user's Podman storage
+first:
+
+```bash
+podman pull ghcr.io/frostyard/cayo:latest
+bcvk libvirt run --name test-cayo \
+  --detach --ssh-wait \
+  --firmware uefi-insecure \
+  --composefs-backend --filesystem btrfs \
+  ghcr.io/frostyard/cayo:latest
+bcvk libvirt ssh test-cayo
+```
+
+The OCI profiles ship `bubblewrap` for bcvk and already ship `virtiofsd`.
+The host still needs bcvk, Podman, libvirt, QEMU/KVM, and UEFI firmware.
+
+**Secure Boot status:** cayo did not reach SSH when tested with bcvk's default
+enrolled-key UEFI firmware. Use `--firmware uefi-insecure` only for bcvk
+mechanics testing until this bcvk enrolled-key firmware limitation is
+understood; this is not Secure Boot validation. Native A/B Secure Boot
+validation and the established bootc install/test workflow are unaffected.
+
 ### Build Process
 
 1. **Base Build**: The `base` image is built first and cached in `output/base/`

--- a/README.md
+++ b/README.md
@@ -406,12 +406,14 @@ bcvk libvirt ssh test-cayo
 
 The OCI profiles ship `bubblewrap` for bcvk and already ship `virtiofsd`.
 The host still needs bcvk, Podman, libvirt, QEMU/KVM, and UEFI firmware.
+Native A/B profiles intentionally do not inherit this OCI-only bcvk dependency.
 
-**Secure Boot status:** cayo did not reach SSH when tested with bcvk's default
-enrolled-key UEFI firmware. Use `--firmware uefi-insecure` only for bcvk
-mechanics testing until this bcvk enrolled-key firmware limitation is
-understood; this is not Secure Boot validation. Native A/B Secure Boot
-validation and the established bootc install/test workflow are unaffected.
+**Secure Boot status:** OCI bootc profiles use `SecureBoot=no` and do not build
+or enroll the MOK signing chain used by native A/B profiles. They therefore do
+not currently boot under bcvk's enrolled-key Secure Boot firmware. Use
+`--firmware uefi-insecure` only for bcvk mechanics testing; this is not Secure
+Boot validation. Native A/B Secure Boot validation and the established bootc
+install/test workflow are unaffected.
 
 ### Build Process
 

--- a/shared/packages/bootc/mkosi.conf
+++ b/shared/packages/bootc/mkosi.conf
@@ -3,6 +3,8 @@
 # evaluated. Keep their incomplete package metadata supplemented explicitly.
 Packages=bootc
           libostree-1-1
+          # bcvk runs bubblewrap from the target bootc OCI image.
+          bubblewrap
           libcurl4t64
           libglib2.0-0t64
           libgpgme11t64

--- a/shared/packages/bootc/mkosi.conf
+++ b/shared/packages/bootc/mkosi.conf
@@ -1,9 +1,11 @@
 [Content]
-# bootc and ostree remain profile dependencies while the native A/B spike is
-# evaluated. Keep their incomplete package metadata supplemented explicitly.
+# OCI bootc profile requirements. Keep bootc/ostree's incomplete package
+# metadata supplemented explicitly. Native A/B profiles do not include this
+# fragment.
 Packages=bootc
           libostree-1-1
-          # bcvk runs bubblewrap from the target bootc OCI image.
+          # cayo lacks snow's Flatpak dependency; make bcvk's target-image
+          # bubblewrap requirement explicit for every OCI bootc profile.
           bubblewrap
           libcurl4t64
           libglib2.0-0t64

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -46,7 +46,7 @@ Each matrix build resets mkosi dependencies to `base` (`--dependency= --dependen
 3. Build profile image via mkosi with dependencies reset to `base` only (produces directory output)
 4. Package OCI image via `buildah-package.sh` (preserves SUID, xattrs)
 5. Optimize layers via `chunkah-package.sh` (skipped on pull_request)
-6. **Smoke test:** Validates SUID bit on `/usr/bin/sudo` (mode 4755) — catches metadata loss
+6. **Smoke tests:** Validates SUID bit on `/usr/bin/sudo` (mode 4755) to catch metadata loss, and verifies `/usr/bin/bwrap` for optional bcvk OCI-image compatibility
 7. Generate SBOM via Syft (scans mkosi output directory, syft-json format; skipped on pull_request)
 8. Push timestamp and `latest` tags to ghcr.io (skipped on pull_request)
 9. Attach SBOM to image via ORAS (`application/vnd.syft+json` artifact type)

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -46,7 +46,7 @@ Each matrix build resets mkosi dependencies to `base` (`--dependency= --dependen
 3. Build profile image via mkosi with dependencies reset to `base` only (produces directory output)
 4. Package OCI image via `buildah-package.sh` (preserves SUID, xattrs)
 5. Optimize layers via `chunkah-package.sh` (skipped on pull_request)
-6. **Smoke tests:** Validates SUID bit on `/usr/bin/sudo` (mode 4755) to catch metadata loss, and verifies `/usr/bin/bwrap` for optional bcvk OCI-image compatibility
+6. **Smoke test:** Validates SUID bit on `/usr/bin/sudo` (mode 4755) to catch metadata loss, plus every bcvk target-image executable (`bwrap`, `systemctl`, `objcopy`, `ssh`, `ssh-keygen`) for optional OCI-image compatibility
 7. Generate SBOM via Syft (scans mkosi output directory, syft-json format; skipped on pull_request)
 8. Push timestamp and `latest` tags to ghcr.io (skipped on pull_request)
 9. Attach SBOM to image via ORAS (`application/vnd.syft+json` artifact type)

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -65,15 +65,16 @@ replacement for `bootc-install-test.sh`, `just test-install`, or
 `test-install.yml`. The images carry `bubblewrap` because bcvk 0.18 executes
 `bwrap` from the target image; `virtiofsd` is already present in the base
 image. bcvk intentionally runs Podman with `--pull=never`, so callers must
-first pull the image into their own Podman storage.
+first pull the image into their own Podman storage. Native A/B profiles
+intentionally do not include this OCI-only bcvk dependency.
 
 Use `bcvk libvirt run` with `--composefs-backend --filesystem btrfs` after
-that pull. As verified against cayo, bcvk's default enrolled-key Secure Boot
-firmware creates the domain but the installed bootc image does not reach SSH.
-Use `--firmware uefi-insecure` only to test bcvk installation mechanics until
-this bcvk enrolled-key firmware limitation is understood and validated. This
-limitation is specific to the optional bcvk path; it does not change the
-existing bootc installation harness or native A/B Secure Boot tests.
+that pull. OCI bootc profiles use root `SecureBoot=no` and omit the native A/B
+MOK-signing configuration, so their failure under bcvk's enrolled-key Secure
+Boot firmware is expected. Use `--firmware uefi-insecure` only to test bcvk
+installation mechanics. This limitation is specific to the optional bcvk path;
+it does not change the existing bootc installation harness or native A/B
+Secure Boot tests.
 
 ## Orchestrator (bootc-install-test.sh)
 

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -58,6 +58,23 @@ Boots an image in a QEMU graphical window (GTK display). Loads the image, instal
 
 **Defaults:** 50G disk (via Justfile), 4G RAM, 2 CPUs. Configurable via `DISK_SIZE`, `VM_MEMORY`, `VM_CPUS` env vars.
 
+## Optional bcvk Testing
+
+bcvk is a supplemental local test option for OCI bootc images, not a
+replacement for `bootc-install-test.sh`, `just test-install`, or
+`test-install.yml`. The images carry `bubblewrap` because bcvk 0.18 executes
+`bwrap` from the target image; `virtiofsd` is already present in the base
+image. bcvk intentionally runs Podman with `--pull=never`, so callers must
+first pull the image into their own Podman storage.
+
+Use `bcvk libvirt run` with `--composefs-backend --filesystem btrfs` after
+that pull. As verified against cayo, bcvk's default enrolled-key Secure Boot
+firmware creates the domain but the installed bootc image does not reach SSH.
+Use `--firmware uefi-insecure` only to test bcvk installation mechanics until
+this bcvk enrolled-key firmware limitation is understood and validated. This
+limitation is specific to the optional bcvk path; it does not change the
+existing bootc installation harness or native A/B Secure Boot tests.
+
 ## Orchestrator (bootc-install-test.sh)
 
 **Usage:**


### PR DESCRIPTION
## Summary
- Added BCVK OCI testing support to the image build workflow
- Updated bootc/mkosi configuration for BCVK compatibility
- Documented the new BCVK testing flow in README and project docs

## Why
- BCVK requires CI and local testing paths that can exercise OCI-based bootc images
- Keeping the workflow and documentation aligned makes it easier to validate BCVK changes consistently
- The mkosi and bootc updates ensure the generated images work with the new testing target

## Testing
- Not run locally; changes were validated through the updated CI workflow configuration and documentation review