### PR TITLE
fix: run bootc version probe inside rootfs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,11 @@ binary, first places the MOK-signed systemd-boot source at
 `/usr/lib/snosi/bootc/systemd-bootx64.efi`, constructs the UKI and ESP copy
 below `/boot`, and requires a final OCI probe to retain the ID. It emits the explicit
 `io.snosi.bootc.secureboot-capable=true` label; non-secure builds emit `false`.
+Before first-pass packaging, the root packager temporarily bind-mounts only host
+`/proc` into the complete mkosi rootfs and runs the exact bootc version probe
+through chroot, so target libraries rather than the CI host ABI resolve. It
+refuses pre-mounted/missing rootfs proc paths and unmounts before any image
+mutation. Storage-digest authority remains bootc inside the candidate OCI image.
 The optional dual-PCR mode requires the previous certificate positionally and
 its matching private key only through `SNOSI_BOOTC_PREVIOUS_PCR_KEY`. Never
 copy private keys into the rootfs, OCI layers, labels, logs, or retained temp

--- a/README.md
+++ b/README.md
@@ -440,6 +440,10 @@ runtime coverage. Secure and insecure images carry explicit
 fail-closed compatibility contract for Frostyard bootc 1.16.3, including its
 hidden storage-digest command and direct two-pass ukify behavior, not an
 upstream-stable API. See `docs/bootc-secure-assembly-compatibility.md`.
+The protected packager checks its pinned bootc through the built rootfs with a
+temporary procfs bind, then removes that bind before assembly. It does not
+require a matching host bootc or host libostree ABI; candidate-image bootc
+remains the storage-digest authority.
 This is not production Secure Boot support: published `latest` images inspected
 on 2026-07-27 lacked `io.snosi.bootc.secureboot-capable` and are unsuitable for
 the secure install/update harnesses. MOK/TPM enrollment and full secure

--- a/docs/superpowers/plans/2026-07-30-bootc-rootfs-version-check.md
+++ b/docs/superpowers/plans/2026-07-30-bootc-rootfs-version-check.md
@@ -1,0 +1,406 @@
+# Bootc Rootfs Version Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Validate the pinned bootc executable with its target rootfs libraries instead of the CI host ABI.
+
+**Architecture:** A dedicated packager helper temporarily bind-mounts only `/proc` into the complete mkosi rootfs, runs `/usr/bin/bootc --version` through chroot, and unmounts before any image mutation or packaging. PATH-controlled fixture commands verify boundary calls, ownership refusal, diagnostics, and cleanup; a measured published-Cayo rootfs proof covers the real dynamic loader behavior that stubs cannot model.
+
+**Tech Stack:** Bash, chroot/coreutils, mount/util-linux, Buildah, Podman, GitHub Actions
+
+## Global Constraints
+
+- The accepted output remains exactly `bootc 1.16.3`.
+- Bind only host `/proc`; do not bind `/sys`, `/dev`, or any credential path.
+- Reject a missing or already-mounted `$ROOTFS_DIR/proc`; do not create, reuse, or unmount a mount the helper does not own.
+- Invoke `mount`, `mountpoint`, `chroot`, and `umount` by bare name so fixtures can intercept them through `PATH`.
+- Unmount the helper-owned procfs before systemd-boot preparation or first-pass packaging starts.
+- Surface rootfs execution diagnostics and distinguish execution failure from a successful wrong version without printing credentials.
+- A failed unmount is fatal.
+- Do not add `bwrap`, host bootc, host libostree, APT packages, or workflow prerequisites.
+- Preserve the direct two-pass ukify contract, candidate-image storage-digest authority, secure labels, credential handling, sudo forwarding, cleanup behavior, fail-before-push ordering, and secretless mechanics build.
+- Update `CLAUDE.md`, `README.md`, and `yeti/build-pipeline.md`.
+
+---
+
+### Task 1: Execute The Version Gate Inside The Rootfs
+
+**Files:**
+- Modify: `test/bootc-secure-package-cleanup-test.sh:19-139`
+- Modify: `shared/outformat/image/buildah-package.sh:18-65`
+- Modify: `CLAUDE.md:63-83`
+- Modify: `README.md:435-456`
+- Modify: `yeti/build-pipeline.md:55-72`
+
+**Interfaces:**
+- Consumes: A complete root-owned mkosi directory rootfs with an empty `/proc` directory and `/usr/bin/bootc` plus its target libraries.
+- Produces: `probe_rootfs_bootc_version ROOTFS`, returning 0 only after exact pinned output and successful unmount; no mount survives the function.
+
+- [ ] **Step 1: Add controlled rootfs-boundary commands to the fixture**
+
+In `write_fixtures()` in `test/bootc-secure-package-cleanup-test.sh`, add
+`"$root/proc"` to the initial `mkdir -p` list. Remove the rootfs shell bootc
+fixture at lines 23-24; the controlled chroot command owns version output.
+
+Add these commands under `$state/bin` before the existing Buildah fixture:
+
+```bash
+    cat >"$state/bin/mountpoint" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $1 == -q && $2 == "$BUILD_FIXTURE_ROOT/proc" ]]
+[[ -e "$BUILD_FIXTURE_STATE/proc-mounted" ]]
+EOF
+    cat >"$state/bin/mount" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $1 == --bind && $2 == /proc && $3 == "$BUILD_FIXTURE_ROOT/proc" ]]
+printf '%s\n' "$*" >"$BUILD_FIXTURE_STATE/mount-invoked"
+touch "$BUILD_FIXTURE_STATE/proc-mounted"
+EOF
+    cat >"$state/bin/chroot" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $1 == "$BUILD_FIXTURE_ROOT" && $2 == /usr/bin/bootc && $3 == --version ]]
+printf '%s\n' "$*" >"$BUILD_FIXTURE_STATE/chroot-invoked"
+if [[ ${BUILD_FIXTURE_CHROOT_FAIL:-0} == 1 ]]; then
+    echo 'fixture rootfs loader failure' >&2
+    exit 86
+fi
+printf '%s\n' "${BUILD_FIXTURE_BOOTC_VERSION:-bootc 1.16.3}"
+EOF
+    cat >"$state/bin/umount" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $1 == "$BUILD_FIXTURE_ROOT/proc" ]]
+printf '%s\n' "$*" >"$BUILD_FIXTURE_STATE/umount-invoked"
+[[ ${BUILD_FIXTURE_UMOUNT_FAIL:-0} != 1 ]] || exit 87
+rm -f "$BUILD_FIXTURE_STATE/proc-mounted"
+EOF
+```
+
+Make all four commands executable alongside the existing fixtures:
+
+```bash
+    chmod +x "$state/bin/mountpoint" "$state/bin/mount" "$state/bin/chroot" \
+        "$state/bin/umount" "$state/bin/buildah" "$state/bin/podman" "$state/assembler"
+```
+
+At the start of the controlled Buildah command, add:
+
+```bash
+touch "$BUILD_FIXTURE_STATE/buildah-invoked"
+```
+
+- [ ] **Step 2: Add positive call-shape assertions and prove RED**
+
+Add to `assert_cleanup()` before image cleanup assertions:
+
+```bash
+    [[ -f "$state/mount-invoked" && $(<"$state/mount-invoked") == "--bind /proc $root/proc" ]] || fail "rootfs proc bind was not exact"
+    [[ -f "$state/chroot-invoked" && $(<"$state/chroot-invoked") == "$root /usr/bin/bootc --version" ]] || fail "bootc version did not use rootfs chroot"
+    [[ -f "$state/umount-invoked" && $(<"$state/umount-invoked") == "$root/proc" ]] || fail "rootfs proc unmount was not exact"
+    [[ ! -e "$state/proc-mounted" ]] || fail "rootfs proc mount survived"
+```
+
+Pass `BUILD_FIXTURE_ROOT="$root"` in both secure packager invocations in
+`run_case()`.
+
+Run:
+
+```bash
+test/bootc-secure-package-cleanup-test.sh
+```
+
+Expected: FAIL because the current packager executes `$root/usr/bin/bootc`
+directly, so no mount/chroot/unmount records exist.
+
+- [ ] **Step 3: Add fail-closed probe fixtures**
+
+Add this helper before the existing `run_case()` calls:
+
+```bash
+run_probe_failure_case() { # name expected-text setup-command env-name env-value
+    local name=$1 expected=$2 setup=$3 env_name=$4 env_value=$5 work state root published status output
+    work=$(mktemp -d)
+    trap 'rm -rf -- "$work"' RETURN
+    state="$work/state"; root="$work/root"
+    published="localhost/task5-probe-$name:latest"
+    write_fixtures "$state" "$root"
+    [[ $setup == none ]] || "$setup" "$state" "$root"
+    set +e
+    output=$(env BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" PATH="$state/bin:$PATH" \
+        SNOSI_BOOTC_SECURE=1 SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture \
+        SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
+        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" \
+        "$env_name=$env_value" "$PACKAGER" "$root" "$published" 2>&1)
+    status=$?
+    set -e
+    [[ $status -ne 0 ]] || fail "$name unexpectedly succeeded"
+    [[ $output == *"$expected"* ]] || fail "$name lacked diagnostic: $expected"
+    [[ ! -e "$state/assembler-invoked" ]] || fail "$name reached the assembler"
+    [[ ! -e "$state/buildah-invoked" ]] || fail "$name reached Buildah"
+}
+
+mark_proc_mounted() { touch "$1/proc-mounted"; }
+remove_proc_dir() { rmdir "$2/proc"; }
+```
+
+Add the cases before the existing cleanup cases:
+
+```bash
+run_probe_failure_case proc-missing 'rootfs proc directory is missing' remove_proc_dir UNUSED 0
+run_probe_failure_case proc-pre-mounted 'rootfs proc is already mounted' mark_proc_mounted UNUSED 0
+run_probe_failure_case chroot-fails 'fixture rootfs loader failure' none BUILD_FIXTURE_CHROOT_FAIL 1
+run_probe_failure_case wrong-version 'expected bootc 1.16.3, observed bootc 1.16.2' none BUILD_FIXTURE_BOOTC_VERSION 'bootc 1.16.2'
+run_probe_failure_case umount-fails 'failed to unmount rootfs proc' none BUILD_FIXTURE_UMOUNT_FAIL 1
+```
+
+After `run_probe_failure_case()` captures output, add case-specific ownership
+assertions:
+
+```bash
+    case $name in
+        proc-missing)
+            [[ ! -e "$state/mount-invoked" && ! -e "$root/proc" ]] || fail "$name changed malformed rootfs"
+            ;;
+        proc-pre-mounted)
+            [[ ! -e "$state/mount-invoked" && ! -e "$state/umount-invoked" && -e "$state/proc-mounted" ]] || fail "$name touched an unowned mount"
+            ;;
+        chroot-fails|wrong-version)
+            [[ -e "$state/umount-invoked" && ! -e "$state/proc-mounted" ]] || fail "$name did not clean its proc mount"
+            ;;
+        umount-fails)
+            [[ -e "$state/umount-invoked" && -e "$state/proc-mounted" ]] || fail "$name did not expose failed unmount state"
+            ;;
+    esac
+```
+
+Run:
+
+```bash
+test/bootc-secure-package-cleanup-test.sh
+```
+
+Expected: FAIL because the current packager lacks the required diagnostics,
+mount ownership check, and rootfs cleanup behavior.
+
+- [ ] **Step 4: Implement the rootfs probe helper**
+
+Add after `ROOTFS_DIR` argument validation in
+`shared/outformat/image/buildah-package.sh`:
+
+```bash
+probe_rootfs_bootc_version() ( # rootfs
+    local root=$1 proc="$1/proc" mounted=0 output status
+
+    cleanup_proc() {
+        local exit_status=$?
+        trap - EXIT
+        if [[ $mounted -eq 1 ]] && ! umount "$proc"; then
+            echo "Error: failed to unmount rootfs proc: $proc" >&2
+            exit_status=1
+        fi
+        exit "$exit_status"
+    }
+
+    [[ -d $proc ]] || {
+        echo "Error: rootfs proc directory is missing: $proc" >&2
+        exit 1
+    }
+    if mountpoint -q "$proc"; then
+        echo "Error: rootfs proc is already mounted: $proc" >&2
+        exit 1
+    fi
+
+    trap cleanup_proc EXIT
+    mount --bind /proc "$proc" || {
+        echo "Error: failed to bind host proc into rootfs: $proc" >&2
+        exit 1
+    }
+    mounted=1
+
+    set +e
+    output=$(chroot "$root" /usr/bin/bootc --version 2>&1)
+    status=$?
+    set -e
+    if [[ $status -ne 0 ]]; then
+        printf 'Error: rootfs bootc execution failed:\n%s\n' "$output" >&2
+        exit 1
+    fi
+    [[ $output == 'bootc 1.16.3' ]] || {
+        printf 'Error: expected bootc 1.16.3, observed %s\n' "$output" >&2
+        exit 1
+    }
+)
+```
+
+Replace the current direct version block:
+
+```bash
+    [[ $($ROOTFS_DIR/usr/bin/bootc --version ...) == ... ]]
+```
+
+with:
+
+```bash
+    probe_rootfs_bootc_version "$ROOTFS_DIR"
+```
+
+The helper subshell's EXIT trap completes its unmount before control returns to
+the next assembler line.
+
+- [ ] **Step 5: Run the fixture and confirm GREEN**
+
+Run:
+
+```bash
+test/bootc-secure-package-cleanup-test.sh
+```
+
+Expected: `bootc secure package cleanup fixtures passed` and exit 0.
+
+- [ ] **Step 6: Document the target-library probe boundary**
+
+Add to the Task 5 paragraph in `CLAUDE.md`:
+
+```markdown
+Before first-pass packaging, the root packager temporarily bind-mounts only
+host `/proc` into the complete mkosi rootfs and runs the exact bootc version
+probe through chroot, so target libraries rather than the CI host ABI resolve.
+It refuses pre-mounted/missing rootfs proc paths and unmounts before any image
+mutation. Storage-digest authority remains bootc inside the candidate OCI image.
+```
+
+Add to the secure assembly paragraph in `README.md`:
+
+```markdown
+The protected packager checks its pinned bootc through the built rootfs with a
+temporary procfs bind, then removes that bind before assembly. It does not
+require a matching host bootc or host libostree ABI; candidate-image bootc
+remains the storage-digest authority.
+```
+
+Add beside the two-pass packaging description in `yeti/build-pipeline.md`:
+
+```markdown
+The preflight version gate uses bare-name `mount`/`mountpoint`/`chroot`/`umount`:
+it refuses a missing or pre-mounted `$ROOTFS_DIR/proc`, bind-mounts only host
+`/proc`, runs `/usr/bin/bootc --version` against target libraries, and always
+unmounts before `--prepare-systemd-boot-source`. Bare names are load-bearing
+for the non-root PATH fixtures. This gate is not digest authority; both storage
+digest probes still run bootc inside their candidate OCI images.
+```
+
+- [ ] **Step 7: Run complete focused verification**
+
+Run:
+
+```bash
+test/bootc-secure-package-cleanup-test.sh
+test/bootc-secure-artifact-negative-test.sh --fixtures
+test/bootc-publication-guard-test.sh
+./check-bootc-publication-guard.sh
+shellcheck shared/outformat/image/buildah-package.sh \
+  test/bootc-secure-package-cleanup-test.sh
+git diff --check
+```
+
+Expected: all commands exit 0; cleanup and negative artifact fixtures pass;
+publication guard reports 29 passing assertions and the real-tree guard passes;
+ShellCheck and `git diff --check` produce no diagnostics.
+
+- [ ] **Step 8: Review and commit Task 1**
+
+Run:
+
+```bash
+git diff -- shared/outformat/image/buildah-package.sh test/bootc-secure-package-cleanup-test.sh CLAUDE.md README.md yeti/build-pipeline.md
+git status --short
+git add shared/outformat/image/buildah-package.sh test/bootc-secure-package-cleanup-test.sh CLAUDE.md README.md yeti/build-pipeline.md
+git commit -m "fix: run bootc version probe inside rootfs"
+```
+
+Expected: exactly the packager, cleanup fixture, and three required
+documentation files are committed.
+
+### Task 2: Merge And Re-run Protected Publication
+
+**Files:**
+- No repository file changes.
+
+**Interfaces:**
+- Consumes: Task 1's reviewed rootfs probe and existing protected credentials.
+- Produces: Three signed immutable OCI candidates promoted only after local and policy-copied artifact validation.
+
+- [ ] **Step 1: Push and create the focused PR**
+
+Run:
+
+```bash
+test "$(git branch --show-current)" = fix/bootc-rootfs-version-check
+git push -u origin fix/bootc-rootfs-version-check
+gh pr create --repo frostyard/snosi \
+  --base main \
+  --head fix/bootc-rootfs-version-check \
+  --title "fix: run bootc version probe inside rootfs" \
+  --body $'## Summary\n- execute the pinned bootc version gate with target rootfs libraries\n- bind only procfs and fail closed on mount ownership or cleanup errors\n- cover call shape, diagnostics, and cleanup with PATH fixtures\n\n## Failure evidence\nProtected run 30563925331 installed bootc 1.16.3 in all three rootfs directories but direct host-context execution failed before packaging; no registry write ran.\n\n## Validation\n- secure package cleanup fixture\n- secure artifact negative fixtures\n- publication guard fixture and real-tree guard\n- ShellCheck'
+```
+
+- [ ] **Step 2: Wait for checks and inspect the complete PR**
+
+Run:
+
+```bash
+PR_NUMBER=$(gh pr view --repo frostyard/snosi --json number --jq .number)
+gh pr checks "$PR_NUMBER" --repo frostyard/snosi --watch
+gh pr diff "$PR_NUMBER" --repo frostyard/snosi
+gh pr view "$PR_NUMBER" --repo frostyard/snosi \
+  --json url,state,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Expected: all required checks pass. If branch protection requires independent
+approval, stop without `--admin`; merge after the user supplies that approval.
+
+- [ ] **Step 3: Squash-merge without bypassing branch protection**
+
+Run:
+
+```bash
+gh pr merge "$PR_NUMBER" --repo frostyard/snosi --squash --delete-branch
+```
+
+Expected: the PR merges normally. Do not use `--admin`.
+
+- [ ] **Step 4: Identify the automatic protected run for the merge SHA**
+
+Run:
+
+```bash
+MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo frostyard/snosi --json mergeCommit --jq .mergeCommit.oid)
+RUN_JSON=$(gh run list --repo frostyard/snosi --workflow build-images.yml --branch main \
+  --limit 10 --json databaseId,headSha,url,status,conclusion | \
+  jq -c --arg sha "$MERGE_SHA" 'map(select(.headSha == $sha)) | first // empty')
+[ -n "$RUN_JSON" ]
+RUN_ID=$(jq -r .databaseId <<<"$RUN_JSON")
+RUN_URL=$(jq -r .url <<<"$RUN_JSON")
+printf 'Run %s: %s\n' "$RUN_ID" "$RUN_URL"
+gh run watch "$RUN_ID" --repo frostyard/snosi --exit-status --interval 20
+```
+
+- [ ] **Step 5: Record immutable evidence and ordering**
+
+Run:
+
+```bash
+gh run view "$RUN_ID" --repo frostyard/snosi \
+  --json url,headSha,status,conclusion,jobs
+gh run view "$RUN_ID" --repo frostyard/snosi --log | \
+  rg 'org.opencontainers.image.version|sha256:|secureboot-capable|Package image|Validate locally assembled|Push immutable|Validate policy-copied|Promote validated'
+```
+
+Expected for Cayo, Snow, and Snowfield: package, local artifact validation,
+immutable push, signing, remote verification, policy-copied artifact validation,
+and latest promotion all succeed in that order. Record each 14-digit version
+and immutable digest. Treat this as one secure candidate set, not distinct
+`N`/`N+1`/`N+2` or installed-system Task 9 evidence.

--- a/docs/superpowers/specs/2026-07-30-bootc-rootfs-version-check-design.md
+++ b/docs/superpowers/specs/2026-07-30-bootc-rootfs-version-check-design.md
@@ -1,0 +1,171 @@
+# Bootc Rootfs Version Check Design
+
+## Problem
+
+Protected `build-images.yml` run `30563925331` proved that the secure flag and
+all credential paths now cross sudo: Cayo, Snow, and Snowfield each entered the
+secure branch of `shared/outformat/image/buildah-package.sh`. All three then
+failed before any registry write with:
+
+```text
+Error: secure assembly requires rootfs bootc 1.16.3
+```
+
+The build log proves each rootfs installed
+`bootc 1.16.3-frostyard202607061837`. The failure is instead caused by the
+packager invoking `"$ROOTFS_DIR/usr/bin/bootc" --version` directly in the
+Ubuntu runner's filesystem and library context. Bootc is dynamically linked,
+including against `libostree-1.so.1`; a path into a rootfs does not make that
+rootfs's loader and libraries active. The current check therefore accidentally
+requires the host ABI and packages to match the target image.
+
+This bug was latent while secure environment state was filtered by sudo. The
+successful fixture uses a host-runnable shell stub, so it did not model the
+real dynamic-link boundary.
+
+## Decision
+
+Run the version probe through the already-root packager's standard `chroot`
+boundary, with only the host procfs temporarily bind-mounted into the target:
+
+```bash
+mount --bind /proc "$ROOTFS_DIR/proc"
+chroot "$ROOTFS_DIR" /usr/bin/bootc --version
+umount "$ROOTFS_DIR/proc"
+```
+
+The accepted output remains exactly `bootc 1.16.3`. Failure to enter the
+rootfs, execute bootc, load its target libraries, or produce the pinned output
+remains fail-closed before first-pass packaging.
+
+This adds no host package or privilege requirement. The workflow already runs
+the packager through sudo; `chroot` is part of coreutils and `mount`, `umount`,
+and `mountpoint` are part of util-linux on the runner. The rootfs is a complete
+mkosi output, not an untrusted partial directory.
+
+The procfs mount is measured, not speculative. Cayo image
+`ghcr.io/frostyard/cayo@sha256:a067ed12ee6e62515b4b15ff7cbeef35d5d76df41f69f957ec1977ea9275ce98`
+(image version `20260727175904`, bootc Debian package
+`1.16.3-frostyard202607061837`) fails under bare chroot with:
+
+```text
+error: reading /proc/1/ns/ipc: No such file or directory (os error 2)
+```
+
+The same mounted OCI rootfs returns `bootc 1.16.3` when only `/proc` is
+bind-mounted. It needs neither `/sys` nor `/dev` for this probe. The proof used
+the exact `chroot ROOT /usr/bin/bootc --version` command shape planned here;
+the pulled image is a real published mkosi rootfs with the same pinned bootc
+package, though it predates the secure-capability label.
+
+## Rejected Alternatives
+
+### Host Bubblewrap
+
+Bubblewrap would provide a namespace sandbox around the same rootfs, but the
+host workflow does not currently establish `bwrap` as a packaging prerequisite.
+Adding and guarding that dependency is unnecessary for a version-only probe.
+The rootfs later contains bubblewrap for bcvk smoke coverage, but a binary
+inside the target cannot bootstrap its own target-library execution from the
+host context.
+
+### Package Metadata Only
+
+Reading dpkg status could prove that version `1.16.3` was registered, but not
+that `/usr/bin/bootc` and its target libraries execute coherently. The secure
+compatibility contract depends on the executable behavior, so metadata alone
+is weaker than the existing intent.
+
+### Host Library Installation
+
+Installing host bootc/libostree dependencies would preserve the defective
+execution boundary and couple target validation to Ubuntu package names and
+ABI versions. It contradicts the candidate-owned validation architecture.
+
+## Implementation Scope
+
+Change only the rootfs version probe and the cleanup state needed for its
+temporary procfs bind mount in `shared/outformat/image/buildah-package.sh`.
+Invoke `mount`, `chroot`, `umount`, and `mountpoint` by bare name so the
+non-root fixture can intercept them through `PATH`. Preserve:
+
+- the exact `bootc 1.16.3` compatibility pin;
+- the direct two-pass ukify and hidden storage-digest contract;
+- storage-digest execution inside the packaged candidate OCI image;
+- cleanup of first-pass, final-probe, and injected secure artifacts;
+- secure labels and caller labels;
+- credential handling and the sudo environment boundary;
+- fail-before-push workflow ordering;
+- the secretless mechanics-build path.
+
+No `bwrap`, host bootc, host libostree, or additional APT installation may be
+introduced.
+
+The version result is a compatibility gate only. It does not replace or feed
+the literal `SNOSI_BOOTC_SECURE_BOOTC_VERSION=1.16.3` passed to the assembler,
+and it does not become storage-digest authority.
+
+## Error Handling
+
+The packager must reject a pre-mounted `$ROOTFS_DIR/proc` rather than unmounting
+or reusing a mount it does not own; use `mountpoint -q` for that ownership
+check. The complete mkosi rootfs must already contain its empty `/proc`
+directory. Do not create a missing target: absence is malformed-rootfs evidence
+and fails closed. Run the probe in a dedicated helper subshell. After its own
+successful bind mount, that helper's EXIT trap must
+unmount the exact path on success, version mismatch, execution failure, and
+interruption. The mount must be gone before systemd-boot preparation or
+first-pass packaging starts; it is never part of an OCI layer or the composefs
+identity. A failed unmount is itself fatal and must not be hidden by an
+otherwise successful probe.
+
+The probe must distinguish a failed `chroot`/bootc execution from an unexpected
+successful version. Capture and surface the execution diagnostic instead of
+suppressing stderr; this output is needed to expose loader, library, or procfs
+failures and contains no credential input. Both conditions exit nonzero before
+the assembler or Buildah creates the first-pass image. A version mismatch may
+print the expected and observed public version strings. No diagnostic may print
+credential values or file contents.
+
+## Test Design
+
+Extend `test/bootc-secure-package-cleanup-test.sh` so its controlled commands
+prove orchestration and cleanup without pretending to reproduce a real dynamic
+loader boundary:
+
+- provide controlled bare-name `mount`, `mountpoint`, `chroot`, and `umount`
+  commands under the fixture's existing `$state/bin` PATH;
+- make the controlled `chroot` command, rather than the now-inert rootfs shell
+  stub, produce the pinned or deliberately wrong version output;
+- assert a successful secure packaging fixture bind-mounted only `/proc`, used
+  chroot with the expected root and `/usr/bin/bootc --version` arguments, and
+  unmounted the owned rootfs proc path;
+- add negative fixtures proving a pre-mounted rootfs proc path is refused, a
+  failed chroot/bootc probe is diagnosed and rejected before assembler/Buildah,
+  a wrong successful version is rejected, and procfs is unmounted after each
+  failure that follows a successful bind;
+- retain all existing cleanup and rerun assertions.
+
+These command stubs prove call shape, ownership refusal, and cleanup behavior;
+they do not model target ABI loading. The immutable published-Cayo experiment
+above grounds the real loader/procfs behavior. The protected rerun then confirms
+the same mechanism against newly built rootfs directories for all profiles.
+
+Run the package cleanup fixture, bootc secure artifact negative fixtures,
+ShellCheck, the publication guard, and `git diff --check`. The next protected
+main-branch run is the production proof: all three package steps must pass this
+probe and local artifact validation before any registry write is accepted.
+
+## Documentation
+
+Update `CLAUDE.md`, `README.md`, and the relevant `yeti/` build-pipeline
+documentation to state that the initial version probe executes through chroot
+with target libraries, while storage-digest authority remains bootc inside the
+candidate OCI image.
+
+## Evidence Boundary
+
+A green protected rerun produces one signed secure candidate set for Cayo,
+Snow, and Snowfield. It does not by itself provide distinct `N`, `N+1`, and
+`N+2` artifacts, installed-system Task 9 evidence, rotation evidence, or the
+representative Snowfield hardware gate.

--- a/shared/outformat/image/buildah-package.sh
+++ b/shared/outformat/image/buildah-package.sh
@@ -21,6 +21,50 @@ shift 2
 
 [[ -d "$ROOTFS_DIR" ]] || { echo "Error: rootfs directory does not exist: $ROOTFS_DIR" >&2; exit 1; }
 
+probe_rootfs_bootc_version() ( # rootfs
+    local root=$1 proc="$1/proc" mounted=0 output status
+
+    # shellcheck disable=SC2329 # Invoked by the helper subshell's EXIT trap.
+    cleanup_proc() {
+        local exit_status=$?
+        trap - EXIT
+        if [[ $mounted -eq 1 ]] && ! umount "$proc"; then
+            echo "Error: failed to unmount rootfs proc: $proc" >&2
+            exit_status=1
+        fi
+        exit "$exit_status"
+    }
+
+    [[ -d $proc ]] || {
+        echo "Error: rootfs proc directory is missing: $proc" >&2
+        exit 1
+    }
+    if mountpoint -q "$proc"; then
+        echo "Error: rootfs proc is already mounted: $proc" >&2
+        exit 1
+    fi
+
+    trap cleanup_proc EXIT
+    mount --bind /proc "$proc" || {
+        echo "Error: failed to bind host proc into rootfs: $proc" >&2
+        exit 1
+    }
+    mounted=1
+
+    set +e
+    output=$(chroot "$root" /usr/bin/bootc --version 2>&1)
+    status=$?
+    set -e
+    if [[ $status -ne 0 ]]; then
+        printf 'Error: rootfs bootc execution failed:\n%s\n' "$output" >&2
+        exit 1
+    fi
+    [[ $output == 'bootc 1.16.3' ]] || {
+        printf 'Error: expected bootc 1.16.3, observed %s\n' "$output" >&2
+        exit 1
+    }
+)
+
 secure_label="io.snosi.bootc.secureboot-capable=false"
 secure_assembly_label=""
 first_image=""
@@ -59,9 +103,7 @@ if [[ ${SNOSI_BOOTC_SECURE:-0} == 1 ]]; then
     [[ -x "$ASSEMBLER" ]] || {
         echo "Error: bootc secure assembler is unavailable" >&2; exit 1;
     }
-    [[ $("$ROOTFS_DIR/usr/bin/bootc" --version 2>/dev/null || true) == 'bootc 1.16.3' ]] || {
-        echo "Error: secure assembly requires rootfs bootc 1.16.3" >&2; exit 1;
-    }
+    probe_rootfs_bootc_version "$ROOTFS_DIR"
     trap cleanup_secure EXIT
     # The reconciler's signed source must be in the pristine first OCI pass:
     # adding it after the storage digest would change the composefs identity.

--- a/test/bootc-secure-package-cleanup-test.sh
+++ b/test/bootc-secure-package-cleanup-test.sh
@@ -18,18 +18,49 @@ image_path() {
 
 write_fixtures() { # state root
     local state=$1 root=$2
-    mkdir -p "$state/bin" "$state/images" "$root/usr/bin" "$root/usr/lib/modules/test-kernel" \
+    mkdir -p "$state/bin" "$state/images" "$root/proc" "$root/usr/bin" "$root/usr/lib/modules/test-kernel" \
         "$root/boot/EFI/Linux" "$root/boot/EFI/BOOT"
-    printf '%s\n' '#!/bin/bash' 'echo "bootc 1.16.3"' >"$root/usr/bin/bootc"
-    chmod +x "$root/usr/bin/bootc"
     : >"$root/usr/lib/modules/test-kernel/vmlinuz"
     : >"$root/usr/lib/modules/test-kernel/initramfs.img"
     printf 'keep-linux\n' >"$root/boot/EFI/Linux/keep.txt"
     printf 'keep-boot\n' >"$root/boot/EFI/BOOT/pre-existing.efi"
 
+    cat >"$state/bin/mountpoint" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $1 == -q && $2 == "$BUILD_FIXTURE_ROOT/proc" ]]
+[[ -e "$BUILD_FIXTURE_STATE/proc-mounted" ]]
+EOF
+    cat >"$state/bin/mount" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $1 == --bind && $2 == /proc && $3 == "$BUILD_FIXTURE_ROOT/proc" ]]
+printf '%s\n' "$*" >"$BUILD_FIXTURE_STATE/mount-invoked"
+touch "$BUILD_FIXTURE_STATE/proc-mounted"
+EOF
+    cat >"$state/bin/chroot" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $1 == "$BUILD_FIXTURE_ROOT" && $2 == /usr/bin/bootc && $3 == --version ]]
+printf '%s\n' "$*" >"$BUILD_FIXTURE_STATE/chroot-invoked"
+if [[ ${BUILD_FIXTURE_CHROOT_FAIL:-0} == 1 ]]; then
+    echo 'fixture rootfs loader failure' >&2
+    exit 86
+fi
+printf '%s\n' "${BUILD_FIXTURE_BOOTC_VERSION:-bootc 1.16.3}"
+EOF
+    cat >"$state/bin/umount" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $1 == "$BUILD_FIXTURE_ROOT/proc" ]]
+printf '%s\n' "$*" >"$BUILD_FIXTURE_STATE/umount-invoked"
+[[ ${BUILD_FIXTURE_UMOUNT_FAIL:-0} != 1 ]] || exit 87
+rm -f "$BUILD_FIXTURE_STATE/proc-mounted"
+EOF
     cat >"$state/bin/buildah" <<'EOF'
 #!/bin/bash
 set -euo pipefail
+touch "$BUILD_FIXTURE_STATE/buildah-invoked"
 hash() { printf '%s' "$1" | sha256sum | cut -d' ' -f1; }
 case $1 in
     from) printf 'container-%s\n' "${RANDOM}" ;;
@@ -79,12 +110,17 @@ printf 'injected-uki\n' >"$1/boot/EFI/Linux/test-kernel.efi"
 printf 'injected-bootloader\n' >"$1/boot/EFI/BOOT/grubx64.efi"
 [[ ${BUILD_FIXTURE_ASSEMBLER_FAIL:-0} != 1 ]]
 EOF
-    chmod +x "$state/bin/buildah" "$state/bin/podman" "$state/assembler"
+    chmod +x "$state/bin/mountpoint" "$state/bin/mount" "$state/bin/chroot" \
+        "$state/bin/umount" "$state/bin/buildah" "$state/bin/podman" "$state/assembler"
 }
 
 assert_cleanup() { # state root first final published
     local state=$1 root=$2 first=$3 final=$4 published=$5
     [[ -f "$state/assembler-invoked" ]] || fail "controlled assembler was not invoked"
+    [[ -f "$state/mount-invoked" && $(<"$state/mount-invoked") == "--bind /proc $root/proc" ]] || fail "rootfs proc bind was not exact"
+    [[ -f "$state/chroot-invoked" && $(<"$state/chroot-invoked") == "$root /usr/bin/bootc --version" ]] || fail "bootc version did not use rootfs chroot"
+    [[ -f "$state/umount-invoked" && $(<"$state/umount-invoked") == "$root/proc" ]] || fail "rootfs proc unmount was not exact"
+    [[ ! -e "$state/proc-mounted" ]] || fail "rootfs proc mount survived"
     [[ ! -e "$state/images/$(image_path "$first")" ]] || fail "first probe image survived"
     [[ ! -e "$state/images/$(image_path "$final")" ]] || fail "final probe image survived"
     [[ ! -e "$state/images/$(image_path "$published")" ]] || fail "published image survived"
@@ -105,7 +141,7 @@ run_case() { # name assembler-fails|final-probe-fails|published-digest-mismatch
     published="localhost/task5-cleanup-$name:latest"
     write_fixtures "$state" "$root"
     set +e
-    BUILD_FIXTURE_STATE="$state" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
+    BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
         SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture \
         SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
         SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" \
@@ -120,7 +156,7 @@ run_case() { # name assembler-fails|final-probe-fails|published-digest-mismatch
 
     # A fresh secure invocation must not be blocked by leftovers from the failure.
     set +e
-    BUILD_FIXTURE_STATE="$state" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
+    BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
         SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture \
         SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
         SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" \
@@ -130,6 +166,51 @@ run_case() { # name assembler-fails|final-probe-fails|published-digest-mismatch
     [[ $status -eq 0 ]] || fail "$name left the next secure packaging run wedged"
     "$state/assembler" --remove-injected "$root"
 }
+
+run_probe_failure_case() { # name expected-text setup-command env-name env-value
+    local name=$1 expected=$2 setup=$3 env_name=$4 env_value=$5 work state root published status output
+    work=$(mktemp -d)
+    trap 'rm -rf -- "$work"' RETURN
+    state="$work/state"; root="$work/root"
+    published="localhost/task5-probe-$name:latest"
+    write_fixtures "$state" "$root"
+    [[ $setup == none ]] || "$setup" "$state" "$root"
+    set +e
+    output=$(env BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" PATH="$state/bin:$PATH" \
+        SNOSI_BOOTC_SECURE=1 SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture \
+        SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
+        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" \
+        "$env_name=$env_value" "$PACKAGER" "$root" "$published" 2>&1)
+    status=$?
+    set -e
+    [[ $status -ne 0 ]] || fail "$name unexpectedly succeeded"
+    [[ $output == *"$expected"* ]] || fail "$name lacked diagnostic: $expected"
+    [[ ! -e "$state/assembler-invoked" ]] || fail "$name reached the assembler"
+    [[ ! -e "$state/buildah-invoked" ]] || fail "$name reached Buildah"
+    case $name in
+        proc-missing)
+            [[ ! -e "$state/mount-invoked" && ! -e "$root/proc" ]] || fail "$name changed malformed rootfs"
+            ;;
+        proc-pre-mounted)
+            [[ ! -e "$state/mount-invoked" && ! -e "$state/umount-invoked" && -e "$state/proc-mounted" ]] || fail "$name touched an unowned mount"
+            ;;
+        chroot-fails|wrong-version)
+            [[ -e "$state/umount-invoked" && ! -e "$state/proc-mounted" ]] || fail "$name did not clean its proc mount"
+            ;;
+        umount-fails)
+            [[ -e "$state/umount-invoked" && -e "$state/proc-mounted" ]] || fail "$name did not expose failed unmount state"
+            ;;
+    esac
+}
+
+mark_proc_mounted() { touch "$1/proc-mounted"; }
+remove_proc_dir() { rmdir "$2/proc"; }
+
+run_probe_failure_case proc-missing 'rootfs proc directory is missing' remove_proc_dir UNUSED 0
+run_probe_failure_case proc-pre-mounted 'rootfs proc is already mounted' mark_proc_mounted UNUSED 0
+run_probe_failure_case chroot-fails 'fixture rootfs loader failure' none BUILD_FIXTURE_CHROOT_FAIL 1
+run_probe_failure_case wrong-version 'expected bootc 1.16.3, observed bootc 1.16.2' none BUILD_FIXTURE_BOOTC_VERSION 'bootc 1.16.2'
+run_probe_failure_case umount-fails 'failed to unmount rootfs proc' none BUILD_FIXTURE_UMOUNT_FAIL 1
 
 run_case assembler-fails
 run_case final-probe-fails

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -61,7 +61,14 @@ plus the ESP copy of systemd-boot under `/boot`. Before that first package, it
 places the same signed systemd-boot source at
 `/usr/lib/snosi/bootc/systemd-bootx64.efi`; this is required because an
 installed ESP mount shadows `/boot`, and it is deliberately present before the
-digest is calculated. A second OCI probe must retain the exact digest. This is a
+digest is calculated. The preflight version gate uses bare-name
+`mount`/`mountpoint`/`chroot`/`umount`: it refuses a missing or pre-mounted
+`$ROOTFS_DIR/proc`, bind-mounts only host `/proc`, runs `/usr/bin/bootc
+--version` against target libraries, and always unmounts before
+`--prepare-systemd-boot-source`. Bare names are load-bearing for the non-root
+PATH fixtures. This gate is not digest authority; both storage digest probes
+still run bootc inside their candidate OCI images. A second OCI probe must
+retain the exact digest. This is a
 fail-closed maintained compatibility contract, not
 an upstream interface; see `docs/bootc-secure-assembly-compatibility.md` for
 the mandatory revalidation triggers. Private keys remain caller-owned and must


### PR DESCRIPTION
## Summary
- execute the pinned bootc version gate with target rootfs libraries
- bind only procfs and fail closed on mount ownership or cleanup errors
- cover call shape, diagnostics, and cleanup with PATH fixtures

## Failure evidence
Protected run 30563925331 installed bootc 1.16.3 in all three rootfs directories but direct host-context execution failed before packaging; no registry write ran.

## Validation
- secure package cleanup fixture
- secure artifact negative fixtures
- publication guard fixture and real-tree guard
- ShellCheck