### PR TITLE
fix: forward secure packaging state through sudo

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -166,7 +166,13 @@ jobs:
           SNOSI_BOOTC_PCR_KEY: /var/tmp/bootc-secure-credentials/pcr.key
           SNOSI_BOOTC_PCR_CERT: /var/tmp/bootc-secure-credentials/pcr.pub
         run: |
-          sudo TMPDIR="$TMPDIR" ./shared/outformat/image/buildah-package.sh \
+          sudo TMPDIR="$TMPDIR" \
+            SNOSI_BOOTC_SECURE="$SNOSI_BOOTC_SECURE" \
+            SNOSI_BOOTC_MOK_KEY="$SNOSI_BOOTC_MOK_KEY" \
+            SNOSI_BOOTC_MOK_CERT="$SNOSI_BOOTC_MOK_CERT" \
+            SNOSI_BOOTC_PCR_KEY="$SNOSI_BOOTC_PCR_KEY" \
+            SNOSI_BOOTC_PCR_CERT="$SNOSI_BOOTC_PCR_CERT" \
+            ./shared/outformat/image/buildah-package.sh \
             output/${{ matrix.profile }} \
             "$IMAGE:${{ steps.version.outputs.tag }}" \
             "org.opencontainers.image.title=${{ matrix.profile }}" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,9 @@ only around local assembly/validation, requires the supplied public MOK/PCR
 identities to byte-match `shared/native-ab/keys/mok-2026.crt` and
 `shared/native-ab/keys/pcr-signing-2026.pub`, deletes credentials before any
 registry write, validates an immutable version digest, then moves `latest`.
+The protected package step forwards the secure flag and credential paths as
+explicit sudo command assignments; GitHub step environment values do not cross
+sudo implicitly, and secret bytes remain only in the mode-0600 files.
 Local and policy-copied artifact validation use host Podman to execute the
 candidate image's pinned bootc; they do not require or accept an independently
 installed host bootc as the storage-digest authority.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Protected bootc publication validates each candidate with host Podman while
 running the candidate image's pinned bootc for its composefs storage digest.
 The publisher does not depend on a separate host bootc installation, avoiding
 version drift at that compatibility boundary.
+The protected packager passes its secure assembly flag and credential paths
+explicitly through sudo. The private bytes stay in mode-0600 runner files;
+only their paths cross the privilege boundary.
 
 ## Architecture
 

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -151,8 +151,9 @@ else
             capture && /^      - name: / && $0 != "      - name: Validate locally assembled secure artifact" { exit }
             capture { print }
         ' <<<"$secure_job")
+        # shellcheck disable=SC2016 # GitHub expression is an exact literal marker.
         if ! grep -Fq './test/bootc-secure-artifact-test.sh' <<<"$local_validation" ||
-                ! grep -Fq "\"output/\${{ matrix.profile }}\"" <<<"$local_validation"; then
+                ! grep -Fq '"output/${{ matrix.profile }}"' <<<"$local_validation"; then
             fail_check "$workflow secure-build: missing local secure artifact validation"
         fi
 
@@ -161,8 +162,9 @@ else
             capture && /^      - name: / && $0 != "      - name: Validate policy-copied secure artifact" { exit }
             capture { print }
         ' <<<"$secure_job")
+        # shellcheck disable=SC2016 # Shell variable reference is an exact literal marker.
         if ! grep -Fq './test/bootc-secure-artifact-test.sh' <<<"$remote_validation" ||
-                ! grep -Fq "\"\$LOCAL_REF\"" <<<"$remote_validation"; then
+                ! grep -Fq '"$LOCAL_REF"' <<<"$remote_validation"; then
             fail_check "$workflow secure-build: missing policy-copied artifact validation"
         fi
 

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -113,6 +113,28 @@ else
             require_text "$workflow secure-build" "$secure_job" "$variable"
         done
 
+        package_step=$(awk '
+            /^      - name: Package image$/ { capture=1 }
+            capture && /^      - name: / && $0 != "      - name: Package image" { exit }
+            capture { print }
+        ' <<<"$secure_job")
+        forwarded_variables=(
+            SNOSI_BOOTC_SECURE
+            SNOSI_BOOTC_MOK_KEY
+            SNOSI_BOOTC_MOK_CERT
+            SNOSI_BOOTC_PCR_KEY
+            SNOSI_BOOTC_PCR_CERT
+        )
+        for variable in "${forwarded_variables[@]}"; do
+            forwarded_line=$(printf '            %s="$%s" %s' \
+                "$variable" "$variable" "\\")
+            require_text "$workflow protected package sudo environment" \
+                "$package_step" "$forwarded_line"
+        done
+        sudo_tmpdir_line=$(printf '%s%s' "          sudo TMPDIR=\"\$TMPDIR\" " "\\")
+        require_text "$workflow protected package sudo environment" \
+            "$package_step" "$sudo_tmpdir_line"
+
         cleanup_step=$(awk '
             /^      - name: Remove protected bootc signing credentials$/ { capture=1 }
             capture && /^      - name: / && $0 != "      - name: Remove protected bootc signing credentials" { exit }
@@ -130,7 +152,7 @@ else
             capture { print }
         ' <<<"$secure_job")
         if ! grep -Fq './test/bootc-secure-artifact-test.sh' <<<"$local_validation" ||
-                ! grep -Fq '"output/${{ matrix.profile }}"' <<<"$local_validation"; then
+                ! grep -Fq "\"output/\${{ matrix.profile }}\"" <<<"$local_validation"; then
             fail_check "$workflow secure-build: missing local secure artifact validation"
         fi
 
@@ -140,7 +162,7 @@ else
             capture { print }
         ' <<<"$secure_job")
         if ! grep -Fq './test/bootc-secure-artifact-test.sh' <<<"$remote_validation" ||
-                ! grep -Fq '"$LOCAL_REF"' <<<"$remote_validation"; then
+                ! grep -Fq "\"\$LOCAL_REF\"" <<<"$remote_validation"; then
             fail_check "$workflow secure-build: missing policy-copied artifact validation"
         fi
 

--- a/docs/superpowers/plans/2026-07-30-bootc-secure-sudo-environment.md
+++ b/docs/superpowers/plans/2026-07-30-bootc-secure-sudo-environment.md
@@ -180,7 +180,7 @@ Run:
 test/bootc-publication-guard-test.sh
 ./check-bootc-publication-guard.sh
 test/bootc-secure-package-cleanup-test.sh
-test/bootc-secure-package-negative-test.sh
+test/bootc-secure-artifact-negative-test.sh --fixtures
 shellcheck check-bootc-publication-guard.sh \
   test/bootc-publication-guard-test.sh
 actionlint .github/workflows/build-images.yml

--- a/docs/superpowers/plans/2026-07-30-bootc-secure-sudo-environment.md
+++ b/docs/superpowers/plans/2026-07-30-bootc-secure-sudo-environment.md
@@ -67,6 +67,17 @@ for variable in SNOSI_BOOTC_SECURE SNOSI_BOOTC_MOK_KEY SNOSI_BOOTC_MOK_CERT SNOS
 done
 ```
 
+Also add the `TMPDIR` anchor mutation beside the forwarding helper and loop:
+
+```bash
+remove_sudo_tmpdir() {
+    perl -0pi -e 's/^          sudo TMPDIR="\$TMPDIR" \\\n//m' \
+        "$1/.github/workflows/build-images.yml"
+}
+
+assert_guard 'missing sudo TMPDIR forwarding fails' 1 remove_sudo_tmpdir
+```
+
 - [ ] **Step 2: Run the guard fixture and confirm RED**
 
 Run:
@@ -127,7 +138,7 @@ Run:
 test/bootc-publication-guard-test.sh
 ```
 
-Expected: the fixture baseline passes because it declares all forwarded values; each of the five forwarding mutations passes by making the guard reject its fixture. The real-tree guard is not run yet because the production workflow still lacks forwarding.
+Expected: the fixture baseline passes because it declares all forwarded values; each of the five secure-variable forwarding mutations and the `TMPDIR` anchor mutation pass by making the guard reject its fixture. The real-tree guard is not run yet because the production workflow still lacks forwarding.
 
 - [ ] **Step 5: Forward secure values through sudo in the protected workflow**
 
@@ -187,7 +198,7 @@ actionlint .github/workflows/build-images.yml
 git diff --check
 ```
 
-Expected: all commands exit 0; the publication fixture reports 28 passing assertions and zero failures; both package fixture scripts pass.
+Expected: all commands exit 0; the publication fixture reports 29 passing assertions and zero failures; both package fixture scripts pass.
 
 - [ ] **Step 8: Review and commit Task 1**
 

--- a/docs/superpowers/plans/2026-07-30-bootc-secure-sudo-environment.md
+++ b/docs/superpowers/plans/2026-07-30-bootc-secure-sudo-environment.md
@@ -1,0 +1,289 @@
+# Bootc Secure Packaging Sudo Environment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Forward secure assembly state explicitly through sudo so protected packaging enters the signed-UKI path.
+
+**Architecture:** Keep GitHub Actions step-level declarations as the source of secure values, then repeat their names as explicit sudo command assignments at the privilege boundary. Extend the publication guard and its isolated mutation fixture to require both declaration and forwarding before a protected workflow is accepted.
+
+**Tech Stack:** GitHub Actions YAML, sudo, Bash, Buildah, Podman, ShellCheck, actionlint
+
+## Global Constraints
+
+- Correct only the protected package invocation's sudo environment boundary and its publication guard.
+- Do not change credential contents, assembly behavior, validation behavior, registry ordering, labels, or the secretless mechanics build.
+- Explicitly forward `TMPDIR`, `SNOSI_BOOTC_SECURE`, `SNOSI_BOOTC_MOK_KEY`, `SNOSI_BOOTC_MOK_CERT`, `SNOSI_BOOTC_PCR_KEY`, and `SNOSI_BOOTC_PCR_CERT` after `sudo`.
+- Do not use `sudo --preserve-env`.
+- Only credential paths cross sudo; secret bytes remain in mode-0600 files under `/var/tmp`.
+- A failed package or local validation must continue to prevent every registry write and `latest` promotion.
+- Update `CLAUDE.md`, `README.md`, and `yeti/ci-cd.md` with the sudo boundary.
+
+---
+
+### Task 1: Forward And Guard Secure Packaging State
+
+**Files:**
+- Modify: `test/bootc-publication-guard-test.sh:52-89,109-149`
+- Modify: `check-bootc-publication-guard.sh:95-125`
+- Modify: `.github/workflows/build-images.yml:160-178`
+- Modify: `CLAUDE.md:141-160`
+- Modify: `README.md:62-75`
+- Modify: `yeti/ci-cd.md:50-60`
+
+**Interfaces:**
+- Consumes: The five `SNOSI_BOOTC_*` values declared by the protected `Package image` step and `TMPDIR` from `$GITHUB_ENV`.
+- Produces: A root packager process that receives those six values explicitly and a guard that rejects any declaration-only regression.
+
+- [ ] **Step 1: Extend the isolated workflow fixture with explicit forwarding**
+
+In `make_fixture()` within `test/bootc-publication-guard-test.sh`, extend the fixture's `Package image` step after its existing `env:` entries:
+
+```yaml
+        run: |
+          sudo TMPDIR="$TMPDIR" \
+            SNOSI_BOOTC_SECURE="$SNOSI_BOOTC_SECURE" \
+            SNOSI_BOOTC_MOK_KEY="$SNOSI_BOOTC_MOK_KEY" \
+            SNOSI_BOOTC_MOK_CERT="$SNOSI_BOOTC_MOK_CERT" \
+            SNOSI_BOOTC_PCR_KEY="$SNOSI_BOOTC_PCR_KEY" \
+            SNOSI_BOOTC_PCR_CERT="$SNOSI_BOOTC_PCR_CERT" \
+            ./shared/outformat/image/buildah-package.sh output/cayo localhost/cayo:version
+```
+
+Add this mutation helper beside `remove_package_variable()`:
+
+```bash
+remove_forwarded_package_variable() {
+    perl -0pi -e "s/^            $1=\\\"\\\$$1\\\" \\\\\n//m" \
+        "$2/.github/workflows/build-images.yml"
+}
+```
+
+Add this mutation loop immediately after the existing `remove_package_variable` loop:
+
+```bash
+for variable in SNOSI_BOOTC_SECURE SNOSI_BOOTC_MOK_KEY SNOSI_BOOTC_MOK_CERT SNOSI_BOOTC_PCR_KEY SNOSI_BOOTC_PCR_CERT; do
+    assert_guard "missing sudo-forwarded $variable fails" 1 \
+        remove_forwarded_package_variable "$variable"
+done
+```
+
+- [ ] **Step 2: Run the guard fixture and confirm RED**
+
+Run:
+
+```bash
+test/bootc-publication-guard-test.sh
+```
+
+Expected: the five new `missing sudo-forwarded ... fails` cases report `not ok` because the current guard checks only the step-level declarations.
+
+- [ ] **Step 3: Extend the real publication guard**
+
+In `check-bootc-publication-guard.sh`, capture the protected package step after validating the declaration list:
+
+```bash
+        package_step=$(awk '
+            /^      - name: Package image$/ { capture=1 }
+            capture && /^      - name: / && $0 != "      - name: Package image" { exit }
+            capture { print }
+        ' <<<"$secure_job")
+```
+
+Then require each name to be explicitly forwarded:
+
+```bash
+        forwarded_variables=(
+            SNOSI_BOOTC_SECURE
+            SNOSI_BOOTC_MOK_KEY
+            SNOSI_BOOTC_MOK_CERT
+            SNOSI_BOOTC_PCR_KEY
+            SNOSI_BOOTC_PCR_CERT
+        )
+        for variable in "${forwarded_variables[@]}"; do
+            forwarded_line=$(printf '            %s="$%s" \\' \
+                "$variable" "$variable")
+            require_text "$workflow protected package sudo environment" \
+                "$package_step" "$forwarded_line"
+        done
+```
+
+Also require the existing explicit `TMPDIR` assignment:
+
+```bash
+        sudo_tmpdir_line='          sudo TMPDIR="$TMPDIR" \'
+        require_text "$workflow protected package sudo environment" \
+            "$package_step" "$sudo_tmpdir_line"
+```
+
+The indentation and trailing continuation slash are intentional: the existing
+`require_text()` helper uses `grep -Fqx` and therefore compares a complete
+line, not a substring.
+
+- [ ] **Step 4: Run the fixture and confirm the intended intermediate failure**
+
+Run:
+
+```bash
+test/bootc-publication-guard-test.sh
+```
+
+Expected: the fixture baseline passes because it declares all forwarded values; each of the five forwarding mutations passes by making the guard reject its fixture. The real-tree guard is not run yet because the production workflow still lacks forwarding.
+
+- [ ] **Step 5: Forward secure values through sudo in the protected workflow**
+
+Change only the protected `Package image` command in `.github/workflows/build-images.yml` to:
+
+```yaml
+          sudo TMPDIR="$TMPDIR" \
+            SNOSI_BOOTC_SECURE="$SNOSI_BOOTC_SECURE" \
+            SNOSI_BOOTC_MOK_KEY="$SNOSI_BOOTC_MOK_KEY" \
+            SNOSI_BOOTC_MOK_CERT="$SNOSI_BOOTC_MOK_CERT" \
+            SNOSI_BOOTC_PCR_KEY="$SNOSI_BOOTC_PCR_KEY" \
+            SNOSI_BOOTC_PCR_CERT="$SNOSI_BOOTC_PCR_CERT" \
+            ./shared/outformat/image/buildah-package.sh \
+```
+
+Retain every existing packager argument below that line unchanged. Do not alter the mechanics-build package command.
+
+- [ ] **Step 6: Document the sudo boundary**
+
+Add to the Task 10 CI paragraph in `CLAUDE.md`:
+
+```markdown
+The protected package step forwards the secure flag and credential paths as
+explicit sudo command assignments; GitHub step environment values do not cross
+sudo implicitly, and secret bytes remain only in the mode-0600 files.
+```
+
+Add after the protected bootc publication paragraph in `README.md`:
+
+```markdown
+The protected packager passes its secure assembly flag and credential paths
+explicitly through sudo. The private bytes stay in mode-0600 runner files;
+only their paths cross the privilege boundary.
+```
+
+Extend protected-publication step 1 in `yeti/ci-cd.md` with:
+
+```markdown
+The package command repeats all five `SNOSI_BOOTC_*` names as explicit sudo
+assignments because step-level environment values are otherwise filtered by
+sudo. Do not replace this with implicit preservation or pass secret bytes in
+arguments.
+```
+
+- [ ] **Step 7: Run all focused verification**
+
+Run:
+
+```bash
+test/bootc-publication-guard-test.sh
+./check-bootc-publication-guard.sh
+test/bootc-secure-package-cleanup-test.sh
+test/bootc-secure-package-negative-test.sh
+shellcheck check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh
+actionlint .github/workflows/build-images.yml
+git diff --check
+```
+
+Expected: all commands exit 0; the publication fixture reports 28 passing assertions and zero failures; both package fixture scripts pass.
+
+- [ ] **Step 8: Review and commit Task 1**
+
+Run:
+
+```bash
+git diff -- .github/workflows/build-images.yml check-bootc-publication-guard.sh test/bootc-publication-guard-test.sh CLAUDE.md README.md yeti/ci-cd.md
+git status --short
+git add .github/workflows/build-images.yml check-bootc-publication-guard.sh test/bootc-publication-guard-test.sh CLAUDE.md README.md yeti/ci-cd.md
+git commit -m "fix: forward secure packaging state through sudo"
+```
+
+Expected: exactly the protected workflow, guard, guard fixture, and three documentation files are committed.
+
+### Task 2: Merge And Re-run Protected Publication
+
+**Files:**
+- No repository file changes.
+
+**Interfaces:**
+- Consumes: Task 1's reviewed explicit forwarding and the existing protected `native-build` credentials.
+- Produces: Three signed immutable OCI candidates promoted only after local and policy-copied artifact validation.
+
+- [ ] **Step 1: Push and create the focused PR**
+
+Run:
+
+```bash
+test "$(git branch --show-current)" = fix/bootc-secure-sudo-env
+git push -u origin fix/bootc-secure-sudo-env
+PR_URL=$(gh pr create --repo frostyard/snosi \
+  --base main \
+  --head fix/bootc-secure-sudo-env \
+  --title "fix: forward secure packaging state through sudo" \
+  --body $'## Summary\n- explicitly forward secure assembly state through sudo\n- reject declaration-only regressions in the publication guard\n- document the privilege-boundary contract\n\n## Failure evidence\nRun 30555492550 passed credentials but packaged without a UKI because sudo filtered the five SNOSI_BOOTC_* values; local validation failed before registry writes.\n\n## Validation\n- publication guard fixture and real-tree guard\n- package cleanup and negative fixtures\n- ShellCheck\n- actionlint')
+PR_NUMBER=${PR_URL##*/}
+printf 'PR %s: %s\n' "$PR_NUMBER" "$PR_URL"
+```
+
+- [ ] **Step 2: Wait for checks, inspect, and merge**
+
+Run:
+
+```bash
+PR_NUMBER=$(gh pr view --repo frostyard/snosi --json number --jq .number)
+gh pr checks "$PR_NUMBER" --repo frostyard/snosi --watch
+gh pr diff "$PR_NUMBER" --repo frostyard/snosi
+gh pr merge "$PR_NUMBER" --repo frostyard/snosi --squash --delete-branch
+```
+
+Expected: all required checks pass and the focused PR merges without generated files.
+
+- [ ] **Step 3: Dispatch and watch a fresh protected build**
+
+Run:
+
+```bash
+DISPATCHED_AT=$(date -u +%s)
+gh workflow run build-images.yml --repo frostyard/snosi --ref main
+RUN_JSON=
+for _ in $(seq 1 30); do
+  RUN_JSON=$(gh run list --repo frostyard/snosi \
+    --workflow build-images.yml --branch main --event workflow_dispatch \
+    --limit 10 --json databaseId,createdAt,url | \
+    jq -c --argjson dispatched "$DISPATCHED_AT" \
+      'map(select((.createdAt | fromdateiso8601) >= $dispatched)) |
+       sort_by(.createdAt) | last // empty')
+  [ -n "$RUN_JSON" ] && break
+  sleep 2
+done
+[ -n "$RUN_JSON" ]
+RUN_ID=$(jq -r .databaseId <<<"$RUN_JSON")
+RUN_URL=$(jq -r .url <<<"$RUN_JSON")
+printf 'Run %s: %s\n' "$RUN_ID" "$RUN_URL"
+gh run watch "$RUN_ID" --repo frostyard/snosi --exit-status --interval 20
+```
+
+Expected for Cayo, Snow, and Snowfield:
+
+```text
+Package image                                  success
+Validate locally assembled secure artifact     success
+Push immutable version tag                     success
+Sign immutable image digest                    success
+Verify pushed secure image                     success
+Validate policy-copied secure artifact          success
+Promote validated digest to latest             success
+```
+
+- [ ] **Step 4: Record immutable evidence**
+
+Run:
+
+```bash
+gh run view "$RUN_ID" --repo frostyard/snosi \
+  --json url,headSha,status,conclusion,jobs
+```
+
+Record each profile's 14-digit version and immutable `sha256:` digest from its log, plus ordering proof that local validation preceded push and policy-copied validation preceded promotion. Treat the result as one secure candidate set, not distinct `N`, `N+1`, and `N+2`, and not installed-system Task 9 evidence.

--- a/docs/superpowers/specs/2026-07-30-bootc-secure-sudo-environment-design.md
+++ b/docs/superpowers/specs/2026-07-30-bootc-secure-sudo-environment-design.md
@@ -1,0 +1,70 @@
+# Bootc Secure Packaging Sudo Environment Design
+
+## Problem
+
+Protected run `30555492550` passed credential materialization for Cayo, Snow,
+and Snowfield. Cayo and Snow then completed `Package image` but failed local
+artifact validation with `Error: missing assembled UKI`.
+
+The protected package step declares `SNOSI_BOOTC_SECURE=1` and the four
+credential-path variables in its GitHub Actions environment, but invokes the
+packager as:
+
+```text
+sudo TMPDIR="$TMPDIR" ./shared/outformat/image/buildah-package.sh ...
+```
+
+Sudo receives only the explicitly assigned `TMPDIR`; its default environment
+filter removes the five `SNOSI_BOOTC_*` variables. The packager consequently
+takes its non-secure default, commits one ordinary image, and never calls the
+UKI assembly path. The validator correctly rejects that image before any
+registry write.
+
+## Scope
+
+Correct only the protected package invocation's sudo environment boundary and
+the publication guard that enforces it. Do not change credential contents,
+assembly behavior, validation behavior, registry ordering, labels, or the
+secretless mechanics build.
+
+## Design
+
+Pass these values as explicit command environment assignments after `sudo`:
+
+```text
+TMPDIR
+SNOSI_BOOTC_SECURE
+SNOSI_BOOTC_MOK_KEY
+SNOSI_BOOTC_MOK_CERT
+SNOSI_BOOTC_PCR_KEY
+SNOSI_BOOTC_PCR_CERT
+```
+
+Explicit assignments are preferred to `sudo --preserve-env`: they make the
+privilege boundary visible at the call site and do not depend on runner sudo
+policy. Only credential paths cross the boundary; secret bytes remain in the
+mode-0600 files already created under `/var/tmp`.
+
+Extend `check-bootc-publication-guard.sh` so each secure variable must appear
+both in the step's GitHub Actions `env:` block and in the sudo command
+environment. Extend the isolated publication-guard fixture with one mutation
+per forwarded variable, proving that a declaration without forwarding fails.
+
+## Documentation
+
+Update `CLAUDE.md`, `README.md`, and `yeti/ci-cd.md` to record that GitHub step
+environment variables do not automatically cross sudo and that the protected
+packager forwards only the secure assembly flag and credential paths.
+
+## Verification
+
+Run the publication-guard fixture and real-tree guard, secure package cleanup
+and negative fixtures, ShellCheck, actionlint, and `git diff --check`. After
+review and merge, dispatch `build-images.yml` from `main` and require all three
+profiles to pass secure packaging and local validation before any immutable
+push. Continue watching through immutable signing, remote verification,
+policy-copied validation, and `latest` promotion.
+
+A successful rerun changes production registry state. A failed package or
+local validation must continue to leave immutable and mutable registry tags
+untouched.

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -70,6 +70,14 @@ jobs:
           SNOSI_BOOTC_MOK_CERT: /var/tmp/bootc-secure-credentials/mok.crt
           SNOSI_BOOTC_PCR_KEY: /var/tmp/bootc-secure-credentials/pcr.key
           SNOSI_BOOTC_PCR_CERT: /var/tmp/bootc-secure-credentials/pcr.pub
+        run: |
+          sudo TMPDIR="$TMPDIR" \
+            SNOSI_BOOTC_SECURE="$SNOSI_BOOTC_SECURE" \
+            SNOSI_BOOTC_MOK_KEY="$SNOSI_BOOTC_MOK_KEY" \
+            SNOSI_BOOTC_MOK_CERT="$SNOSI_BOOTC_MOK_CERT" \
+            SNOSI_BOOTC_PCR_KEY="$SNOSI_BOOTC_PCR_KEY" \
+            SNOSI_BOOTC_PCR_CERT="$SNOSI_BOOTC_PCR_CERT" \
+            ./shared/outformat/image/buildah-package.sh output/cayo localhost/cayo:version
       - name: Validate locally assembled secure artifact
         run: |
           sudo ./test/bootc-secure-artifact-test.sh \
@@ -116,6 +124,10 @@ permit_pull_request_with_or() { perl -0pi -e "s/ &&\n      github\.ref == 'refs\
 remove_main_condition() { perl -0pi -e "s/      github\.ref == 'refs\/heads\/main'\n//" "$1/.github/workflows/build-images.yml"; }
 allow_shell_or() { perl -0pi -e 's{(        run: sudo rm -rf /var/tmp/bootc-secure-credentials)}{$1 || exit 1}' "$1/.github/workflows/build-images.yml"; }
 remove_package_variable() { perl -0pi -e "s/          $1:.*\n//" "$2/.github/workflows/build-images.yml"; }
+remove_forwarded_package_variable() {
+    perl -0pi -e "s/^            $1=\\\"\\\$$1\\\" \\\\\n//m" \
+        "$2/.github/workflows/build-images.yml"
+}
 remove_cleanup_condition() { perl -0pi -e 's/        if: always\(\)\n//' "$1/.github/workflows/build-images.yml"; }
 break_label_check() { perl -0pi -e 's/== "true"/== "false"/' "$1/shared/bootc-secure/ci/verify-published-image.sh"; }
 remove_label_check() { perl -0pi -e 's/    \.Labels\["io\.snosi\.bootc\.secureboot-capable"\].*\n//' "$1/shared/bootc-secure/ci/verify-published-image.sh"; }
@@ -142,6 +154,10 @@ assert_guard 'missing main publishing condition fails' 1 remove_main_condition
 assert_guard 'shell || in a secure-build run block passes' 0 allow_shell_or
 for variable in SNOSI_BOOTC_SECURE SNOSI_BOOTC_MOK_KEY SNOSI_BOOTC_MOK_CERT SNOSI_BOOTC_PCR_KEY SNOSI_BOOTC_PCR_CERT; do
     assert_guard "missing $variable fails" 1 remove_package_variable "$variable"
+done
+for variable in SNOSI_BOOTC_SECURE SNOSI_BOOTC_MOK_KEY SNOSI_BOOTC_MOK_CERT SNOSI_BOOTC_PCR_KEY SNOSI_BOOTC_PCR_CERT; do
+    assert_guard "missing sudo-forwarded $variable fails" 1 \
+        remove_forwarded_package_variable "$variable"
 done
 assert_guard 'missing unconditional cleanup fails' 1 remove_cleanup_condition
 assert_guard 'false secure label check fails' 1 break_label_check

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -128,6 +128,7 @@ remove_forwarded_package_variable() {
     perl -0pi -e "s/^            $1=\\\"\\\$$1\\\" \\\\\n//m" \
         "$2/.github/workflows/build-images.yml"
 }
+remove_sudo_tmpdir() { perl -0pi -e 's/^          sudo TMPDIR="\$TMPDIR" \\\n//m' "$1/.github/workflows/build-images.yml"; }
 remove_cleanup_condition() { perl -0pi -e 's/        if: always\(\)\n//' "$1/.github/workflows/build-images.yml"; }
 break_label_check() { perl -0pi -e 's/== "true"/== "false"/' "$1/shared/bootc-secure/ci/verify-published-image.sh"; }
 remove_label_check() { perl -0pi -e 's/    \.Labels\["io\.snosi\.bootc\.secureboot-capable"\].*\n//' "$1/shared/bootc-secure/ci/verify-published-image.sh"; }
@@ -159,6 +160,7 @@ for variable in SNOSI_BOOTC_SECURE SNOSI_BOOTC_MOK_KEY SNOSI_BOOTC_MOK_CERT SNOS
     assert_guard "missing sudo-forwarded $variable fails" 1 \
         remove_forwarded_package_variable "$variable"
 done
+assert_guard 'missing sudo TMPDIR forwarding fails' 1 remove_sudo_tmpdir
 assert_guard 'missing unconditional cleanup fails' 1 remove_cleanup_condition
 assert_guard 'false secure label check fails' 1 break_label_check
 assert_guard 'missing secure label check fails' 1 remove_label_check

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -51,6 +51,10 @@ Each matrix build resets mkosi dependencies to `base` (`--dependency= --dependen
 
 **Protected publication steps:**
 1. Transiently materialize the durable production MOK/PCR signing credentials supplied by the four `NATIVE_*` secrets, then build and package each profile. The supplied MOK certificate and derived PCR public key must byte-match the committed public identities; runner-local credential files are removed unconditionally after local artifact validation and before registry writes. The distinct disposable PR keys remain ephemeral.
+   The package command repeats all five `SNOSI_BOOTC_*` names as explicit sudo
+   assignments because step-level environment values are otherwise filtered by
+   sudo. Do not replace this with implicit preservation or pass secret bytes in
+   arguments.
    Local validation requires host Podman, not host bootc: the validator runs the
    candidate image's pinned bootc 1.16.3 to recompute its storage composefs digest.
    The same boundary applies to the policy-copied validation after registry pull.


### PR DESCRIPTION
## Summary
- explicitly forward secure assembly state through sudo
- reject declaration-only and missing-anchor regressions in the publication guard
- document the privilege-boundary contract

## Failure evidence
Run 30555492550 passed credentials but packaged without a UKI because sudo filtered the five SNOSI_BOOTC_* values; local validation failed before registry writes.

## Validation
- publication guard fixture: 29 passing assertions
- real-tree publication guard
- package cleanup and secure artifact negative fixtures
- ShellCheck
- actionlint