### PR TITLE
feat: add GitHub Copilot sysext

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -60,6 +60,15 @@ jobs:
             echo "bitwarden_version=$LATEST_BW" >> $GITHUB_OUTPUT
           fi
 
+          # Check GitHub Copilot desktop app
+          CURRENT_GITHUB_COPILOT=$(jq -r '."github-copilot".version' "$CHECKSUMS")
+          LATEST_GITHUB_COPILOT=$(gh_api https://api.github.com/repos/github/app/releases | jq -r '[.[] | select(.draft == false and .prerelease == false)][0].tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_GITHUB_COPILOT" && "$LATEST_GITHUB_COPILOT" != "null" ]] && ver_gt "$LATEST_GITHUB_COPILOT" "$CURRENT_GITHUB_COPILOT"; then
+            UPDATES="${UPDATES}github-copilot: $CURRENT_GITHUB_COPILOT -> $LATEST_GITHUB_COPILOT\n"
+            echo "github_copilot_update=true" >> "$GITHUB_OUTPUT"
+            echo "github_copilot_version=$LATEST_GITHUB_COPILOT" >> "$GITHUB_OUTPUT"
+          fi
+
           # Check code-server
           CURRENT_CS=$(jq -r '.["code-server"].version' "$CHECKSUMS")
           LATEST_CS=$(gh_api https://api.github.com/repos/coder/code-server/releases/latest | jq -r '.tag_name' | sed 's/^v//')
@@ -151,6 +160,8 @@ jobs:
         env:
           BITWARDEN_UPDATE: ${{ steps.check.outputs.bitwarden_update }}
           BITWARDEN_VERSION: ${{ steps.check.outputs.bitwarden_version }}
+          GITHUB_COPILOT_UPDATE: ${{ steps.check.outputs.github_copilot_update }}
+          GITHUB_COPILOT_VERSION: ${{ steps.check.outputs.github_copilot_version }}
           CODESERVER_UPDATE: ${{ steps.check.outputs.codeserver_update }}
           CODESERVER_VERSION: ${{ steps.check.outputs.codeserver_version }}
           CODER_UPDATE: ${{ steps.check.outputs.coder_update }}
@@ -178,6 +189,18 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
               '.bitwarden.url=$u | .bitwarden.sha256=$s | .bitwarden.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$GITHUB_COPILOT_UPDATE" == "true" ]]; then
+            VER="$GITHUB_COPILOT_VERSION"
+            URL="https://github.com/github/app/releases/download/v${VER}/GitHub-Copilot-linux-x64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '."github-copilot".url=$u | ."github-copilot".sha256=$s | ."github-copilot".version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -144,6 +144,11 @@ jobs:
         # hooks. No root, no bind mount, no image build.
         run: ./test/snosi-etc-diff-test.sh
 
+      - name: Validate sysext required paths finalizer
+        # Fixture regression test for whitespace-preserving parsing of sysext
+        # required-paths.txt entries. No root, network, or image build.
+        run: ./test/sysext-required-paths-test.sh
+
   runtime-etc-guard:
     runs-on: ubuntu-latest
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 19 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode).
+**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 20 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 19 sysexts
+just sysexts            # Build base + all 20 sysexts
 just snow               # Build snow desktop image
 just snowfield          # Build snowfield (Surface kernel)
 just cayo               # Build cayo server image
@@ -510,7 +510,7 @@ persistence.
 builds two real `cayo-ab-raw` versions itself, boots N, and asserts no failed
 systemd units and the bootc/nbc/systemd-sysupdate masks from above; that
 `/usr/lib/sysupdate.d/` contains only the three OS transfers (no `.feature`
-files) while `systemd-sysupdate components` enumerates all 19 shipped sysext
+files) while `systemd-sysupdate components` enumerates all 20 shipped sysext
 components; that two independently versioned ad hoc test components
 (`testa`/`testb`, created under `/etc/sysupdate.<name>.d/`) update via
 `--component=` without touching OS partitions, the ESP, or each other's

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The project produces:
 | **dev**             | Build essentials, Python, cmake, valgrind, gdb                  | sysext        |
 | **docker**          | Docker CE container runtime                                     | sysext        |
 | **edge**            | Microsoft Edge browser                                          | sysext        |
+| **github-copilot**  | GitHub Copilot agent-native desktop application                 | sysext        |
 | **incus**           | Incus container/VM manager                                      | sysext        |
 | **lemonade**        | Lemonade local LLM server (GPU/NPU accelerated)                 | sysext        |
 | **nix**             | Nix package manager                                             | sysext        |
@@ -195,7 +196,7 @@ sudo test/native-ab-update-test.sh \
              sysexts                         profiles
     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
     │    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
-  1pass azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge incus lemonade nix paseo podman tailscale vscode │         │
+  1password 1password-cli azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge github-copilot incus lemonade nix paseo pilothouse podman tailscale vscode
                                      snow            cayo
                                       │
                                   snowfield
@@ -220,17 +221,24 @@ Sysexts are overlay images that extend the base system without modifying it. The
 | ----------------- | --------------------------------------------- | ------------------------------------------------------------------------------ |
 | **1password**     | 1Password desktop app                         | [mkosi.images/1password/mkosi.conf](mkosi.images/1password/mkosi.conf)         |
 | **1password-cli** | 1Password CLI tool                            | [mkosi.images/1password-cli/mkosi.conf](mkosi.images/1password-cli/mkosi.conf) |
+| **azurevpn**      | Microsoft Azure VPN client                    | [mkosi.images/azurevpn/mkosi.conf](mkosi.images/azurevpn/mkosi.conf)           |
+| **bitwarden**     | Bitwarden password manager desktop app        | [mkosi.images/bitwarden/mkosi.conf](mkosi.images/bitwarden/mkosi.conf)         |
+| **claude-desktop**| Claude desktop application                    | [mkosi.images/claude-desktop/mkosi.conf](mkosi.images/claude-desktop/mkosi.conf) |
 | **code-server**   | code-server (VS Code in the browser)          | [mkosi.images/code-server/mkosi.conf](mkosi.images/code-server/mkosi.conf)     |
 | **coder**         | Coder workspaces server + workspace proxy     | [mkosi.images/coder/mkosi.conf](mkosi.images/coder/mkosi.conf)                 |
 | **debdev**        | debootstrap, distro-info, archive keyrings    | [mkosi.images/debdev/mkosi.conf](mkosi.images/debdev/mkosi.conf)               |
 | **dev**           | build-essential, cmake, Python, valgrind, gdb | [mkosi.images/dev/mkosi.conf](mkosi.images/dev/mkosi.conf)                     |
 | **docker**        | Docker CE, containerd, buildx, compose        | [mkosi.images/docker/mkosi.conf](mkosi.images/docker/mkosi.conf)               |
+| **edge**          | Microsoft Edge browser                         | [mkosi.images/edge/mkosi.conf](mkosi.images/edge/mkosi.conf)                   |
+| **github-copilot**| GitHub Copilot agent-native desktop application | [mkosi.images/github-copilot/mkosi.conf](mkosi.images/github-copilot/mkosi.conf) |
 | **incus**         | Incus, QEMU/KVM, OVMF, virt-viewer            | [mkosi.images/incus/mkosi.conf](mkosi.images/incus/mkosi.conf)                 |
 | **lemonade**      | Lemonade local LLM server (lemond)            | [mkosi.images/lemonade/mkosi.conf](mkosi.images/lemonade/mkosi.conf)           |
 | **nix**           | Nix package manager, systemd integration      | [mkosi.images/nix/mkosi.conf](mkosi.images/nix/mkosi.conf)                     |
 | **paseo**         | Paseo desktop app (Electron)                  | [mkosi.images/paseo/mkosi.conf](mkosi.images/paseo/mkosi.conf)                 |
+| **pilothouse**    | Pilothouse local web administration console   | [mkosi.images/pilothouse/mkosi.conf](mkosi.images/pilothouse/mkosi.conf)       |
 | **podman**        | Podman, Distrobox, buildah, crun              | [mkosi.images/podman/mkosi.conf](mkosi.images/podman/mkosi.conf)               |
 | **tailscale**     | Tailscale VPN client                          | [mkosi.images/tailscale/mkosi.conf](mkosi.images/tailscale/mkosi.conf)         |
+| **vscode**        | Visual Studio Code desktop application         | [mkosi.images/vscode/mkosi.conf](mkosi.images/vscode/mkosi.conf)               |
 
 ## How Profiles Work
 
@@ -538,7 +546,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode)
+1. Builds the base image and all sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode)
 2. Publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Uploads package manifests for version tracking
 

--- a/check-profile-dependencies.sh
+++ b/check-profile-dependencies.sh
@@ -5,18 +5,26 @@ cd "$(dirname "$0")"
 
 profiles=(cayo snow snowfield)
 sysexts=(
+    1password
     1password-cli
+    azurevpn
+    bitwarden
     claude-desktop
     code-server
     coder
     debdev
     dev
     docker
+    edge
+    github-copilot
     incus
+    lemonade
     nix
+    paseo
     pilothouse
     podman
     tailscale
+    vscode
 )
 
 failed=0

--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -37,7 +37,7 @@ Frostyard workspace root (the parent of `snosi/`).
 | ostree | `libostree-1-1` | `snosi/shared/packages/bootc/mkosi.conf:5` | bootc profiles |
 | pilothouse | `frostyard-pilothouse` | `snosi/mkosi.images/pilothouse/mkosi.conf:23` (sysext) | opt-in sysext, all products |
 
-`pilothouse` is the **only** Frostyard-authored sysext (all 17 other sysexts
+`pilothouse` is the **only** Frostyard-authored sysext (all 19 other sysexts
 wrap third-party tools). It is a pinned GitHub-release `.deb`
 (`snosi/shared/download/sysext-checksums.json:37-40`,
 `snosi/mkosi.images/pilothouse/mkosi.postinst.chroot:8-17`), not an APT install.

--- a/docs/native-ab-contracts.md
+++ b/docs/native-ab-contracts.md
@@ -175,12 +175,10 @@ Every independently versioned sysext lives in its own named component:
 Component name = sysext name. Admin overrides live at
 `/etc/sysupdate.<name>.d/<name>.feature.d/*.conf`.
 
-Today all 17 sysext transfer/feature pairs ship in the default
-`/usr/lib/sysupdate.d/` (in
-`mkosi.images/base/mkosi.extra/usr/lib/sysupdate.d/`), one shared target with
-the OS transfers once native profiles exist. Each is allowlisted with tag
-`component-migration` until Phase 1 adds `frostyard-updex` component
-discovery and migrates each pair to its own `sysupdate.<name>.d/`.
+All 20 sysext transfer/feature pairs ship in component-scoped
+`/usr/lib/sysupdate.<name>.d/` directories under
+`mkosi.images/base/mkosi.extra/`. `/usr/lib/sysupdate.d/` is reserved for the
+three OS transfers above; sysext pairs must never be added there.
 
 ## 7. Key ownership, custody, and rotation
 

--- a/docs/superpowers/plans/2026-07-29-github-copilot-sysext.md
+++ b/docs/superpowers/plans/2026-07-29-github-copilot-sysext.md
@@ -1,0 +1,411 @@
+# GitHub Copilot Sysext Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GitHub's official Copilot desktop application as the independently updateable, desktop-only `github-copilot` sysext.
+
+**Architecture:** Download the immutable official x86-64 Debian package through Snosi's checksum-verifying helper, install its already-sysext-compatible `/usr` payload into an overlay image, and publish it through the existing component-scoped systemd-sysupdate path. Reuse dpkg package `github` as the version source and the existing required-path and icon-cache finalizers.
+
+**Tech Stack:** mkosi, Debian packages, Bash, systemd-sysext/systemd-sysupdate, GitHub Actions YAML, jq.
+
+## Global Constraints
+
+- The component name is exactly `github-copilot`; the upstream dpkg package name is exactly `github`.
+- The initial artifact is `https://github.com/github/app/releases/download/v1.1.2/GitHub-Copilot-linux-x64.deb` with SHA-256 `df80379b8e624eaf751c33758534f111bed7faf09b8d988e59ac7e0ab3dc9ff4`.
+- Install the official `.deb`; do not extract the AppImage or add FUSE handling.
+- The sysext may ship only `/usr` content and must not add runtime `/etc` or `/var` mutations.
+- The feature is disabled by default and offered only to `snow,snowfield`.
+- Retain `Verify=false` for this sysext, matching the repository's accepted native sysext-signature risk.
+- Do not add a runtime service, preset, sysusers file, tmpfiles rule, `/etc` factory capture, relocation, or desktop-file rewrite.
+- Do not commit changes unless the user explicitly requests a commit.
+
+---
+
+### Task 1: Package And Register The Sysext
+
+**Files:**
+- Create: `mkosi.images/github-copilot/mkosi.conf`
+- Create: `mkosi.images/github-copilot/mkosi.postinst.chroot`
+- Create: `mkosi.images/github-copilot/required-paths.txt`
+- Create: `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.github-copilot.d/github-copilot.transfer`
+- Create: `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.github-copilot.d/github-copilot.feature`
+- Modify: `shared/download/sysext-checksums.json`
+- Modify: `mkosi.conf:3-22`
+- Modify: `check-profile-dependencies.sh:6-20`
+- Modify: `test/native-ab-components-test.sh:18-20,527-529`
+
+**Interfaces:**
+- Consumes: `verified_download <key> <destination>` from `shared/download/verified-download.sh`; shared sysext post-output and finalize scripts.
+- Produces: image `github-copilot`, dpkg key package `github`, systemd-sysupdate component `github-copilot`, and current symlink `/var/lib/extensions.d/github-copilot.raw`.
+
+- [ ] **Step 1: Extend the dependency guard first**
+
+Replace the partial `sysexts` array in `check-profile-dependencies.sh` with the complete root sysext inventory, including the not-yet-created component:
+
+```bash
+sysexts=(
+    1password
+    1password-cli
+    azurevpn
+    bitwarden
+    claude-desktop
+    code-server
+    coder
+    debdev
+    dev
+    docker
+    edge
+    github-copilot
+    incus
+    lemonade
+    nix
+    paseo
+    pilothouse
+    podman
+    tailscale
+    vscode
+)
+```
+
+- [ ] **Step 2: Run the registration assertion to verify it fails**
+
+Run:
+
+```bash
+grep -q '^[[:space:]]*github-copilot$' mkosi.conf
+```
+
+Expected: exit 1 because the new root image dependency is not registered yet.
+
+- [ ] **Step 3: Add the pinned download metadata**
+
+Add this object in sorted logical order to `shared/download/sysext-checksums.json` and retain valid JSON:
+
+```json
+"github-copilot": {
+  "url": "https://github.com/github/app/releases/download/v1.1.2/GitHub-Copilot-linux-x64.deb",
+  "sha256": "df80379b8e624eaf751c33758534f111bed7faf09b8d988e59ac7e0ab3dc9ff4",
+  "version": "1.1.2"
+}
+```
+
+- [ ] **Step 4: Create the image configuration**
+
+Create `mkosi.images/github-copilot/mkosi.conf` with exactly this structure:
+
+```ini
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=github-copilot
+Output=github-copilot
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+Packages=libayatana-appindicator3-1
+         libwebkit2gtk-4.1-0
+         libgtk-3-0
+
+[Build]
+Environment=KEYPACKAGE=github
+```
+
+- [ ] **Step 5: Create the verified package installer**
+
+Create executable `mkosi.images/github-copilot/mkosi.postinst.chroot`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "github-copilot" "$DEBS/github-copilot.deb"
+
+dpkg -i "$DEBS/github-copilot.deb"
+```
+
+Set mode `0755`. Do not add package extraction or relocation code.
+mkosi discovers the conventionally named `mkosi.postinst.chroot` automatically,
+matching `mkosi.images/code-server`; do not also list it in
+`PostInstallationScripts=`.
+
+- [ ] **Step 6: Add delta integrity assertions**
+
+Create `mkosi.images/github-copilot/required-paths.txt`:
+
+```text
+# github-copilot sysext: GitHub Copilot desktop application (Tauri)
+/usr/bin/github
+/usr/bin/git-credential-copilot
+/usr/lib/GitHub Copilot
+/usr/share/applications/GitHub Copilot.desktop
+/usr/share/icons/hicolor/128x128/apps/github.png
+```
+
+- [ ] **Step 7: Add component-scoped update metadata**
+
+Create `github-copilot.transfer`:
+
+```ini
+[Transfer]
+Features=github-copilot
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/github-copilot/
+MatchPattern=github-copilot_@v_%w_%a.raw.zst \
+             github-copilot_@v_%w_%a.raw.xz \
+             github-copilot_@v_%w_%a.raw.gz \
+             github-copilot_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=github-copilot_@v_%w_%a.raw.zst \
+             github-copilot_@v_%w_%a.raw.xz \
+             github-copilot_@v_%w_%a.raw.gz \
+             github-copilot_@v_%w_%a.raw
+CurrentSymlink=github-copilot.raw
+```
+
+Create `github-copilot.feature`:
+
+```ini
+[Feature]
+Description=GitHub Copilot agent-native desktop application
+Documentation=https://github.com/github/app
+Enabled=false
+X-Snosi-Products=snow,snowfield
+```
+
+- [ ] **Step 8: Register the image and runtime inventory**
+
+Add `github-copilot` to root `mkosi.conf`'s `Dependencies=` list in alphabetical position. In `test/native-ab-components-test.sh`, change the header's shipped-component count from 19 to 20 and add `github-copilot` to `expected_sysext_components` in sorted order.
+
+- [ ] **Step 9: Run focused static verification**
+
+Run:
+
+```bash
+jq -e '."github-copilot" == {
+  url: "https://github.com/github/app/releases/download/v1.1.2/GitHub-Copilot-linux-x64.deb",
+  sha256: "df80379b8e624eaf751c33758534f111bed7faf09b8d988e59ac7e0ab3dc9ff4",
+  version: "1.1.2"
+}' shared/download/sysext-checksums.json
+shellcheck mkosi.images/github-copilot/mkosi.postinst.chroot
+./check-profile-dependencies.sh
+./test/native-ab-contracts-test.sh
+```
+
+Expected: jq exits 0, shellcheck emits no findings, and both repository guards pass.
+
+---
+
+### Task 2: Automate Upstream Release Updates
+
+**Files:**
+- Modify: `.github/workflows/check-dependencies.yml:54-138,151-279`
+
+**Interfaces:**
+- Consumes: `.github/workflows/check-dependencies.yml` helpers `gh_api()` and `ver_gt()` plus checksum key `."github-copilot"` created in Task 1.
+- Produces: step outputs `github_copilot_update` and `github_copilot_version`; environment variables `GITHUB_COPILOT_UPDATE` and `GITHUB_COPILOT_VERSION` for the checksum-update step.
+
+- [ ] **Step 1: Confirm updater metadata is not wired yet**
+
+Run:
+
+```bash
+if grep -q 'github_copilot_update' .github/workflows/check-dependencies.yml; then
+    exit 1
+fi
+```
+
+Expected: exit 0 before implementation.
+
+- [ ] **Step 2: Add latest-release detection**
+
+Add this block after the Bitwarden check and before code-server:
+
+```bash
+# Check GitHub Copilot desktop app
+CURRENT_GITHUB_COPILOT=$(jq -r '."github-copilot".version' "$CHECKSUMS")
+LATEST_GITHUB_COPILOT=$(gh_api https://api.github.com/repos/github/app/releases | jq -r '[.[] | select(.draft == false and .prerelease == false)][0].tag_name' | sed 's/^v//')
+if [[ -n "$LATEST_GITHUB_COPILOT" && "$LATEST_GITHUB_COPILOT" != "null" ]] && ver_gt "$LATEST_GITHUB_COPILOT" "$CURRENT_GITHUB_COPILOT"; then
+  UPDATES="${UPDATES}github-copilot: $CURRENT_GITHUB_COPILOT -> $LATEST_GITHUB_COPILOT\n"
+  echo "github_copilot_update=true" >> "$GITHUB_OUTPUT"
+  echo "github_copilot_version=$LATEST_GITHUB_COPILOT" >> "$GITHUB_OUTPUT"
+fi
+```
+
+- [ ] **Step 3: Pass outputs through the trusted environment boundary**
+
+Add these entries to the update step's `env:` block:
+
+```yaml
+GITHUB_COPILOT_UPDATE: ${{ steps.check.outputs.github_copilot_update }}
+GITHUB_COPILOT_VERSION: ${{ steps.check.outputs.github_copilot_version }}
+```
+
+- [ ] **Step 4: Add checksum regeneration**
+
+Add this block after Bitwarden's updater branch:
+
+```bash
+if [[ "$GITHUB_COPILOT_UPDATE" == "true" ]]; then
+  VER="$GITHUB_COPILOT_VERSION"
+  URL="https://github.com/github/app/releases/download/v${VER}/GitHub-Copilot-linux-x64.deb"
+  TMP=$(mktemp)
+  curl -fsSL -o "$TMP" "$URL"
+  SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+  jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+    '."github-copilot".url=$u | ."github-copilot".sha256=$s | ."github-copilot".version=$v' \
+    "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+  rm -f "$TMP"
+fi
+```
+
+- [ ] **Step 5: Validate workflow syntax and trust-boundary wiring**
+
+Run:
+
+```bash
+actionlint .github/workflows/check-dependencies.yml
+grep -q 'github_copilot_update=true' .github/workflows/check-dependencies.yml
+grep -q 'GITHUB_COPILOT_VERSION.*steps.check.outputs.github_copilot_version' .github/workflows/check-dependencies.yml
+grep -q 'github.com/github/app/releases/download/v${VER}/GitHub-Copilot-linux-x64.deb' .github/workflows/check-dependencies.yml
+```
+
+Expected: all commands exit 0 and actionlint emits no findings.
+
+---
+
+### Task 3: Reconcile Documentation And Prove The Build
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `yeti/sysexts.md`
+- Modify: `yeti/OVERVIEW.md`
+- Modify: `yeti/ci-cd.md`
+- Modify: `docs/integration-contracts.md`
+- Modify: `docs/native-ab-contracts.md`
+
+**Interfaces:**
+- Consumes: the component name, package source, runtime dependencies, and update topology implemented in Tasks 1 and 2.
+- Produces: accurate human-facing and AI-facing inventories describing 20 sysexts and the component-scoped update layout.
+
+- [ ] **Step 1: Locate every stale count and complete inventory**
+
+Run:
+
+```bash
+rg -n '19 sysext|19 shipped|18 component|17 other|17 pairs|13 sysext|claude-desktop.*code-server|paseo.*pilothouse' CLAUDE.md README.md yeti docs
+```
+
+Expected: matches include the known stale inventories identified in the design review; use the output as the exact edit checklist.
+
+- [ ] **Step 2: Update source-of-truth product inventories**
+
+Make these exact semantic changes:
+
+```text
+CLAUDE.md:
+- Change all complete sysext counts from 19 to 20.
+- Insert github-copilot alphabetically in every complete sysext list.
+
+README.md:
+- Add a `github-copilot` output row: GitHub Copilot agent-native desktop application; sysext.
+- Add it to the architecture diagram, detailed sysext table, and build workflow inventory.
+- Reconcile those lists to all 20 root mkosi dependencies rather than preserving pre-existing omissions.
+```
+
+- [ ] **Step 3: Document the package and component mechanics**
+
+Make these exact semantic changes:
+
+```text
+yeti/sysexts.md:
+- Add `github-copilot | github | GitHub Copilot desktop app (official pinned .deb via verified_download; Tauri; native /usr layout)` to Current Sysexts.
+- Add github-copilot to the direct-download exception list.
+- Add a github-copilot subsection recording: no mkosi.extra, no relocation, no runtime service, no /etc capture, and shared hicolor cache stripping.
+
+yeti/OVERVIEW.md:
+- Change complete sysext/component counts to 20.
+- Add github-copilot to complete lists and checksum-managed direct downloads.
+
+yeti/ci-cd.md:
+- Correct the stale sysext count to 20.
+
+docs/integration-contracts.md:
+- Keep pilothouse as the sole Frostyard-authored sysext and change the external count to 19.
+
+docs/native-ab-contracts.md:
+- Replace the stale shared-/usr/lib/sysupdate.d description with 20 component-scoped `/usr/lib/sysupdate.<name>.d/` transfer/feature pairs; retain `/usr/lib/sysupdate.d/` for the three OS transfers only.
+```
+
+- [ ] **Step 4: Run the full static validation set**
+
+Run:
+
+```bash
+jq empty shared/download/sysext-checksums.json
+actionlint .github/workflows/check-dependencies.yml
+shellcheck mkosi.images/github-copilot/mkosi.postinst.chroot
+./check-duplicate-packages.sh
+./check-profile-dependencies.sh
+./test/native-ab-static-test.sh
+./test/native-ab-contracts-test.sh
+./check-native-publication-guard.sh
+git diff --check
+```
+
+Expected: every command exits 0 with no new findings.
+
+- [ ] **Step 5: Resolve and build only the new image**
+
+Run:
+
+```bash
+sudo .mkosi/bin/mkosi --image github-copilot summary
+sudo .mkosi/bin/mkosi --image github-copilot build
+```
+
+Expected: summary resolves `github-copilot` with `KEYPACKAGE=github`; build verifies the pinned hash, installs package `github` version `1.1.2`, passes all five required paths, strips the hicolor cache, and emits a versioned `github-copilot_1.1.2_*` sysext plus manifest. If the repository's pinned mkosi uses a different image-selection spelling, use the equivalent selector reported by `.mkosi/bin/mkosi --help` without changing image semantics.
+
+- [ ] **Step 6: Perform the graphical acceptance smoke where a Snow desktop session is available**
+
+Install or merge the built sysext, start a fresh desktop session so shell caches are refreshed, then run:
+
+```bash
+command -v github
+gtk-launch 'GitHub Copilot'
+xdg-open 'github-app:'
+```
+
+Expected: `/usr/bin/github` is selected; the launcher has the GitHub Copilot icon; the application window remains running without dynamic-loader errors; and the registered URL scheme routes to the application. Do not sign in or create a repository session. If no graphical Snow/Snowfield session is available in the execution environment, record this step as not run rather than claiming success.
+
+- [ ] **Step 7: Inspect the final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+git diff --check
+```
+
+Expected: only the planned sysext, updater, tests/inventories, design, plan, and documentation files are changed; no generated build outputs are tracked.

--- a/docs/superpowers/specs/2026-07-29-github-copilot-sysext-design.md
+++ b/docs/superpowers/specs/2026-07-29-github-copilot-sysext-design.md
@@ -1,0 +1,168 @@
+# GitHub Copilot Sysext Design
+
+## Goal
+
+Add the GitHub Copilot desktop app as an independently updateable Snosi system
+extension named `github-copilot`. The component must work on the graphical
+`snow` and `snowfield` products without modifying their immutable base images or
+requiring AppImage/FUSE support at runtime.
+
+GitHub authentication and account provisioning are outside this change. The
+acceptance check stops after proving that the application launches correctly.
+
+## Upstream Artifact
+
+Use GitHub's official x86-64 Debian package rather than unpacking the AppImage.
+Both artifacts are published in each `github/app` release, but the Debian
+package is the better sysext input:
+
+- It is smaller than the corresponding AppImage.
+- It installs its complete payload under `/usr`, the filesystem namespace this
+  sysext may provide.
+- It carries package name and version metadata for the existing sysext output
+  naming machinery.
+- It declares its host-library dependencies explicitly.
+- It avoids AppImage extraction, FUSE, launcher rewriting, and synthetic
+  package metadata.
+
+The initial pin is GitHub Copilot v1.1.2:
+
+- Package: `github`
+- Version: `1.1.2`
+- Artifact: `GitHub-Copilot-linux-x64.deb`
+- SHA-256: `df80379b8e624eaf751c33758534f111bed7faf09b8d988e59ac7e0ab3dc9ff4`
+
+The inspected package has no maintainer scripts. Its payload includes
+`/usr/bin/github`, `/usr/bin/git-credential-copilot`, application support files
+under `/usr/lib/GitHub Copilot`, a desktop entry, hicolor icons, and URL-handler
+registrations. The upstream `/usr/bin/github` name does not collide with the
+GitHub CLI's conventional `/usr/bin/gh` command.
+
+## Packaging Architecture
+
+Create `mkosi.images/github-copilot/` as an overlay sysext based on `base`.
+Its configuration follows the existing direct-download desktop application
+pattern:
+
+1. Install runtime dependencies through mkosi `Packages=` before the direct
+   package installation:
+   - `libayatana-appindicator3-1`
+   - `libwebkit2gtk-4.1-0`
+   - `libgtk-3-0`
+2. Run a chroot post-install script that obtains the pinned Debian package with
+   `verified_download("github-copilot", ...)` and installs it with `dpkg -i`.
+3. Do not relocate or rewrite package files. The upstream package already uses
+   sysext-compatible `/usr` paths and its desktop entry executes `github %u`.
+4. Run the shared required-path and icon-cache stripping finalizers. The latter
+   prevents the sysext from masking icons supplied by this or other extensions.
+5. Set `KEYPACKAGE=github`, allowing the shared post-output script to derive
+   the sysext version from dpkg metadata.
+
+The required-path list must cover, at minimum:
+
+- `/usr/bin/github`
+- `/usr/bin/git-credential-copilot`
+- `/usr/lib/GitHub Copilot`
+- `/usr/share/applications/GitHub Copilot.desktop`
+- `/usr/share/icons/hicolor/128x128/apps/github.png`
+
+No system service, preset, sysusers entry, tmpfiles rule, or `/etc` factory
+capture is needed. User settings, credentials, repositories, sessions, and
+worktrees remain in the application's normal per-user writable locations.
+
+## Distribution And Feature Policy
+
+Add a dedicated component directory at
+`mkosi.images/base/mkosi.extra/usr/lib/sysupdate.github-copilot.d/`.
+
+The transfer follows the established sysext naming and repository convention:
+
+- Source: `https://repository.frostyard.org/ext/github-copilot/`
+- Target: `/var/lib/extensions.d/`
+- Current symlink: `github-copilot.raw`
+- Feature name: `github-copilot`
+
+The feature is disabled by default and carries
+`X-Snosi-Products=snow,snowfield`. It must not be offered on the headless
+`cayo` product.
+
+Add `github-copilot` to the root mkosi dependency list so the standard sysext
+build and publication workflow includes it. Update any tests or inventories
+that enumerate the complete component set.
+
+## Dependency Updates
+
+Add a `github-copilot` entry to
+`shared/download/sysext-checksums.json` containing the immutable release URL,
+SHA-256, and version.
+
+Extend the `check-sysext-updates` job in
+`.github/workflows/check-dependencies.yml` to:
+
+1. Query `github/app` releases through the existing authenticated GitHub API
+   helper.
+2. Select the latest non-draft, non-prerelease release.
+3. Normalize the leading `v` from the tag and require it to sort strictly newer
+   than the pinned version.
+4. Construct the immutable
+   `GitHub-Copilot-linux-x64.deb` release URL.
+5. Download the artifact, calculate its SHA-256, update the checksum metadata,
+   and let the existing workflow open the normal update pull request.
+
+All external release values continue to pass through environment variables
+rather than direct expression interpolation in shell code.
+
+## Failure Handling
+
+The build fails closed when:
+
+- The downloaded artifact does not match the pinned SHA-256.
+- The Debian package cannot be installed with its declared runtime
+  dependencies.
+- Any required application, helper, desktop integration, or icon path is
+  missing from the sysext delta.
+- Static component metadata does not match the sysext name or publication
+  paths.
+
+The build must not fall back to a moving `latest` URL, the AppImage, or an
+unverified artifact.
+
+## Validation
+
+Automated validation covers:
+
+- JSON and workflow syntax after metadata changes.
+- Existing profile/dependency, native component, and publication guards.
+- mkosi configuration resolution for the new image.
+- A real `github-copilot` sysext build, including checksum verification, dpkg
+  installation, post-output version extraction, and required-path checks.
+
+A graphical acceptance smoke test on Snow or Snowfield covers:
+
+1. Install or merge the built `github-copilot` sysext.
+2. Confirm the GitHub Copilot launcher and icon appear in the desktop shell.
+3. Start the application from the launcher.
+4. Run `xdg-open` on one of the desktop entry's registered URL schemes
+   (`github-app`, `ghapp`, or `gh`) and confirm it routes to the running
+   application.
+5. Confirm the process and window remain running without dynamic-loader or
+   startup errors.
+
+The smoke test does not sign in, create a session, mutate a repository, or
+require GitHub credentials. No new general-purpose GUI automation framework is
+introduced; structural regressions remain enforced by the repeatable build and
+required-path checks.
+
+## Documentation
+
+Update the source-of-truth inventories and architecture notes in:
+
+- `CLAUDE.md`
+- `README.md`
+- `yeti/sysexts.md`
+- Other existing count-based or complete sysext inventories found during
+  implementation
+
+The documentation must identify the component as an official pinned `.deb`,
+not an extracted AppImage, and record that it is a Tauri desktop application
+with no runtime service.

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -12,6 +12,7 @@ Dependencies=base
              dev
              docker
              edge
+             github-copilot
              incus
              lemonade
              nix

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.github-copilot.d/github-copilot.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.github-copilot.d/github-copilot.feature
@@ -1,0 +1,5 @@
+[Feature]
+Description=GitHub Copilot agent-native desktop application
+Documentation=https://github.com/github/app
+Enabled=false
+X-Snosi-Products=snow,snowfield

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.github-copilot.d/github-copilot.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.github-copilot.d/github-copilot.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=github-copilot
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/github-copilot/
+MatchPattern=github-copilot_@v_%w_%a.raw.zst \
+             github-copilot_@v_%w_%a.raw.xz \
+             github-copilot_@v_%w_%a.raw.gz \
+             github-copilot_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=github-copilot_@v_%w_%a.raw.zst \
+             github-copilot_@v_%w_%a.raw.xz \
+             github-copilot_@v_%w_%a.raw.gz \
+             github-copilot_@v_%w_%a.raw
+CurrentSymlink=github-copilot.raw

--- a/mkosi.images/github-copilot/mkosi.conf
+++ b/mkosi.images/github-copilot/mkosi.conf
@@ -1,0 +1,21 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=github-copilot
+Output=github-copilot
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+Packages=libayatana-appindicator3-1
+         libwebkit2gtk-4.1-0
+         libgtk-3-0
+
+[Build]
+Environment=KEYPACKAGE=github

--- a/mkosi.images/github-copilot/mkosi.postinst.chroot
+++ b/mkosi.images/github-copilot/mkosi.postinst.chroot
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+# shellcheck disable=SC1091
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "github-copilot" "$DEBS/github-copilot.deb"
+
+dpkg -i "$DEBS/github-copilot.deb"

--- a/mkosi.images/github-copilot/required-paths.txt
+++ b/mkosi.images/github-copilot/required-paths.txt
@@ -1,0 +1,6 @@
+# github-copilot sysext: GitHub Copilot desktop application (Tauri)
+/usr/bin/github
+/usr/bin/git-credential-copilot
+/usr/lib/GitHub Copilot
+/usr/share/applications/GitHub Copilot.desktop
+/usr/share/icons/hicolor/128x128/apps/github.png

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -29,6 +29,11 @@
     "sha256": "a23cc8ceb36b881c341fd4d3bba217bf1b9f1097b5f462ba62da9a58c11d8870",
     "version": "2.34.7"
   },
+  "github-copilot": {
+    "url": "https://github.com/github/app/releases/download/v1.1.2/GitHub-Copilot-linux-x64.deb",
+    "sha256": "df80379b8e624eaf751c33758534f111bed7faf09b8d988e59ac7e0ab3dc9ff4",
+    "version": "1.1.2"
+  },
   "lemonade": {
     "url": "https://github.com/lemonade-sdk/lemonade/releases/download/v11.5.0/lemonade-server_11.5.0-debian13_amd64.deb",
     "sha256": "cd7448b1b577815a75b4596a9611d29a37db737c036dd9bc9b18d258ddd4204e",

--- a/shared/sysext/finalize/sysext-required-paths.sh
+++ b/shared/sysext/finalize/sysext-required-paths.sh
@@ -39,7 +39,8 @@ path_present() {
 missing=()
 while IFS= read -r line; do
     line="${line%%#*}"
-    line="${line//[[:space:]]/}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
     [[ -n "$line" ]] || continue
     if ! path_present "$line"; then
         missing+=("$line")

--- a/test/native-ab-components-test.sh
+++ b/test/native-ab-components-test.sh
@@ -15,7 +15,7 @@
 # in QEMU, and validates in order:
 #
 #   1. No failed legacy updaters; bootc/nbc/sysupdate auto-update units masked.
-#   2. The OS default sysupdate.d target and the 19 shipped sysext components
+#   2. The OS default sysupdate.d target and the 20 shipped sysext components
 #      are structurally separate (component discovery via `systemd-sysupdate
 #      components`).
 #   3. Two ad hoc test sysext components (testa, testb; independently
@@ -525,8 +525,8 @@ assert_eq "/usr/lib/sysupdate.d/ contains exactly the OS transfers, no features"
     "$default_target_listing" "$expected_default_listing"
 
 expected_sysext_components=(1password 1password-cli azurevpn bitwarden claude-desktop
-    coder code-server debdev dev docker edge incus lemonade nix paseo pilothouse podman
-    tailscale vscode)
+    code-server coder debdev dev docker edge github-copilot incus lemonade nix paseo
+    pilothouse podman tailscale vscode)
 
 components_raw="$(vm_ssh '/usr/lib/systemd/systemd-sysupdate components --no-legend')"
 echo "systemd-sysupdate components --no-legend:"

--- a/test/sysext-required-paths-test.sh
+++ b/test/sysext-required-paths-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FINALIZE_SCRIPT="$ROOT_DIR/shared/sysext/finalize/sysext-required-paths.sh"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+failures=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    failures=$((failures + 1))
+}
+
+pass() {
+    echo "PASS: $*"
+}
+
+run_finalize() {
+    local paths_file="$1"
+    local output
+
+    cp "$paths_file" "$WORK_DIR/src/mkosi.images/test/required-paths.txt"
+    if output=$(SRCDIR="$WORK_DIR/src" BUILDROOT="$WORK_DIR/buildroot" IMAGE_ID=test \
+        "$FINALIZE_SCRIPT" 2>&1); then
+        RUN_STATUS=0
+    else
+        RUN_STATUS=$?
+    fi
+    RUN_OUTPUT="$output"
+}
+
+mkdir -p "$WORK_DIR/src/mkosi.images/test" "$WORK_DIR/buildroot/usr/lib/GitHub Copilot"
+
+present_paths="$WORK_DIR/present-paths.txt"
+printf '/usr/lib/GitHub Copilot\n' > "$present_paths"
+run_finalize "$present_paths"
+if [[ $RUN_STATUS -eq 0 ]]; then
+    pass "present required path with internal spaces is accepted"
+else
+    fail "present required path with internal spaces is accepted: $RUN_OUTPUT"
+fi
+
+missing_paths="$WORK_DIR/missing-paths.txt"
+printf '/usr/lib/Missing Copilot\n' > "$missing_paths"
+run_finalize "$missing_paths"
+if [[ $RUN_STATUS -ne 0 && "$RUN_OUTPUT" == *"/usr/lib/Missing Copilot"* ]]; then
+    pass "missing required path diagnostic preserves internal spaces"
+else
+    fail "missing required path diagnostic preserves internal spaces: $RUN_OUTPUT"
+fi
+
+if (( failures > 0 )); then
+    exit 1
+fi
+
+echo "sysext-required-paths-test: PASSED"

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1007,7 +1007,7 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
-1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode
+1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode
 
 ## Architecture
 
@@ -1017,10 +1017,10 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 19 sysexts)
+mkosi.images/               # Image definitions (base + 20 sysexts)
   base/                     # Foundation image: systemd, bootc/ostree (frostyard debs), firmware, core utils
     mkosi.extra/            # Base filesystem overlay (dracut, systemd units/timers, sysupdate, tmpfiles, sysusers)
-      usr/lib/sysupdate.<name>.d/  # per-sysext .transfer + .feature component dirs (one pair each, 18 total)
+      usr/lib/sysupdate.<name>.d/  # per-sysext .transfer + .feature component dirs (one pair each, 20 total)
     mkosi.postinst.chroot   # Mount enablement, useradd home dir, bls-garbage-collect removal
     mkosi.finalize.chroot   # Masks systemd-networkd-wait-online
   docker/                   # Each sysext: mkosi.conf + optional extra/scripts
@@ -1262,8 +1262,9 @@ Docker, 1Password) are tracked separately in
 `shared/download/package-versions.json`, checked daily by `check-packages.yml`.
 This file is only a rebuild sentinel; mkosi still resolves packages from APT.
 
-Current sysext checksum-managed downloads are 1Password desktop, Bitwarden,
-code-server, coder, Azure VPN, and Microsoft Edge. Current image checksum-managed downloads are Homebrew
+Current sysext checksum-managed downloads are 1Password, Bitwarden, Azure VPN,
+Microsoft Edge, code-server, coder, GitHub Copilot, Lemonade, Paseo, and
+Pilothouse. Current image checksum-managed downloads are Homebrew
 install script, Surface secure boot certificate, Hotedge, Logomenu, and Bazaar
 Companion. Current APT version tracking covers `code`, `docker-ce`,
 `1password-cli`, and `claude-desktop`; Edge is checksum-managed because the build installs a patched
@@ -1314,7 +1315,7 @@ Use build-time enablement/presets for desired service state. For run-once runtim
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 19 sysexts
+just sysexts            # Build base + all 20 sysexts
 just snow               # Build snow desktop
 just snowfield          # Build snowfield (Surface)
 just cayo               # Build cayo server

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -392,7 +392,8 @@ by the build artifact that must be rebuilt when a dependency changes:
 ### sysext-checksums.json
 
 Pins URL + SHA256 for direct downloads consumed by sysext builds. Current
-consumers include the Bitwarden, Edge, Azure VPN, and code-server sysexts.
+consumers are 1Password, Bitwarden, Azure VPN, Edge, code-server, coder,
+GitHub Copilot, Lemonade, Paseo, and Pilothouse.
 Updates to this file should trigger `build.yml` and skip the OCI image matrix.
 
 ### image-checksums.json

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -8,7 +8,7 @@
 `shared/download/image-checksums.json` when that is the only changed path;
 image-only direct-download updates should rebuild OCI profiles instead.
 
-Builds the base image and all 13 sysexts, publishes to the Frostyard repository on Cloudflare R2.
+Builds the base image and all 20 sysexts, publishes to the Frostyard repository on Cloudflare R2.
 
 **Steps:**
 1. Aggressive cleanup of runner (removes JDK, .NET, Android SDK, etc. to free disk space)
@@ -287,6 +287,7 @@ for the build artifact that must be rebuilt.
   followed
 - Microsoft Azure VPN Client
 - Microsoft Edge Stable .deb
+- GitHub Copilot desktop .deb
 
 Version-based checks only propose an update when the candidate sorts
 **strictly newer** (`sort -V`) than the pinned version — a plain `!=`

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -28,6 +28,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **dev** | build-essential | Build essentials, cmake, Python3, valgrind, gdb, strace |
 | **docker** | docker-ce | Docker CE, containerd, buildx, compose |
 | **edge** | microsoft-edge-stable | Microsoft Edge browser (pinned .deb via verified_download, relocated from /opt) |
+| **github-copilot** | github | GitHub Copilot desktop app (official pinned .deb via verified_download; Tauri; native /usr layout) |
 | **incus** | incus | Incus container/VM manager, QEMU/KVM, dnsmasq, OVMF, virt-viewer |
 | **lemonade** | lemonade-server | Lemonade local LLM server (lemond) — downloaded via `verified_download()` from lemonade-sdk/lemonade GitHub releases; libcpp-httplib0.41 dep from trixie-backports |
 | **nix** | nix-setup-systemd | Nix package manager with systemd integration |
@@ -103,6 +104,10 @@ payload of load-bearing dependency packages, the primary unit files, and the
 check in addition to (after) the image's own `mkosi.finalize` — file-detected
 default scripts compose with explicit `FinalizeScripts=` entries.
 
+Entries may contain internal spaces. The parser trims only surrounding
+whitespace and comments, preserving the path itself for the required-path
+check.
+
 **Delta semantics:** for `Overlay=yes` images the finalize `$BUILDROOT` is the
 sysext DELTA (the overlay upper layer — exactly what ships), not the merged
 base view. Only list paths the sysext itself provides. A package that is also
@@ -111,7 +116,7 @@ installed" at build time, contributes nothing to the delta, and its paths will
 always fail the check even though they exist at runtime — caught live when
 `wget` in debdev's list failed CI on the first run.
 
-`code-server`, `coder`, `edge`, `bitwarden`, `paseo`, and `azurevpn` are the current exceptions to the `Packages=` line: it downloads a pinned upstream `.deb` in `mkosi.images/code-server/mkosi.postinst.chroot` with `verified_download()` and installs it with `dpkg -i`. It still sets `KEYPACKAGE=code-server`, and the shared postoutput script resolves that version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file Exec rewrite, deps via `Include=`. `paseo` is the same shape again (`shared/packages/paseo/`), plus the `edge`-style update-alternatives repointing (its deb registers `/usr/bin/Paseo` through `/etc/alternatives`, which a sysext never ships).
+`code-server`, `coder`, `edge`, `bitwarden`, `github-copilot`, `paseo`, and `azurevpn` are the current exceptions to the `Packages=` line: each downloads a pinned upstream artifact with `verified_download()` and installs it with `dpkg -i`. `github-copilot` uses GitHub's official `.deb`; its Tauri payload already has a native `/usr` layout. The shared postoutput script resolves every `KEYPACKAGE` version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file `Exec=` rewrite, deps via `Include=`. `paseo` is the same shape again (`shared/packages/paseo/`), plus the `edge`-style update-alternatives repointing (its deb registers `/usr/bin/Paseo` through `/etc/alternatives`, which a sysext never ships).
 
 ## Sysext-Specific Extra Files
 
@@ -177,6 +182,10 @@ Some sysexts include extra files via `mkosi.extra/`:
 - Desktop app with no systemd service: no preset, no `Upholds=` drop-in
 - The postinst repoints the update-alternatives symlinks (`/usr/bin/microsoft-edge`, `x-www-browser`, `gnome-www-browser`) at the real binary: their `/etc/alternatives` targets ship in profile images but are stripped from sysexts, so they would dangle on target systems
 - Its icons are hicolor symlinks created by the relocation script — visibility depends on the no-icon-cache pattern (see Desktop Applications in Sysexts below), so on images that still ship `icon-theme.cache` the Edge icon renders generic
+
+### github-copilot
+- No `mkosi.extra/`, relocation, runtime service, or `/etc` capture: GitHub's official pinned `.deb` installs the Tauri application directly under `/usr`
+- Ships hicolor icons, so the shared `sysext-strip-icon-cache.sh` finalize step is required
 
 ### incus
 - `mkosi.finalize` — Captures the tmpfiles-referenced `/etc` paths to factory defaults

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -371,7 +371,7 @@ install: `/var/lib/dpkg` is a symlink to `../../usr/lib/sysimage/dpkg`,
 `usr/share/snosi/var-inventory.txt` exists with at least one
 `image-metadata` line, and no unit failures were introduced; (2)
 `/usr/lib/sysupdate.d/` contains only the three OS transfers (no `.feature`
-files) and `systemd-sysupdate components` enumerates all 17 shipped sysext
+files) and `systemd-sysupdate components` enumerates all 20 shipped sysext
 components; (3) two ad hoc test components (`testa`, `testb`, independently
 versioned) created under `/etc/sysupdate.<name>.d/` update independently via
 `--component=`, leave the GPT partition table and ESP `/EFI/Linux` listing


### PR DESCRIPTION
## Summary
- add the official pinned GitHub Copilot `.deb` as a desktop-only `github-copilot` sysext
- register component-scoped sysupdate metadata and automated stable-release checksum updates
- preserve internal spaces in required-path validation with a CI regression test
- reconcile sysext inventories and architecture documentation to 20 components

## Validation
- `sudo .mkosi/bin/mkosi --dependency= --dependency=github-copilot build`
- `./test/sysext-required-paths-test.sh`
- `./test/native-ab-static-test.sh`
- `./test/native-ab-contracts-test.sh` (127 checks)
- `./check-native-publication-guard.sh`
- `PATH="$PWD/.mkosi/bin:$PATH" ./check-profile-dependencies.sh`
- CI-equivalent `shellcheck -S warning -x` pass
- local Snow merge: `systemd-sysext status` reports `github-copilot`; launcher and `github-app:` URL handler opened successfully

## Notes
- `actionlint` continues to report existing informational SC2086 findings in unchanged workflow branches; the new Copilot blocks use quoted output paths and add no diagnostics.
- sysext remains disabled by default and is curated only for Snow/Snowfield.