### PR TITLE
fix: run ukify inside bootc candidate image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,12 @@ Before first-pass packaging, the root packager temporarily bind-mounts only host
 through chroot, so target libraries rather than the CI host ABI resolve. It
 refuses pre-mounted/missing rootfs proc paths and unmounts before any image
 mutation. Storage-digest authority remains bootc inside the candidate OCI image.
+Direct ukify executes as `/usr/bin/ukify` inside the pristine first-pass
+candidate with network disabled, individual read-only credential mounts, and a
+public-only writable work mount. The candidate supplies pinned systemd-ukify
+261.1-3 and its dependencies; no host ukify is accepted. The disposable
+container and mounts never enter a layer. Host `.linux`/`.initrd` byte checks
+remain valid because first-pass packaging is a byte-identical `cp -a` snapshot.
 The optional dual-PCR mode requires the previous certificate positionally and
 its matching private key only through `SNOSI_BOOTC_PREVIOUS_PCR_KEY`. Never
 copy private keys into the rootfs, OCI layers, labels, logs, or retained temp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ public-only writable work mount. The candidate supplies pinned systemd-ukify
 261.1-3 and its dependencies; no host ukify is accepted. The disposable
 container and mounts never enter a layer. Host `.linux`/`.initrd` byte checks
 remain valid because first-pass packaging is a byte-identical `cp -a` snapshot.
+Candidate execution drops all Linux capabilities. The active and optional
+previous PCR public identities remain in the unmounted assembler gate directory;
+only copies enter the writable work mount and must compare byte-for-byte with
+the protected identities after execution.
 The optional dual-PCR mode requires the previous certificate positionally and
 its matching private key only through `SNOSI_BOOTC_PREVIOUS_PCR_KEY`. Never
 copy private keys into the rootfs, OCI layers, labels, logs, or retained temp

--- a/README.md
+++ b/README.md
@@ -444,6 +444,13 @@ The protected packager checks its pinned bootc through the built rootfs with a
 temporary procfs bind, then removes that bind before assembly. It does not
 require a matching host bootc or host libostree ABI; candidate-image bootc
 remains the storage-digest authority.
+Direct ukify similarly runs as `/usr/bin/ukify` inside the pristine first-pass
+candidate, with networking disabled, individual read-only credential mounts,
+and a public-only writable work mount. Its pinned systemd-ukify 261.1-3 and
+dependencies therefore come from the candidate, never the host; the disposable
+container and mounts do not enter a layer. Host `.linux` and `.initrd` byte
+checks remain valid because first-pass packaging is a byte-identical `cp -a`
+snapshot.
 This is not production Secure Boot support: published `latest` images inspected
 on 2026-07-27 lacked `io.snosi.bootc.secureboot-capable` and are unsuitable for
 the secure install/update harnesses. MOK/TPM enrollment and full secure

--- a/README.md
+++ b/README.md
@@ -451,6 +451,9 @@ dependencies therefore come from the candidate, never the host; the disposable
 container and mounts do not enter a layer. Host `.linux` and `.initrd` byte
 checks remain valid because first-pass packaging is a byte-identical `cp -a`
 snapshot.
+The candidate also runs with all Linux capabilities dropped. Protected active
+and optional previous PCR public identities remain outside the writable mount;
+the copied public inputs are checked against those identities after execution.
 This is not production Secure Boot support: published `latest` images inspected
 on 2026-07-27 lacked `io.snosi.bootc.secureboot-capable` and are unsuitable for
 the secure install/update harnesses. MOK/TPM enrollment and full secure

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -17,6 +17,11 @@ The adapter relies on all of the following observed behavior:
    key, and four PCR policies per signer.
 4. `bootc install to-filesystem` consumes the resulting image as a Type #2 UKI
    deployment without raw `linux` or `initrd` BLS fallback.
+5. Forky `systemd-ukify 261.1-3` ships executable `/usr/bin/ukify` (package
+   SHA-256 `817b8ea0a8953f9fb4b42d91f04ed1511bbb1e76cee466497dfb955cb246aa34`).
+6. Direct ukify runs inside the first-pass candidate; candidate bootc remains
+   storage-digest authority.
+7. Final host byte comparisons depend on first-pass `cp -a` identity.
 
 `buildah-package.sh` makes a first, unsigned-label OCI image, computes that
 storage digest through the image's own bootc binary, invokes the assembler,

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -22,6 +22,9 @@ The adapter relies on all of the following observed behavior:
 6. Direct ukify runs inside the first-pass candidate; candidate bootc remains
    storage-digest authority.
 7. Final host byte comparisons depend on first-pass `cp -a` identity.
+8. Candidate ukify runs with network disabled and all Linux capabilities dropped.
+   Its authoritative active and optional previous PCR public identities remain
+   outside the writable work mount; exposed copies must match after execution.
 
 `buildah-package.sh` makes a first, unsigned-label OCI image, computes that
 storage digest through the image's own bootc binary, invokes the assembler,

--- a/docs/superpowers/plans/2026-07-30-bootc-candidate-ukify.md
+++ b/docs/superpowers/plans/2026-07-30-bootc-candidate-ukify.md
@@ -1,0 +1,523 @@
+# Bootc Candidate-Image Ukify Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run pinned direct ukify inside the first-pass candidate image instead of depending on a host ukify installation.
+
+**Architecture:** The packager hands its exact first-pass local image reference to the assembler. A focused assembler helper runs `/usr/bin/ukify` as the candidate entrypoint with no network, individual read-only credential mounts, and one public-only writable work mount; all target inputs use in-image paths while bootc remains storage-digest authority.
+
+**Tech Stack:** Bash, Podman, Buildah, systemd-ukify 261.1-3, OpenSSL, ShellCheck
+
+## Global Constraints
+
+- Execute `/usr/bin/ukify` from the first-pass candidate image; do not install or invoke host ukify.
+- Require exact Forky `systemd-ukify 261.1-3` layout: executable `/usr/bin/ukify`.
+- Use `podman run --rm --network=none --security-opt label=type:unconfined_t --entrypoint=/usr/bin/ukify`.
+- Mount MOK key, MOK certificate, active PCR key, and optional previous PCR key individually read-only at fixed `/run/snosi-ukify-*` paths.
+- Mount exactly one assembler-owned public-only work directory writable at `/run/snosi-ukify-work`.
+- Never use `:z`/`:Z`, mount a credential directory, use Podman secrets, create a retained container, or add privilege/PID-host access.
+- Translate kernel, initrd, os-release, PCR-public-key, output, and credential arguments to in-container paths; no host rootfs/work path may remain in ukify argv.
+- Redact both host and fixed in-container private-key paths plus PEM contents from diagnostics and the retained log.
+- Reject candidate failure and absent/empty `uki.efi`; scan the work directory for caller-owned credentials before and after candidate execution.
+- Preserve exact direct-ukify options, phases, `rw composefs=?<digest>`, two-pass digest sequence, candidate bootc authority, final byte comparisons, secure labels, sudo forwarding, cleanup, and fail-before-push ordering.
+- Update `CLAUDE.md`, `README.md`, `yeti/build-pipeline.md`, and `docs/bootc-secure-assembly-compatibility.md`.
+- Execute this plan on the existing `fix/bootc-candidate-ukify` branch based on `origin/main`.
+
+---
+
+### Task 1: Hand Off The Exact First-Pass Candidate
+
+**Files:**
+- Modify: `test/bootc-secure-package-cleanup-test.sh:60-139`
+- Modify: `shared/outformat/image/buildah-package.sh:112-122`
+
+**Interfaces:**
+- Consumes: `first_image`, the packager-owned local image reference `localhost/snosi-bootc-secure-first-$$`.
+- Produces: `SNOSI_BOOTC_SECURE_UKIFY_IMAGE=<first_image>` on the actual assembler invocation only.
+
+- [ ] **Step 1: Add the failing handoff assertion**
+
+In the controlled assembler's normal assembly branch in
+`test/bootc-secure-package-cleanup-test.sh`, record the environment value before
+touching `assembler-invoked`:
+
+```bash
+printf '%s\n' "${SNOSI_BOOTC_SECURE_UKIFY_IMAGE:-}" \
+    >"$BUILD_FIXTURE_STATE/ukify-image"
+```
+
+Add to `assert_cleanup()`:
+
+```bash
+    [[ -f "$state/ukify-image" ]] || fail "assembler did not receive a ukify image"
+    ukify_image=$(<"$state/ukify-image")
+    [[ $ukify_image == localhost/snosi-bootc-secure-first-[0-9]* ]] ||
+        fail "assembler did not receive the exact first-pass ukify image"
+    [[ -f "$state/podman-first-args" ]] && grep -Fxq -- "$ukify_image" "$state/podman-first-args" ||
+        fail "assembler ukify image differs from the first digest candidate"
+```
+
+Add `ukify_image` to `assert_cleanup()`'s local declaration.
+
+Extend the controlled Podman fixture so its first invocation writes every
+argument, one per line, to `$BUILD_FIXTURE_STATE/podman-first-args`. This makes
+the digest invocation, not a separately reconstructed PID, authoritative.
+
+- [ ] **Step 2: Run the package fixture and confirm RED**
+
+Run:
+
+```bash
+test/bootc-secure-package-cleanup-test.sh
+```
+
+Expected: FAIL with `assembler did not receive the exact first-pass ukify image`.
+
+- [ ] **Step 3: Pass the first image to the assembler**
+
+In `shared/outformat/image/buildah-package.sh`, extend only the real assembly
+invocation after first-pass digest computation:
+
+```bash
+    SNOSI_BOOTC_SECURE_COMPOSEFS_DIGEST="$digest" SNOSI_BOOTC_SECURE_BOOTC_VERSION=1.16.3 \
+        SNOSI_BOOTC_SECURE_UKIFY_IMAGE="$first_image" \
+        SNOSI_BOOTC_PREVIOUS_PCR_KEY="${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-}" \
+        "$ASSEMBLER" "$ROOTFS_DIR" \
+        "$SNOSI_BOOTC_MOK_KEY" "$SNOSI_BOOTC_MOK_CERT" "$SNOSI_BOOTC_PCR_KEY" "$SNOSI_BOOTC_PCR_CERT" \
+        "${SNOSI_BOOTC_PREVIOUS_PCR_CERT:-}"
+```
+
+Do not export the value globally and do not pass it to recursive insecure
+packaging, scans, or cleanup calls.
+
+- [ ] **Step 4: Run focused verification**
+
+Run:
+
+```bash
+test/bootc-secure-package-cleanup-test.sh
+shellcheck shared/outformat/image/buildah-package.sh \
+  test/bootc-secure-package-cleanup-test.sh
+git diff --check
+```
+
+Expected: cleanup fixtures pass; ShellCheck and diff check are silent.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add shared/outformat/image/buildah-package.sh test/bootc-secure-package-cleanup-test.sh
+git commit -m "fix: hand candidate image to bootc assembler"
+```
+
+### Task 2: Run Direct Ukify Inside The Candidate
+
+**Files:**
+- Modify: `shared/bootc-secure/assemble-uki.sh:8-283,293-319,450-465`
+- Modify: `CLAUDE.md:66-89`
+- Modify: `README.md:439-456`
+- Modify: `yeti/build-pipeline.md:55-79`
+- Modify: `docs/bootc-secure-assembly-compatibility.md:1-50`
+
+**Interfaces:**
+- Consumes: `SNOSI_BOOTC_SECURE_UKIFY_IMAGE`, directory rootfs paths, caller-owned key paths, assembler work directory, and unchanged ukify option values.
+- Produces: `run_candidate_ukify IMAGE WORK LOG MOK_KEY MOK_CERT PCR_KEY PREVIOUS_KEY -- UKIFY_ARGS...`, returning 0 only when Podman exits 0 and a nonempty host-side `WORK/uki.efi` exists.
+
+- [ ] **Step 1: Add candidate path constants and helper fixture**
+
+Add after `EXPECTED_BOOTC_VERSION` in `shared/bootc-secure/assemble-uki.sh`:
+
+```bash
+readonly CANDIDATE_UKIFY_MOK_KEY=/run/snosi-ukify-mok.key
+readonly CANDIDATE_UKIFY_MOK_CERT=/run/snosi-ukify-mok.crt
+readonly CANDIDATE_UKIFY_PCR_KEY=/run/snosi-ukify-pcr.key
+readonly CANDIDATE_UKIFY_PREVIOUS_KEY=/run/snosi-ukify-previous-pcr.key
+readonly CANDIDATE_UKIFY_WORK=/run/snosi-ukify-work
+```
+
+Add `candidate_ukify_self_test()` before `self_test()`. It must create a
+temporary `root`, separate per-case work directories, and a `bin/podman`
+fixture that records one argument per line in
+`$CANDIDATE_UKIFY_TEST_ARGS`, locates the host source of the
+`:$CANDIDATE_UKIFY_WORK:rw` volume, and then:
+
+Create `root` and every case work directory as siblings under the top-level
+temporary directory so `$work/outside` is structurally outside `$root` in the
+path-refusal assertion.
+
+```bash
+if [[ ${CANDIDATE_UKIFY_TEST_FAIL:-0} == 1 ]]; then
+    echo "candidate ukify failed at $CANDIDATE_UKIFY_PCR_KEY" >&2
+    exit 86
+fi
+if [[ ${CANDIDATE_UKIFY_TEST_NO_OUTPUT:-0} != 1 ]]; then
+    if [[ ${CANDIDATE_UKIFY_TEST_EMPTY_OUTPUT:-0} == 1 ]]; then
+        : >"$host_work/uki.efi"
+    else
+        printf 'fixture uki\n' >"$host_work/uki.efi"
+    fi
+fi
+printf 'safe diagnostic; key path %s\n' "$CANDIDATE_UKIFY_PCR_KEY" >&2
+cat "$CANDIDATE_UKIFY_TEST_PRIVATE_KEY" >&2
+```
+
+The fixture parser must reject any invocation without these exact control
+arguments before the image name:
+
+```text
+run
+--rm
+--network=none
+--security-opt
+label=type:unconfined_t
+--entrypoint=/usr/bin/ukify
+```
+
+- [ ] **Step 2: Add single-key assertions and confirm RED**
+
+Have `candidate_ukify_self_test()` generate disposable MOK/PCR keys and a MOK
+certificate, create `work/pcr.pub`, then invoke the not-yet-implemented helper
+with image `localhost/snosi-bootc-secure-first-fixture`, a log path, no previous
+key, and this ukify argv:
+
+```bash
+build
+--linux /usr/lib/modules/one/vmlinuz
+--initrd /usr/lib/modules/one/initramfs.img
+--os-release @/usr/lib/os-release
+--cmdline 'rw composefs=?fixture'
+--pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY"
+--secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
+--secureboot-certificate "$CANDIDATE_UKIFY_MOK_CERT"
+--pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub"
+--output "$CANDIDATE_UKIFY_WORK/uki.efi"
+```
+
+Assert the recorded Podman argv contains:
+
+```text
+localhost/snosi-bootc-secure-first-fixture
+<mok-host-path>:/run/snosi-ukify-mok.key:ro
+<mok-cert-host-path>:/run/snosi-ukify-mok.crt:ro
+<pcr-host-path>:/run/snosi-ukify-pcr.key:ro
+<work-host-path>:/run/snosi-ukify-work:rw
+```
+
+Assert it contains no `snosi-ukify-previous-pcr.key`, no host rootfs path in
+arguments after the image, and no second `:rw` volume. Assert `work/uki.efi` is
+nonempty. Assert the retained log contains `safe diagnostic` but contains
+neither the host/fixed private-key paths nor `BEGIN PRIVATE KEY`.
+
+Call `candidate_ukify_self_test` immediately before `self_test()`'s existing
+`return "$rc"` line.
+
+Run:
+
+```bash
+test/bootc-secure-artifact-test.sh --fixtures
+```
+
+Expected: FAIL because `run_candidate_ukify` is undefined.
+
+- [ ] **Step 3: Add dual-key and failure assertions**
+
+Within `candidate_ukify_self_test()`, run a second success case with a generated
+previous PCR key. Require exactly this additional read-only mount and argument:
+
+```text
+<previous-host-path>:/run/snosi-ukify-previous-pcr.key:ro
+--pcr-private-key
+/run/snosi-ukify-previous-pcr.key
+```
+
+Add three fail-closed cases around the helper with `set +e`/status capture:
+
+```text
+CANDIDATE_UKIFY_TEST_FAIL=1          -> status 86, sanitized safe diagnostic retained
+CANDIDATE_UKIFY_TEST_NO_OUTPUT=1     -> nonzero, "candidate ukify produced no UKI"
+CANDIDATE_UKIFY_TEST_EMPTY_OUTPUT=1  -> nonzero, "candidate ukify produced no UKI"
+```
+
+Use a fresh work directory for every helper invocation, or remove `uki.efi`
+before each case. No-output and empty-output cases must never observe a prior
+success artifact. For the status-86 case, require the log to contain
+`candidate ukify failed at [redacted credential path]`; it must not require the
+later success-only `safe diagnostic` line and must contain neither the fixed
+PCR path nor PEM content.
+
+Run:
+
+```bash
+test/bootc-secure-artifact-test.sh --fixtures
+```
+
+Expected: FAIL until the helper implements status propagation, redaction, and
+nonempty output enforcement.
+
+- [ ] **Step 4: Implement candidate execution helper**
+
+Add before `assemble()`:
+
+```bash
+run_candidate_ukify() { # image work log mok-key mok-cert pcr-key previous-key -- ukify-args...
+    local image=$1 work=$2 log=$3 mok_key=$4 mok_cert=$5 pcr_key=$6 previous_key=$7 status
+    local -a podman_args
+    shift 7
+    [[ ${1:-} == -- ]] || die "candidate ukify argument separator is missing"
+    shift
+
+    podman_args=(run --rm --network=none
+        --security-opt label=type:unconfined_t
+        --entrypoint=/usr/bin/ukify
+        --volume "$mok_key:$CANDIDATE_UKIFY_MOK_KEY:ro"
+        --volume "$mok_cert:$CANDIDATE_UKIFY_MOK_CERT:ro"
+        --volume "$pcr_key:$CANDIDATE_UKIFY_PCR_KEY:ro"
+        --volume "$work:$CANDIDATE_UKIFY_WORK:rw")
+    [[ -z $previous_key ]] || podman_args+=(
+        --volume "$previous_key:$CANDIDATE_UKIFY_PREVIOUS_KEY:ro")
+
+    podman "${podman_args[@]}" "$image" "$@" 2>&1 |
+        redact_credentials "$mok_key" "$pcr_key" "$previous_key" \
+            "$CANDIDATE_UKIFY_MOK_KEY" "$CANDIDATE_UKIFY_PCR_KEY" \
+            "$CANDIDATE_UKIFY_PREVIOUS_KEY" |
+        tee "$log" >&2
+    status=${PIPESTATUS[0]}
+    [[ $status -eq 0 ]] || return "$status"
+    [[ -s $work/uki.efi ]] || {
+        echo "Error: candidate ukify produced no UKI" >&2
+        return 1
+    }
+}
+```
+
+Do not add `--privileged`, `--pid=host`, `:z`, or `:Z`.
+
+- [ ] **Step 5: Translate rootfs paths and replace host ukify**
+
+Add before `assemble()`:
+
+```bash
+rootfs_image_path() { # rootfs host-path
+    local root=${1%/} path=$2 relative
+    [[ $path == "$root/"* ]] || die "path is outside rootfs: $path"
+    relative=${path#"$root/"}
+    while [[ $relative == /* ]]; do relative=${relative#/}; done
+    printf '/%s\n' "$relative"
+}
+```
+
+Add direct self-test assertions before the Podman cases:
+
+```bash
+    [[ $(rootfs_image_path "$root/" "$root//usr/lib/modules/one/vmlinuz") == \
+        /usr/lib/modules/one/vmlinuz ]] || die "rootfs path translation failed"
+    if (rootfs_image_path "$root" "$work/outside") >/dev/null 2>&1; then
+        die "outside-rootfs path accepted"
+    fi
+```
+
+In `assemble()`, immediately after `discover_kernel` populates `$kernel` and
+`$initrd`, require and resolve the candidate image and translated paths:
+
+```bash
+    local ukify_image image_kernel image_initrd
+    ukify_image=${SNOSI_BOOTC_SECURE_UKIFY_IMAGE:-}
+    [[ -n $ukify_image ]] || die "missing first-pass candidate image for ukify"
+    image_kernel=$(rootfs_image_path "$root" "$kernel")
+    image_initrd=$(rootfs_image_path "$root" "$initrd")
+```
+
+Build `ukify_args` with only candidate paths:
+
+```bash
+    ukify_args=(build --linux "$image_kernel" --initrd "$image_initrd"
+        --os-release @/usr/lib/os-release --cmdline "rw composefs=?$digest"
+        --uname "$version" --pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY"
+        --secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
+        --secureboot-certificate "$CANDIDATE_UKIFY_MOK_CERT"
+        --measure --output "$CANDIDATE_UKIFY_WORK/uki.efi")
+```
+
+Replace the existing single/dual-key argument conditional with:
+
+```bash
+    if [[ -n "$previous_key" ]]; then
+        ukify_args+=(--pcr-private-key "$CANDIDATE_UKIFY_PREVIOUS_KEY"
+            --pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub"
+            --phases "enter-initrd,enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready"
+            --phases "enter-initrd,enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready")
+    else
+        ukify_args+=(--pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub")
+    fi
+```
+
+Immediately before candidate execution, require the work directory contains no
+caller-owned private credential:
+
+```bash
+    credential_gate_scan_tree "$gate" "ukify work directory before candidate execution" "$work"
+```
+
+Replace the host `ukify ... | redact ... | tee ...` pipeline with:
+
+```bash
+    set +e
+    run_candidate_ukify "$ukify_image" "$work" "$work/ukify.log" \
+        "$mok_key" "$mok_cert" "$pcr_key" "$previous_key" -- \
+        "${ukify_args[@]}"
+    ukify_status=$?
+    set -e
+    [[ $ukify_status -eq 0 ]] || die "ukify failed"
+    credential_gate_scan_tree "$gate" "ukify work directory after candidate execution" "$work"
+```
+
+Retain the sanitized-log scan, host installation of `work/uki.efi`, UKI
+validation, and final rootfs credential scan.
+
+- [ ] **Step 6: Run assembler fixtures and confirm GREEN**
+
+Run:
+
+```bash
+test/bootc-secure-artifact-test.sh --fixtures
+test/bootc-secure-artifact-negative-test.sh --fixtures
+```
+
+Expected: positive and negative artifact fixtures pass.
+
+- [ ] **Step 7: Document the candidate-image boundary**
+
+Update the Task 5 paragraph in `CLAUDE.md` to state:
+
+```markdown
+Direct ukify executes as `/usr/bin/ukify` inside the pristine first-pass
+candidate with network disabled, individual read-only credential mounts, and a
+public-only writable work mount. The candidate supplies pinned systemd-ukify
+261.1-3 and its dependencies; no host ukify is accepted. The disposable
+container and mounts never enter a layer. Host `.linux`/`.initrd` byte checks
+remain valid because first-pass packaging is a byte-identical `cp -a` snapshot.
+```
+
+Add equivalent concise user-facing text to `README.md`. In
+`yeti/build-pipeline.md`, record the fixed mount paths, path translation,
+entrypoint/network/label options, and the public-only work scans. In
+`docs/bootc-secure-assembly-compatibility.md`, record:
+
+```markdown
+- Forky systemd-ukify 261.1-3 ships executable `/usr/bin/ukify` (package
+  SHA-256 `817b8ea0a8953f9fb4b42d91f04ed1511bbb1e76cee466497dfb955cb246aa34`).
+- Direct ukify runs inside the first-pass candidate; candidate bootc remains
+  storage-digest authority.
+- Final host byte comparisons depend on first-pass `cp -a` identity.
+```
+
+- [ ] **Step 8: Run complete focused verification**
+
+Run:
+
+```bash
+test/bootc-secure-artifact-test.sh --fixtures
+test/bootc-secure-artifact-negative-test.sh --fixtures
+test/bootc-secure-package-cleanup-test.sh
+test/bootc-publication-guard-test.sh
+./check-bootc-publication-guard.sh
+shellcheck shared/bootc-secure/assemble-uki.sh \
+  shared/outformat/image/buildah-package.sh \
+  test/bootc-secure-package-cleanup-test.sh
+git diff --check
+```
+
+Expected: all commands exit 0; publication guard reports 29 passing assertions;
+ShellCheck and diff check are silent.
+
+- [ ] **Step 9: Review and commit Task 2**
+
+Run:
+
+```bash
+git diff -- shared/bootc-secure/assemble-uki.sh CLAUDE.md README.md yeti/build-pipeline.md docs/bootc-secure-assembly-compatibility.md
+git status --short
+git add shared/bootc-secure/assemble-uki.sh CLAUDE.md README.md yeti/build-pipeline.md docs/bootc-secure-assembly-compatibility.md
+git commit -m "fix: run ukify inside bootc candidate image"
+```
+
+### Task 3: Merge And Re-run Protected Publication
+
+**Files:**
+- No repository file changes.
+
+**Interfaces:**
+- Consumes: Reviewed candidate-image ukify implementation and protected credentials.
+- Produces: Three signed immutable OCI candidates promoted only after local and policy-copied artifact validation.
+
+- [ ] **Step 1: Push and create the PR**
+
+Run:
+
+```bash
+test "$(git branch --show-current)" = fix/bootc-candidate-ukify
+git push -u origin fix/bootc-candidate-ukify
+gh pr create --repo frostyard/snosi --base main --head fix/bootc-candidate-ukify \
+  --title "fix: run ukify inside bootc candidate image" \
+  --body $'## Summary\n- run pinned direct ukify inside the first-pass candidate image\n- expose credentials only as ephemeral read-only mounts\n- guard single/dual-key command shape, output, redaction, and cleanup\n\n## Failure evidence\nProtected run 30568330831 completed first-pass packaging and digest computation for all profiles, then failed because the Ubuntu host had no ukify; no registry write ran.\n\n## Validation\n- secure artifact positive and negative fixtures\n- secure package cleanup fixture\n- publication guard fixture and real-tree guard\n- ShellCheck'
+```
+
+- [ ] **Step 2: Wait for checks and inspect the PR**
+
+Run:
+
+```bash
+PR_NUMBER=$(gh pr view --repo frostyard/snosi --json number --jq .number)
+gh pr checks "$PR_NUMBER" --repo frostyard/snosi --watch
+gh pr diff "$PR_NUMBER" --repo frostyard/snosi
+gh pr view "$PR_NUMBER" --repo frostyard/snosi \
+  --json url,state,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+If branch protection requires independent approval, stop without `--admin` and
+resume after the user merges or supplies approval.
+
+- [ ] **Step 3: Merge normally and identify the exact automatic run**
+
+Run:
+
+```bash
+gh pr merge "$PR_NUMBER" --repo frostyard/snosi --squash --delete-branch
+MERGE_SHA=
+for _ in $(seq 1 30); do
+  MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo frostyard/snosi \
+    --json mergeCommit --jq '.mergeCommit.oid // empty')
+  [[ -n $MERGE_SHA ]] && break
+  sleep 2
+done
+[[ -n $MERGE_SHA ]]
+RUN_JSON=
+for _ in $(seq 1 30); do
+  RUN_JSON=$(gh run list --repo frostyard/snosi --workflow build-images.yml --branch main \
+    --limit 10 --json databaseId,headSha,url,status,conclusion | \
+    jq -c --arg sha "$MERGE_SHA" 'map(select(.headSha == $sha)) | first // empty')
+  [[ -n $RUN_JSON ]] && break
+  sleep 2
+done
+[ -n "$RUN_JSON" ]
+RUN_ID=$(jq -r .databaseId <<<"$RUN_JSON")
+RUN_URL=$(jq -r .url <<<"$RUN_JSON")
+printf 'Run %s: %s\n' "$RUN_ID" "$RUN_URL"
+gh run watch "$RUN_ID" --repo frostyard/snosi --exit-status --interval 20
+```
+
+- [ ] **Step 4: Record immutable evidence and ordering**
+
+Run:
+
+```bash
+gh run view "$RUN_ID" --repo frostyard/snosi --json url,headSha,status,conclusion,jobs
+```
+
+Expected for Cayo, Snow, and Snowfield: package, local artifact validation,
+immutable push, signing, remote verification, policy-copied validation, and
+latest promotion all succeed in order. Record each 14-digit version and digest.
+Treat the result as one candidate set, not distinct `N`/`N+1`/`N+2`, Task 9,
+rotation, or Snowfield hardware evidence.

--- a/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
+++ b/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
@@ -1,0 +1,199 @@
+# Bootc Candidate-Image Ukify Design
+
+## Problem
+
+Protected `build-images.yml` run `30568330831` proved that all three secure
+profiles now pass the target-library bootc version gate, prepare the signed
+systemd-boot source, package a first-pass OCI image, and compute its storage
+digest. Cayo, Snow, and Snowfield then fail at the same next boundary:
+
+```text
+assemble-uki.sh: line 272: ukify: command not found
+Error: ukify failed
+```
+
+Each built rootfs contains the deliberately selected
+`systemd-ukify 261.1-3` package from Forky. The GitHub Ubuntu host does not
+provide `ukify`. The assembler's bare `ukify` invocation therefore makes the
+maintained direct-ukify compatibility contract accidentally depend on an
+unselected host systemd family.
+
+This was latent while earlier gates stopped packaging before direct ukify.
+No immutable image push, signature, or `latest` promotion ran in the failed
+build.
+
+## Decision
+
+Run direct `/usr/bin/ukify` inside the already-packaged first-pass candidate
+OCI image. The packager passes that local image reference to the assembler via
+`SNOSI_BOOTC_SECURE_UKIFY_IMAGE`. The assembler uses `podman run --rm` with
+network disabled, the existing unconfined-label convention, and explicit
+`--entrypoint=/usr/bin/ukify` so future image CMD/ENTRYPOINT changes cannot
+intercept the ukify arguments.
+
+The path is verified against Debian Forky package
+`systemd-ukify_261.1-3_all.deb` (SHA-256
+`817b8ea0a8953f9fb4b42d91f04ed1511bbb1e76cee466497dfb955cb246aa34`):
+its file list contains executable `/usr/bin/ukify` and the
+`/usr/lib/systemd/ukify -> ../../bin/ukify` compatibility symlink. This is a
+pinned compatibility observation, not an assumed package layout.
+
+Ukify reads these immutable inputs directly from the candidate image:
+
+- `/usr/lib/modules/<kernel>/vmlinuz`;
+- `/usr/lib/modules/<kernel>/initramfs.img`;
+- `/usr/lib/os-release`;
+- the candidate's pinned `systemd-ukify` and all of its dependencies.
+
+The assembler rejects a discovered kernel or initrd path outside the supplied
+rootfs, then translates every host-side path in the current ukify arguments:
+
+- kernel and initrd become their absolute paths below `/usr/lib/modules`;
+- os-release becomes `@/usr/lib/os-release`;
+- active and previous PCR private keys become fixed credential mount paths;
+- MOK private key and certificate become fixed credential mount paths;
+- PCR public key becomes `/run/snosi-ukify-work/pcr.pub`;
+- output becomes `/run/snosi-ukify-work/uki.efi`.
+
+No host-rootfs or host-work path may remain in the container command.
+
+## Ephemeral Mount Contract
+
+The candidate receives only these bind mounts:
+
+- MOK private key, read-only;
+- MOK certificate, read-only;
+- active PCR private key, read-only;
+- previous PCR private key, read-only only in dual-key mode;
+- one assembler-owned temporary work directory, writable.
+
+Each credential is mounted at a fixed `/run/snosi-ukify-*.key|crt` path. The
+work directory is mounted at `/run/snosi-ukify-work`; it carries the generated
+public PCR key into the container and returns only `uki.efi`. Public inputs do
+not need separate credential mounts when already present in the work directory
+or candidate rootfs.
+
+Credential mounts are never copied into the rootfs or OCI layers. The
+container is removed by Podman, the first-pass image remains under the existing
+packager cleanup trap, and the host work directory remains under the existing
+assembler RETURN cleanup. Do not mount a credential directory wholesale, use
+Podman secrets, create a retained container, or relabel credential files.
+
+Use `--security-opt label=type:unconfined_t`, matching existing candidate-image
+storage probes, rather than `:z`/`:Z` bind suffixes that mutate host labels.
+Use `--network=none`; ukify requires no network.
+
+The writable work directory is public-output-only by invariant. Before exposing
+it to the container, run the existing caller-credential gate over the directory
+and reject any private-key match. Future code must not place a private temporary
+file there. After successful Podman execution, require a nonempty `uki.efi`
+through its host-side bind path before continuing.
+
+## Command And Diagnostics
+
+The direct command remains `ukify build`; this change relocates its execution
+without changing its pinned options, phases, command line, signing inputs, PCR
+policy, or output validation. The container command uses fixed in-container
+credential paths and the in-image kernel/initrd paths.
+
+Preserve the current pipeline status handling: Podman's exit status is the
+ukify status, any nonzero result fails assembly, and diagnostics pass through
+credential redaction before reaching stderr or the sanitized retained log.
+Redaction must cover both caller-side credential paths and fixed in-container
+credential paths. Concretely, pass the host MOK/PCR/previous-key paths and the
+fixed mounted MOK/PCR/previous-key paths to `redact_credentials`; continue its
+content-based PEM block removal unchanged. The diagnostic stream and retained
+log must not contain private key bytes or unredacted private-key paths.
+
+`SNOSI_BOOTC_SECURE_UKIFY_IMAGE` is required only for an actual assembly call;
+self-tests that do not assemble remain independent. An unavailable image,
+missing `/usr/bin/ukify`, mount failure, command failure, or missing output is
+fail-closed.
+
+## Authority Boundaries
+
+The first-pass candidate already determines the pre-injection storage digest.
+Running ukify inside it does not make ukify a digest authority and does not
+change the digest sequence:
+
+1. Package pristine first-pass candidate.
+2. Compute storage digest with bootc inside that candidate.
+3. Run direct ukify inside that same candidate using ephemeral mounts.
+4. Inject only the UKI and signed second stage into the directory rootfs.
+5. Package the final probe image.
+6. Recompute the digest with bootc inside the final candidate and require
+   equality.
+
+The first-pass candidate cannot retain output or credentials in a committed
+layer because `podman run` writes only to its disposable container layer and
+the explicit work bind. Existing final rootfs, OCI config/filesystem, sanitized
+log, and retained-state credential scans remain authoritative.
+
+## Rejected Alternatives
+
+### Install Host Ukify
+
+Ubuntu's host package belongs to a different systemd family than selected
+Forky `261.1-3`. Installing it would reintroduce host/target version drift and
+would require a new workflow prerequisite. It is not acceptable.
+
+### Chroot The Directory Rootfs
+
+Chroot would require several temporary credential and output mounts in the
+mutable directory rootfs, plus procfs for any target helpers that inspect
+namespaces. Candidate execution needs fewer mutable host-side boundaries and
+cannot accidentally package the mount targets.
+
+### Copy Target Ukify To The Host
+
+`systemd-ukify` is Python and depends on its selected Python modules and target
+systemd helpers. Copying only the script does not establish a coherent runtime;
+copying its dependency closure duplicates the candidate image poorly.
+
+## Test Design
+
+Factor the Podman invocation into a focused assembler helper. Extend assembler
+self-tests with a PATH-controlled Podman fixture that:
+
+- records every argument without recording credential contents;
+- asserts the exact first-pass image is selected;
+- requires `--rm`, `--network=none`, `--entrypoint=/usr/bin/ukify`, and the
+  unconfined label option;
+- requires each private credential as an individual read-only mount;
+- separately requires the MOK certificate as an individual read-only mount;
+- rejects a previous-key mount in single-key mode and requires it in dual-key
+  mode;
+- requires exactly one writable work-directory mount;
+- requires in-image kernel, initrd, os-release, PCR-public-key, and output
+  paths rather than host rootfs paths;
+- creates `uki.efi` only through the work mount to model successful output;
+- rejects a zero-byte or absent `uki.efi` even when Podman exits zero;
+- proves a nonzero Podman/ukify status propagates and retains a safe diagnostic;
+- proves fixed in-container credential paths and credential values are removed
+  from the sanitized log.
+
+Extend package cleanup fixtures to require that the packager passes its exact
+first-pass image reference to the controlled assembler. Keep all existing
+failure cleanup and rerun coverage.
+
+Run the assembler fixture and negative fixture suites, package cleanup fixture,
+publication guard, ShellCheck, and `git diff --check`. The protected main-branch
+run is the production proof against all three newly built candidate images.
+
+## Documentation
+
+Update `CLAUDE.md`, `README.md`, `yeti/build-pipeline.md`, and
+`docs/bootc-secure-assembly-compatibility.md` to say that direct ukify executes
+inside the first-pass candidate. Preserve the distinction between direct ukify
+as UKI construction and candidate bootc as storage-digest authority. Record
+that final host-side `.linux` and `.initrd` byte comparisons remain valid only
+because the first-pass image is a byte-identical `cp -a` snapshot of those same
+directory-rootfs files; changing first-pass construction requires revalidating
+that invariant.
+
+## Evidence Boundary
+
+A green protected rerun yields one signed secure candidate set for Cayo, Snow,
+and Snowfield. It is not distinct `N`, `N+1`, and `N+2` evidence, installed
+Task 9 evidence, key-rotation evidence, or representative Snowfield hardware
+evidence.

--- a/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
+++ b/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
@@ -27,7 +27,7 @@ build.
 Run direct `/usr/bin/ukify` inside the already-packaged first-pass candidate
 OCI image. The packager passes that local image reference to the assembler via
 `SNOSI_BOOTC_SECURE_UKIFY_IMAGE`. The assembler uses `podman run --rm` with
-network disabled, the existing unconfined-label convention, and explicit
+network disabled, all Linux capabilities dropped, the existing unconfined-label convention, and explicit
 `--entrypoint=/usr/bin/ukify` so future image CMD/ENTRYPOINT changes cannot
 intercept the ukify arguments.
 
@@ -69,9 +69,11 @@ The candidate receives only these bind mounts:
 
 Each credential is mounted at a fixed `/run/snosi-ukify-*.key|crt` path. The
 work directory is mounted at `/run/snosi-ukify-work`; it carries the generated
-public PCR key into the container and returns only `uki.efi`. Public inputs do
-not need separate credential mounts when already present in the work directory
-or candidate rootfs.
+public PCR keys into the container and returns only `uki.efi`. The authoritative
+active and optional previous public identities remain in the unmounted assembler
+gate directory; the exposed copies are compared with them after successful
+candidate execution before UKI validation. Public inputs do not need separate
+credential mounts when already present in the work directory or candidate rootfs.
 
 Credential mounts are never copied into the rootfs or OCI layers. The
 container is removed by Podman, the first-pass image remains under the existing
@@ -81,7 +83,8 @@ Podman secrets, create a retained container, or relabel credential files.
 
 Use `--security-opt label=type:unconfined_t`, matching existing candidate-image
 storage probes, rather than `:z`/`:Z` bind suffixes that mutate host labels.
-Use `--network=none`; ukify requires no network.
+Use `--network=none` and `--cap-drop=all`; ukify requires neither network nor
+Linux capabilities.
 
 The writable work directory is public-output-only by invariant. Before exposing
 it to the container, run the existing caller-credential gate over the directory

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -233,6 +233,7 @@ sign_systemd_boot() { # rootfs mok-cert
 run_candidate_ukify() { # image work log mok-key mok-cert pcr-key previous-key -- ukify-args...
     local image=$1 work=$2 log=$3 mok_key=$4 mok_cert=$5 pcr_key=$6 previous_key=$7 status
     local -a podman_args
+    [[ -n $image ]] || die "candidate ukify image is missing"
     shift 7
     [[ ${1:-} == -- ]] || die "candidate ukify argument separator is missing"
     shift
@@ -268,9 +269,31 @@ rootfs_image_path() { # rootfs host-path
     printf '/%s\n' "$relative"
 }
 
+candidate_ukify_args() { # rootfs kernel initrd digest version previous-key output-array
+    local root=$1 kernel=$2 initrd=$3 digest=$4 version=$5 previous_key=$6 output_name=$7
+    local image_kernel image_initrd
+    local -n output="$output_name"
+    image_kernel=$(rootfs_image_path "$root" "$kernel")
+    image_initrd=$(rootfs_image_path "$root" "$initrd")
+    output=(build --linux "$image_kernel" --initrd "$image_initrd"
+        --os-release @/usr/lib/os-release --cmdline "rw composefs=?$digest"
+        --uname "$version" --pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY"
+        --secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
+        --secureboot-certificate "$CANDIDATE_UKIFY_MOK_CERT" --measure
+        --output "$CANDIDATE_UKIFY_WORK/uki.efi")
+    if [[ -n "$previous_key" ]]; then
+        output+=(--pcr-private-key "$CANDIDATE_UKIFY_PREVIOUS_KEY"
+            --pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub"
+            --phases "enter-initrd,enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready"
+            --phases "enter-initrd,enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready")
+    else
+        output+=(--pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub")
+    fi
+}
+
 assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     local root=$1 mok_key=$2 mok_cert=$3 pcr_key=$4 pcr_cert=$5 previous_cert=${6:-}
-    local previous_key=${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-} digest kernel_info version kernel initrd work gate primary_public previous_public uki ukify_status ukify_image image_kernel image_initrd
+    local previous_key=${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-} digest kernel_info version kernel initrd work gate primary_public previous_public uki ukify_status ukify_image
     local -a ukify_args
     [[ -d "$root" ]] || die "rootfs directory is missing"
     validate_keypair "$mok_key" "$mok_cert" "MOK"
@@ -295,8 +318,6 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     IFS=$'\t' read -r version kernel initrd <<<"$kernel_info"
     ukify_image=${SNOSI_BOOTC_SECURE_UKIFY_IMAGE:-}
     [[ -n $ukify_image ]] || die "missing first-pass candidate image for ukify"
-    image_kernel=$(rootfs_image_path "$root" "$kernel")
-    image_initrd=$(rootfs_image_path "$root" "$initrd")
     work=$(mktemp -d)
     openssl pkey -in "$pcr_key" -pubout -out "$work/pcr.pub" >/dev/null
     primary_public="$work/pcr.pub"; previous_public=""
@@ -304,20 +325,7 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
         openssl pkey -pubin -in "$previous_cert" -pubout -out "$work/previous.pub"
         previous_public="$work/previous.pub"
     fi
-    ukify_args=(build --linux "$image_kernel" --initrd "$image_initrd"
-        --os-release @/usr/lib/os-release --cmdline "rw composefs=?$digest"
-        --uname "$version" --pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY"
-        --secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
-        --secureboot-certificate "$CANDIDATE_UKIFY_MOK_CERT" --measure
-        --output "$CANDIDATE_UKIFY_WORK/uki.efi")
-    if [[ -n "$previous_key" ]]; then
-        ukify_args+=(--pcr-private-key "$CANDIDATE_UKIFY_PREVIOUS_KEY"
-            --pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub"
-            --phases "enter-initrd,enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready"
-            --phases "enter-initrd,enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready")
-    else
-        ukify_args+=(--pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub")
-    fi
+    candidate_ukify_args "$root" "$kernel" "$initrd" "$digest" "$version" "$previous_key" ukify_args
     credential_gate_scan_tree "$gate" "ukify work directory before candidate execution" "$work"
     set +e
     run_candidate_ukify "$ukify_image" "$work" "$work/ukify.log" \
@@ -345,7 +353,8 @@ remove_injected() { # rootfs
 }
 
 candidate_ukify_self_test() (
-    local top root work key cert pcr log args mok_mount cert_mount pcr_mount work_mount
+    local top root work key cert pcr log args mok_mount cert_mount pcr_mount work_mount empty_args status
+    local -a fixture_args expected_args
     top=$(mktemp -d); trap 'rm -rf -- "$top"' RETURN
     root="$top/root"; work="$top/work-single"; log="$work/ukify.log"; args="$top/podman.args"
     mkdir -p "$root/usr/lib/modules/one" "$work" "$top/bin"
@@ -355,6 +364,17 @@ candidate_ukify_self_test() (
     openssl req -new -x509 -key "$key" -subj /CN=mok -days 1 -out "$cert" >/dev/null 2>&1
     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$pcr" >/dev/null 2>&1
     openssl pkey -in "$pcr" -pubout -out "$work/pcr.pub" >/dev/null
+    candidate_ukify_args "$root" "$root/usr/lib/modules/one/vmlinuz" "$root/usr/lib/modules/one/initramfs.img" \
+        fixture one "" fixture_args
+    expected_args=(build --linux /usr/lib/modules/one/vmlinuz --initrd /usr/lib/modules/one/initramfs.img
+        --os-release @/usr/lib/os-release --cmdline 'rw composefs=?fixture' --uname one
+        --pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY" --secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
+        --secureboot-certificate "$CANDIDATE_UKIFY_MOK_CERT" --measure --output "$CANDIDATE_UKIFY_WORK/uki.efi"
+        --pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub")
+    [[ ${#fixture_args[@]} -eq ${#expected_args[@]} ]] || die "candidate ukify arguments have an unexpected length"
+    for index in "${!expected_args[@]}"; do
+        [[ ${fixture_args[index]} == "${expected_args[index]}" ]] || die "candidate ukify argument translation is incorrect"
+    done
     cat >"$top/bin/podman" <<'EOF'
 #!/bin/bash
 set -euo pipefail
@@ -375,6 +395,10 @@ if [[ ${1:-} == --volume ]]; then
 fi
 [[ ${1:-} == localhost/snosi-bootc-secure-first-fixture ]] || exit 91
 [[ -n ${host_work:-} ]] || exit 88
+if [[ ${CANDIDATE_UKIFY_TEST_PODMAN_UNAVAILABLE:-0} == 1 ]]; then
+    echo 'candidate ukify image is unavailable' >&2
+    exit 127
+fi
 if [[ ${CANDIDATE_UKIFY_TEST_FAIL:-0} == 1 ]]; then
     echo "candidate ukify failed at /run/snosi-ukify-pcr.key" >&2
     exit 86
@@ -390,13 +414,26 @@ printf 'safe diagnostic; key path %s\n' /run/snosi-ukify-pcr.key >&2
 cat "$CANDIDATE_UKIFY_TEST_PRIVATE_KEY" >&2
 EOF
     chmod +x "$top/bin/podman"
+    empty_args="$top/podman-empty.args"
+    if (PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$empty_args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
+        run_candidate_ukify "" "$work" "$top/empty.log" "$key" "$cert" "$pcr" "" -- build) >"$top/empty-output" 2>&1; then
+        die "candidate ukify accepted an empty image"
+    fi
+    [[ ! -e "$empty_args" ]] || die "candidate ukify ran Podman without an image"
+    grep -Fq -- 'candidate ukify image is missing' "$top/empty-output" || die "candidate ukify empty-image diagnostic is missing"
+    local unavailable_work="$top/work-podman-unavailable" unavailable_log="$top/podman-unavailable.log"
+    mkdir "$unavailable_work"
+    set +e
+    PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-unavailable.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
+        CANDIDATE_UKIFY_TEST_PODMAN_UNAVAILABLE=1 \
+        run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$unavailable_work" "$unavailable_log" "$key" "$cert" "$pcr" "" -- build
+    status=$?
+    set -e
+    [[ $status -eq 127 ]] || die "candidate ukify did not propagate unavailable Podman status"
+    grep -Fq -- 'candidate ukify image is unavailable' "$unavailable_log" || die "candidate ukify unavailable diagnostic was not retained"
     PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
         run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$work" "$log" "$key" "$cert" "$pcr" "" -- \
-        build --linux /usr/lib/modules/one/vmlinuz --initrd /usr/lib/modules/one/initramfs.img \
-        --os-release @/usr/lib/os-release --cmdline 'rw composefs=?fixture' \
-        --pcr-private-key /run/snosi-ukify-pcr.key --secureboot-private-key /run/snosi-ukify-mok.key \
-        --secureboot-certificate /run/snosi-ukify-mok.crt --pcrpkey /run/snosi-ukify-work/pcr.pub \
-        --output /run/snosi-ukify-work/uki.efi
+        "${fixture_args[@]}"
     mok_mount="$key:/run/snosi-ukify-mok.key:ro"; cert_mount="$cert:/run/snosi-ukify-mok.crt:ro"
     pcr_mount="$pcr:/run/snosi-ukify-pcr.key:ro"; work_mount="$work:/run/snosi-ukify-work:rw"
     if ! grep -Fqx -- localhost/snosi-bootc-secure-first-fixture "$args" || ! grep -Fqx -- "$mok_mount" "$args" ||
@@ -424,15 +461,14 @@ EOF
     fi
 
     local previous="$top/previous.key" dual_work="$top/work-dual" dual_args="$top/podman-dual.args"
+    local -a dual_ukify_args
     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$previous" >/dev/null 2>&1
     mkdir "$dual_work"; openssl pkey -in "$pcr" -pubout -out "$dual_work/pcr.pub" >/dev/null
+    candidate_ukify_args "$root" "$root/usr/lib/modules/one/vmlinuz" "$root/usr/lib/modules/one/initramfs.img" \
+        fixture one "$previous" dual_ukify_args
     PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$dual_args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
         run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$dual_work" "$dual_work/ukify.log" "$key" "$cert" "$pcr" "$previous" -- \
-        build --linux /usr/lib/modules/one/vmlinuz --initrd /usr/lib/modules/one/initramfs.img \
-        --os-release @/usr/lib/os-release --cmdline 'rw composefs=?fixture' \
-        --pcr-private-key /run/snosi-ukify-pcr.key --pcr-private-key /run/snosi-ukify-previous-pcr.key \
-        --secureboot-private-key /run/snosi-ukify-mok.key --secureboot-certificate /run/snosi-ukify-mok.crt \
-        --pcrpkey /run/snosi-ukify-work/pcr.pub --output /run/snosi-ukify-work/uki.efi
+        "${dual_ukify_args[@]}"
     if ! grep -Fqx -- "$previous:/run/snosi-ukify-previous-pcr.key:ro" "$dual_args" ||
         ! grep -Fqx -- /run/snosi-ukify-previous-pcr.key "$dual_args"; then
         die "candidate ukify dual-key mount is incorrect"

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -232,13 +232,13 @@ sign_systemd_boot() { # rootfs mok-cert
 
 run_candidate_ukify() { # image work log mok-key mok-cert pcr-key previous-key -- ukify-args...
     local image=$1 work=$2 log=$3 mok_key=$4 mok_cert=$5 pcr_key=$6 previous_key=$7 status
-    local -a podman_args
+    local -a podman_args pipeline_status
     [[ -n $image ]] || die "candidate ukify image is missing"
     shift 7
     [[ ${1:-} == -- ]] || die "candidate ukify argument separator is missing"
     shift
 
-    podman_args=(run --rm --network=none
+    podman_args=(run --rm --network=none --cap-drop=all
         --security-opt label=type:unconfined_t
         --entrypoint=/usr/bin/ukify
         --volume "$mok_key:$CANDIDATE_UKIFY_MOK_KEY:ro"
@@ -253,8 +253,13 @@ run_candidate_ukify() { # image work log mok-key mok-cert pcr-key previous-key -
             "$CANDIDATE_UKIFY_MOK_KEY" "$CANDIDATE_UKIFY_PCR_KEY" \
             "$CANDIDATE_UKIFY_PREVIOUS_KEY" |
         tee "$log" >&2
-    status=${PIPESTATUS[0]}
+    pipeline_status=("${PIPESTATUS[@]}")
+    status=${pipeline_status[0]}
     [[ $status -eq 0 ]] || return "$status"
+    [[ ${pipeline_status[1]} -eq 0 && ${pipeline_status[2]} -eq 0 ]] || {
+        echo "Error: candidate ukify diagnostics could not be retained" >&2
+        return 1
+    }
     [[ -s $work/uki.efi ]] || {
         echo "Error: candidate ukify produced no UKI" >&2
         return 1
@@ -262,11 +267,19 @@ run_candidate_ukify() { # image work log mok-key mok-cert pcr-key previous-key -
 }
 
 rootfs_image_path() { # rootfs host-path
-    local root=${1%/} path=$2 relative
+    local root path relative
+    root=$(realpath -e "$1") || die "rootfs path cannot be resolved: $1"
+    path=$(realpath -e "$2") || die "rootfs path cannot be resolved: $2"
     [[ $path == "$root/"* ]] || die "path is outside rootfs: $path"
     relative=${path#"$root/"}
-    while [[ $relative == /* ]]; do relative=${relative#/}; done
     printf '/%s\n' "$relative"
+}
+
+verify_exposed_pcr_public_keys() { # active-public work-directory [previous-public]
+    local active=$1 work=$2 previous=${3:-}
+    cmp -s "$active" "$work/pcr.pub" || die "candidate changed active PCR public key"
+    [[ -z $previous ]] || cmp -s "$previous" "$work/previous.pub" ||
+        die "candidate changed previous PCR public key"
 }
 
 candidate_ukify_args() { # rootfs kernel initrd digest version previous-key output-array
@@ -319,11 +332,13 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     ukify_image=${SNOSI_BOOTC_SECURE_UKIFY_IMAGE:-}
     [[ -n $ukify_image ]] || die "missing first-pass candidate image for ukify"
     work=$(mktemp -d)
-    openssl pkey -in "$pcr_key" -pubout -out "$work/pcr.pub" >/dev/null
-    primary_public="$work/pcr.pub"; previous_public=""
+    openssl pkey -in "$pcr_key" -pubout -out "$gate/pcr.pub" >/dev/null
+    primary_public="$gate/pcr.pub"; previous_public=""
+    install -m 0644 "$primary_public" "$work/pcr.pub"
     if [[ -n "$previous_cert" ]]; then
-        openssl pkey -pubin -in "$previous_cert" -pubout -out "$work/previous.pub"
-        previous_public="$work/previous.pub"
+        openssl pkey -pubin -in "$previous_cert" -pubout -out "$gate/previous.pub"
+        previous_public="$gate/previous.pub"
+        install -m 0644 "$previous_public" "$work/previous.pub"
     fi
     candidate_ukify_args "$root" "$kernel" "$initrd" "$digest" "$version" "$previous_key" ukify_args
     credential_gate_scan_tree "$gate" "ukify work directory before candidate execution" "$work"
@@ -334,6 +349,7 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     ukify_status=$?
     set -e
     [[ $ukify_status -eq 0 ]] || die "ukify failed"
+    verify_exposed_pcr_public_keys "$primary_public" "$work" "$previous_public"
     credential_gate_scan_tree "$gate" "ukify work directory after candidate execution" "$work"
     credential_gate_scan_file "$gate" "sanitized ukify log" ukify.log "$work/ukify.log"
     uki="$root/boot/EFI/Linux/$version.efi"
@@ -379,7 +395,7 @@ candidate_ukify_self_test() (
 #!/bin/bash
 set -euo pipefail
 printf '%s\n' "$@" >"$CANDIDATE_UKIFY_TEST_ARGS"
-expected=(run --rm --network=none --security-opt label=type:unconfined_t --entrypoint=/usr/bin/ukify)
+expected=(run --rm --network=none --cap-drop=all --security-opt label=type:unconfined_t --entrypoint=/usr/bin/ukify)
 for expected_arg in "${expected[@]}"; do
     [[ ${1:-} == "$expected_arg" ]] || exit 87
     shift
@@ -402,6 +418,12 @@ fi
 if [[ ${CANDIDATE_UKIFY_TEST_FAIL:-0} == 1 ]]; then
     echo "candidate ukify failed at /run/snosi-ukify-pcr.key" >&2
     exit 86
+fi
+if [[ ${CANDIDATE_UKIFY_TEST_OVERWRITE_ACTIVE_PUB:-0} == 1 ]]; then
+    printf 'candidate-mutated-active-public-key\n' >"$host_work/pcr.pub"
+fi
+if [[ ${CANDIDATE_UKIFY_TEST_OVERWRITE_PREVIOUS_PUB:-0} == 1 ]]; then
+    printf 'candidate-mutated-previous-public-key\n' >"$host_work/previous.pub"
 fi
 if [[ ${CANDIDATE_UKIFY_TEST_NO_OUTPUT:-0} != 1 ]]; then
     if [[ ${CANDIDATE_UKIFY_TEST_EMPTY_OUTPUT:-0} == 1 ]]; then
@@ -444,7 +466,8 @@ EOF
     local seen_image=0 podman_arg
     local writable_mounts=0
     while IFS= read -r podman_arg; do
-        [[ $seen_image -eq 0 || $podman_arg != "$root"* ]] || die "candidate ukify passed a host rootfs path"
+        [[ $seen_image -eq 0 || ( $podman_arg != "$root"* && $podman_arg != "$work"* ) ]] ||
+            die "candidate ukify passed a host rootfs or work path"
         [[ $podman_arg == localhost/snosi-bootc-secure-first-fixture ]] && seen_image=1
         [[ $podman_arg == *:rw ]] && writable_mounts=$((writable_mounts + 1))
     done <"$args"
@@ -459,10 +482,53 @@ EOF
     if (rootfs_image_path "$root" "$work/outside") >/dev/null 2>&1; then
         die "outside-rootfs path accepted"
     fi
+    mkdir "$top/outside"
+    touch "$top/outside/vmlinuz"
+    ln -s ../outside/vmlinuz "$root/relative-escape"
+    ln -s "$top/outside/vmlinuz" "$root/absolute-escape"
+    ln -s usr/lib/modules/one/vmlinuz "$root/internal-link"
+    if (rootfs_image_path "$root" "$root/relative-escape") >/dev/null 2>&1; then
+        die "relative rootfs symlink escape accepted"
+    fi
+    if (rootfs_image_path "$root" "$root/absolute-escape") >/dev/null 2>&1; then
+        die "absolute rootfs symlink escape accepted"
+    fi
+    [[ $(rootfs_image_path "$root" "$root/internal-link") == /usr/lib/modules/one/vmlinuz ]] ||
+        die "internal rootfs symlink translation failed"
 
-    local previous="$top/previous.key" dual_work="$top/work-dual" dual_args="$top/podman-dual.args"
-    local -a dual_ukify_args
+    local previous="$top/previous.key" protected="$top/protected" overwrite_work="$top/work-overwrite-active"
     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$previous" >/dev/null 2>&1
+    mkdir "$protected" "$overwrite_work"
+    cp "$work/pcr.pub" "$protected/pcr.pub"; cp "$protected/pcr.pub" "$overwrite_work/pcr.pub"
+    PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-overwrite-active.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
+        CANDIDATE_UKIFY_TEST_OVERWRITE_ACTIVE_PUB=1 \
+        run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$overwrite_work" "$overwrite_work/ukify.log" "$key" "$cert" "$pcr" "" -- build
+    if (verify_exposed_pcr_public_keys "$protected/pcr.pub" "$overwrite_work") >/dev/null 2>&1; then
+        die "candidate active PCR public-key overwrite accepted"
+    fi
+
+    local previous_protected="$protected/previous.pub" overwrite_dual_work="$top/work-overwrite-previous"
+    mkdir "$overwrite_dual_work"
+    openssl pkey -in "$previous" -pubout -out "$previous_protected" >/dev/null
+    cp "$protected/pcr.pub" "$overwrite_dual_work/pcr.pub"; cp "$previous_protected" "$overwrite_dual_work/previous.pub"
+    PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-overwrite-previous.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
+        CANDIDATE_UKIFY_TEST_OVERWRITE_PREVIOUS_PUB=1 \
+        run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$overwrite_dual_work" "$overwrite_dual_work/ukify.log" "$key" "$cert" "$pcr" "$previous" -- build
+    if (verify_exposed_pcr_public_keys "$protected/pcr.pub" "$overwrite_dual_work" "$previous_protected") >/dev/null 2>&1; then
+        die "candidate previous PCR public-key overwrite accepted"
+    fi
+
+    local tee_work="$top/work-tee-failure" tee_log="$top/not-a-log"
+    mkdir "$tee_work" "$tee_log"
+    set +e
+    PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-tee-failure.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
+        run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$tee_work" "$tee_log" "$key" "$cert" "$pcr" "" -- build
+    status=$?
+    set -e
+    [[ $status -ne 0 ]] || die "candidate ukify accepted a tee failure"
+
+    local dual_work="$top/work-dual" dual_args="$top/podman-dual.args"
+    local -a dual_ukify_args
     mkdir "$dual_work"; openssl pkey -in "$pcr" -pubout -out "$dual_work/pcr.pub" >/dev/null
     candidate_ukify_args "$root" "$root/usr/lib/modules/one/vmlinuz" "$root/usr/lib/modules/one/initramfs.img" \
         fixture one "$previous" dual_ukify_args

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -267,9 +267,40 @@ run_candidate_ukify() { # image work log mok-key mok-cert pcr-key previous-key -
 }
 
 rootfs_image_path() { # rootfs host-path
-    local root path relative
+    local root input_root=${1%/} input=$2 relative current component candidate target path links=0
     root=$(realpath -e "$1") || die "rootfs path cannot be resolved: $1"
-    path=$(realpath -e "$2") || die "rootfs path cannot be resolved: $2"
+    if [[ $input == "$root/"* ]]; then
+        relative=${input#"$root/"}
+    elif [[ $input == "$input_root/"* ]]; then
+        relative=${input#"$input_root/"}
+    else
+        die "path is outside rootfs: $input"
+    fi
+    current=$root
+    while [[ -n $relative ]]; do
+        component=${relative%%/*}
+        if [[ $relative == */* ]]; then relative=${relative#*/}; else relative=""; fi
+        [[ -z $component || $component == . ]] && continue
+        if [[ $component == .. ]]; then
+            current=$(dirname "$current")
+            continue
+        fi
+        candidate="$current/$component"
+        if [[ -L $candidate ]]; then
+            target=$(readlink "$candidate")
+            links=$((links + 1)); [[ $links -le 40 ]] || die "too many rootfs symlinks"
+            if [[ $target == /* ]]; then
+                current=$root
+                target=${target#/}
+            else
+                current=$(dirname "$candidate")
+            fi
+            relative="$target${relative:+/$relative}"
+        else
+            current=$candidate
+        fi
+    done
+    path=$(realpath -e "$current") || die "rootfs path cannot be resolved: $input"
     [[ $path == "$root/"* ]] || die "path is outside rootfs: $path"
     relative=${path#"$root/"}
     printf '/%s\n' "$relative"
@@ -487,6 +518,7 @@ EOF
     ln -s ../outside/vmlinuz "$root/relative-escape"
     ln -s "$top/outside/vmlinuz" "$root/absolute-escape"
     ln -s usr/lib/modules/one/vmlinuz "$root/internal-link"
+    ln -s /usr/lib/modules/one/vmlinuz "$root/absolute-internal-link"
     if (rootfs_image_path "$root" "$root/relative-escape") >/dev/null 2>&1; then
         die "relative rootfs symlink escape accepted"
     fi
@@ -495,6 +527,8 @@ EOF
     fi
     [[ $(rootfs_image_path "$root" "$root/internal-link") == /usr/lib/modules/one/vmlinuz ]] ||
         die "internal rootfs symlink translation failed"
+    [[ $(rootfs_image_path "$root" "$root/absolute-internal-link") == /usr/lib/modules/one/vmlinuz ]] ||
+        die "absolute internal rootfs symlink translation failed"
 
     local previous="$top/previous.key" protected="$top/protected" overwrite_work="$top/work-overwrite-active"
     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$previous" >/dev/null 2>&1
@@ -526,6 +560,20 @@ EOF
     status=$?
     set -e
     [[ $status -ne 0 ]] || die "candidate ukify accepted a tee failure"
+
+    local redaction_work="$top/work-redaction-failure"
+    mkdir "$redaction_work"
+    set +e
+    (
+        redact_credentials() { return 1; }
+        PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-redaction-failure.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
+            run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$redaction_work" "$redaction_work/ukify.log" "$key" "$cert" "$pcr" "" -- build
+    )
+    status=$?
+    set -e
+    [[ $status -ne 0 ]] || die "candidate ukify accepted a redaction failure"
+    [[ -f "$top/podman-redaction-failure.args" ]] || die "candidate ukify redaction fixture did not run Podman"
+    [[ -f "$redaction_work/ukify.log" ]] || die "candidate ukify redaction fixture did not reach tee"
 
     local dual_work="$top/work-dual" dual_args="$top/podman-dual.args"
     local -a dual_ukify_args

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -6,6 +6,11 @@ set -euo pipefail
 umask 077
 
 readonly EXPECTED_BOOTC_VERSION="1.16.3"
+readonly CANDIDATE_UKIFY_MOK_KEY=/run/snosi-ukify-mok.key
+readonly CANDIDATE_UKIFY_MOK_CERT=/run/snosi-ukify-mok.crt
+readonly CANDIDATE_UKIFY_PCR_KEY=/run/snosi-ukify-pcr.key
+readonly CANDIDATE_UKIFY_PREVIOUS_KEY=/run/snosi-ukify-previous-pcr.key
+readonly CANDIDATE_UKIFY_WORK=/run/snosi-ukify-work
 
 die() { echo "Error: $*" >&2; exit 1; }
 valid_digest() { [[ ${1:-} =~ ^[[:xdigit:]]{128}$ ]]; }
@@ -225,9 +230,47 @@ sign_systemd_boot() { # rootfs mok-cert
     sbverify --cert "$mok_cert" "$out" >/dev/null || die "systemd-boot MOK signature failed"
 }
 
+run_candidate_ukify() { # image work log mok-key mok-cert pcr-key previous-key -- ukify-args...
+    local image=$1 work=$2 log=$3 mok_key=$4 mok_cert=$5 pcr_key=$6 previous_key=$7 status
+    local -a podman_args
+    shift 7
+    [[ ${1:-} == -- ]] || die "candidate ukify argument separator is missing"
+    shift
+
+    podman_args=(run --rm --network=none
+        --security-opt label=type:unconfined_t
+        --entrypoint=/usr/bin/ukify
+        --volume "$mok_key:$CANDIDATE_UKIFY_MOK_KEY:ro"
+        --volume "$mok_cert:$CANDIDATE_UKIFY_MOK_CERT:ro"
+        --volume "$pcr_key:$CANDIDATE_UKIFY_PCR_KEY:ro"
+        --volume "$work:$CANDIDATE_UKIFY_WORK:rw")
+    [[ -z $previous_key ]] || podman_args+=(
+        --volume "$previous_key:$CANDIDATE_UKIFY_PREVIOUS_KEY:ro")
+
+    podman "${podman_args[@]}" "$image" "$@" 2>&1 |
+        redact_credentials "$mok_key" "$pcr_key" "$previous_key" \
+            "$CANDIDATE_UKIFY_MOK_KEY" "$CANDIDATE_UKIFY_PCR_KEY" \
+            "$CANDIDATE_UKIFY_PREVIOUS_KEY" |
+        tee "$log" >&2
+    status=${PIPESTATUS[0]}
+    [[ $status -eq 0 ]] || return "$status"
+    [[ -s $work/uki.efi ]] || {
+        echo "Error: candidate ukify produced no UKI" >&2
+        return 1
+    }
+}
+
+rootfs_image_path() { # rootfs host-path
+    local root=${1%/} path=$2 relative
+    [[ $path == "$root/"* ]] || die "path is outside rootfs: $path"
+    relative=${path#"$root/"}
+    while [[ $relative == /* ]]; do relative=${relative#/}; done
+    printf '/%s\n' "$relative"
+}
+
 assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     local root=$1 mok_key=$2 mok_cert=$3 pcr_key=$4 pcr_cert=$5 previous_cert=${6:-}
-    local previous_key=${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-} digest kernel_info version kernel initrd work gate primary_public previous_public uki ukify_status
+    local previous_key=${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-} digest kernel_info version kernel initrd work gate primary_public previous_public uki ukify_status ukify_image image_kernel image_initrd
     local -a ukify_args
     [[ -d "$root" ]] || die "rootfs directory is missing"
     validate_keypair "$mok_key" "$mok_cert" "MOK"
@@ -250,6 +293,10 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     refuse_existing_uki "$root"
     kernel_info=$(discover_kernel "$root")
     IFS=$'\t' read -r version kernel initrd <<<"$kernel_info"
+    ukify_image=${SNOSI_BOOTC_SECURE_UKIFY_IMAGE:-}
+    [[ -n $ukify_image ]] || die "missing first-pass candidate image for ukify"
+    image_kernel=$(rootfs_image_path "$root" "$kernel")
+    image_initrd=$(rootfs_image_path "$root" "$initrd")
     work=$(mktemp -d)
     openssl pkey -in "$pcr_key" -pubout -out "$work/pcr.pub" >/dev/null
     primary_public="$work/pcr.pub"; previous_public=""
@@ -257,22 +304,29 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
         openssl pkey -pubin -in "$previous_cert" -pubout -out "$work/previous.pub"
         previous_public="$work/previous.pub"
     fi
-    ukify_args=(build --linux "$kernel" --initrd "$initrd" --os-release "@$root/usr/lib/os-release"
-        --cmdline "rw composefs=?$digest" --uname "$version" --pcr-private-key "$pcr_key"
-        --secureboot-private-key "$mok_key"
-        --secureboot-certificate "$mok_cert" --measure --output "$work/uki.efi")
+    ukify_args=(build --linux "$image_kernel" --initrd "$image_initrd"
+        --os-release @/usr/lib/os-release --cmdline "rw composefs=?$digest"
+        --uname "$version" --pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY"
+        --secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
+        --secureboot-certificate "$CANDIDATE_UKIFY_MOK_CERT" --measure
+        --output "$CANDIDATE_UKIFY_WORK/uki.efi")
     if [[ -n "$previous_key" ]]; then
-        ukify_args+=(--pcr-private-key "$previous_key" --pcrpkey "$primary_public"
+        ukify_args+=(--pcr-private-key "$CANDIDATE_UKIFY_PREVIOUS_KEY"
+            --pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub"
             --phases "enter-initrd,enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready"
             --phases "enter-initrd,enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready")
+    else
+        ukify_args+=(--pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub")
     fi
-    [[ -n "$previous_key" ]] || ukify_args+=(--pcrpkey "$primary_public")
-    # Preserve useful ukify diagnostics without retaining paths or PEM values.
+    credential_gate_scan_tree "$gate" "ukify work directory before candidate execution" "$work"
     set +e
-    ukify "${ukify_args[@]}" 2>&1 | redact_credentials "$mok_key" "$pcr_key" "$previous_key" | tee "$work/ukify.log" >&2
-    ukify_status=${PIPESTATUS[0]}
+    run_candidate_ukify "$ukify_image" "$work" "$work/ukify.log" \
+        "$mok_key" "$mok_cert" "$pcr_key" "$previous_key" -- \
+        "${ukify_args[@]}"
+    ukify_status=$?
     set -e
     [[ $ukify_status -eq 0 ]] || die "ukify failed"
+    credential_gate_scan_tree "$gate" "ukify work directory after candidate execution" "$work"
     credential_gate_scan_file "$gate" "sanitized ukify log" ukify.log "$work/ukify.log"
     uki="$root/boot/EFI/Linux/$version.efi"
     mkdir -p "$(dirname "$uki")"
@@ -289,6 +343,127 @@ remove_injected() { # rootfs
     rm -f -- "$root/boot/EFI/Linux/$version.efi" "$root/boot/EFI/BOOT/grubx64.efi" \
         "$root/usr/lib/snosi/bootc/systemd-bootx64.efi"
 }
+
+candidate_ukify_self_test() (
+    local top root work key cert pcr log args mok_mount cert_mount pcr_mount work_mount
+    top=$(mktemp -d); trap 'rm -rf -- "$top"' RETURN
+    root="$top/root"; work="$top/work-single"; log="$work/ukify.log"; args="$top/podman.args"
+    mkdir -p "$root/usr/lib/modules/one" "$work" "$top/bin"
+    touch "$root/usr/lib/modules/one/vmlinuz" "$root/usr/lib/modules/one/initramfs.img"
+    key="$top/mok.key"; cert="$top/mok.crt"; pcr="$top/pcr.key"
+    openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$key" >/dev/null 2>&1
+    openssl req -new -x509 -key "$key" -subj /CN=mok -days 1 -out "$cert" >/dev/null 2>&1
+    openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$pcr" >/dev/null 2>&1
+    openssl pkey -in "$pcr" -pubout -out "$work/pcr.pub" >/dev/null
+    cat >"$top/bin/podman" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$@" >"$CANDIDATE_UKIFY_TEST_ARGS"
+expected=(run --rm --network=none --security-opt label=type:unconfined_t --entrypoint=/usr/bin/ukify)
+for expected_arg in "${expected[@]}"; do
+    [[ ${1:-} == "$expected_arg" ]] || exit 87
+    shift
+done
+for target in /run/snosi-ukify-mok.key:ro /run/snosi-ukify-mok.crt:ro /run/snosi-ukify-pcr.key:ro /run/snosi-ukify-work:rw; do
+    [[ ${1:-} == --volume && ${2:-} == *:"$target" ]] || exit 89
+    [[ $target != /run/snosi-ukify-work:rw ]] || host_work=${2%:/run/snosi-ukify-work:rw}
+    shift 2
+done
+if [[ ${1:-} == --volume ]]; then
+    [[ ${2:-} == *:/run/snosi-ukify-previous-pcr.key:ro ]] || exit 90
+    shift 2
+fi
+[[ ${1:-} == localhost/snosi-bootc-secure-first-fixture ]] || exit 91
+[[ -n ${host_work:-} ]] || exit 88
+if [[ ${CANDIDATE_UKIFY_TEST_FAIL:-0} == 1 ]]; then
+    echo "candidate ukify failed at /run/snosi-ukify-pcr.key" >&2
+    exit 86
+fi
+if [[ ${CANDIDATE_UKIFY_TEST_NO_OUTPUT:-0} != 1 ]]; then
+    if [[ ${CANDIDATE_UKIFY_TEST_EMPTY_OUTPUT:-0} == 1 ]]; then
+        : >"$host_work/uki.efi"
+    else
+        printf 'fixture uki\n' >"$host_work/uki.efi"
+    fi
+fi
+printf 'safe diagnostic; key path %s\n' /run/snosi-ukify-pcr.key >&2
+cat "$CANDIDATE_UKIFY_TEST_PRIVATE_KEY" >&2
+EOF
+    chmod +x "$top/bin/podman"
+    PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
+        run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$work" "$log" "$key" "$cert" "$pcr" "" -- \
+        build --linux /usr/lib/modules/one/vmlinuz --initrd /usr/lib/modules/one/initramfs.img \
+        --os-release @/usr/lib/os-release --cmdline 'rw composefs=?fixture' \
+        --pcr-private-key /run/snosi-ukify-pcr.key --secureboot-private-key /run/snosi-ukify-mok.key \
+        --secureboot-certificate /run/snosi-ukify-mok.crt --pcrpkey /run/snosi-ukify-work/pcr.pub \
+        --output /run/snosi-ukify-work/uki.efi
+    mok_mount="$key:/run/snosi-ukify-mok.key:ro"; cert_mount="$cert:/run/snosi-ukify-mok.crt:ro"
+    pcr_mount="$pcr:/run/snosi-ukify-pcr.key:ro"; work_mount="$work:/run/snosi-ukify-work:rw"
+    if ! grep -Fqx -- localhost/snosi-bootc-secure-first-fixture "$args" || ! grep -Fqx -- "$mok_mount" "$args" ||
+        ! grep -Fqx -- "$cert_mount" "$args" || ! grep -Fqx -- "$pcr_mount" "$args" || ! grep -Fqx -- "$work_mount" "$args"; then
+        die "candidate ukify single-key mounts are incorrect"
+    fi
+    ! grep -q -- snosi-ukify-previous-pcr.key "$args" || die "candidate ukify mounted previous key in single-key mode"
+    local seen_image=0 podman_arg
+    local writable_mounts=0
+    while IFS= read -r podman_arg; do
+        [[ $seen_image -eq 0 || $podman_arg != "$root"* ]] || die "candidate ukify passed a host rootfs path"
+        [[ $podman_arg == localhost/snosi-bootc-secure-first-fixture ]] && seen_image=1
+        [[ $podman_arg == *:rw ]] && writable_mounts=$((writable_mounts + 1))
+    done <"$args"
+    [[ $writable_mounts -eq 1 ]] || die "candidate ukify has more than one writable mount"
+    [[ -s "$work/uki.efi" ]] || die "candidate ukify fixture produced no UKI"
+    if ! grep -Fq -- 'safe diagnostic' "$log" || grep -Fq -- "$pcr" "$log" ||
+        grep -Fq -- /run/snosi-ukify-pcr.key "$log" || grep -Fq -- 'BEGIN PRIVATE KEY' "$log"; then
+        die "candidate ukify fixture log was not redacted"
+    fi
+    [[ $(rootfs_image_path "$root/" "$root//usr/lib/modules/one/vmlinuz") == /usr/lib/modules/one/vmlinuz ]] ||
+        die "rootfs path translation failed"
+    if (rootfs_image_path "$root" "$work/outside") >/dev/null 2>&1; then
+        die "outside-rootfs path accepted"
+    fi
+
+    local previous="$top/previous.key" dual_work="$top/work-dual" dual_args="$top/podman-dual.args"
+    openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$previous" >/dev/null 2>&1
+    mkdir "$dual_work"; openssl pkey -in "$pcr" -pubout -out "$dual_work/pcr.pub" >/dev/null
+    PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$dual_args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
+        run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$dual_work" "$dual_work/ukify.log" "$key" "$cert" "$pcr" "$previous" -- \
+        build --linux /usr/lib/modules/one/vmlinuz --initrd /usr/lib/modules/one/initramfs.img \
+        --os-release @/usr/lib/os-release --cmdline 'rw composefs=?fixture' \
+        --pcr-private-key /run/snosi-ukify-pcr.key --pcr-private-key /run/snosi-ukify-previous-pcr.key \
+        --secureboot-private-key /run/snosi-ukify-mok.key --secureboot-certificate /run/snosi-ukify-mok.crt \
+        --pcrpkey /run/snosi-ukify-work/pcr.pub --output /run/snosi-ukify-work/uki.efi
+    if ! grep -Fqx -- "$previous:/run/snosi-ukify-previous-pcr.key:ro" "$dual_args" ||
+        ! grep -Fqx -- /run/snosi-ukify-previous-pcr.key "$dual_args"; then
+        die "candidate ukify dual-key mount is incorrect"
+    fi
+
+    local case_work case_log status
+    for case_name in fail no-output empty-output; do
+        case_work="$top/work-$case_name"; case_log="$case_work/ukify.log"; mkdir "$case_work"
+        set +e
+        case "$case_name" in
+            fail) PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-$case_name.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" CANDIDATE_UKIFY_TEST_FAIL=1 run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$case_work" "$case_log" "$key" "$cert" "$pcr" "" -- build --output /run/snosi-ukify-work/uki.efi ;;
+            no-output) PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-$case_name.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" CANDIDATE_UKIFY_TEST_NO_OUTPUT=1 run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$case_work" "$case_log" "$key" "$cert" "$pcr" "" -- build --output /run/snosi-ukify-work/uki.efi ;;
+            empty-output) PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-$case_name.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" CANDIDATE_UKIFY_TEST_EMPTY_OUTPUT=1 run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$case_work" "$case_log" "$key" "$cert" "$pcr" "" -- build --output /run/snosi-ukify-work/uki.efi ;;
+        esac
+        status=$?
+        set -e
+        [[ ! -e "$case_work/uki.efi" || ! -s "$case_work/uki.efi" ]] || die "candidate ukify $case_name reused an output"
+        case "$case_name" in
+            fail)
+                if [[ $status -ne 86 ]] || ! grep -Fq -- 'candidate ukify failed at [redacted credential path]' "$case_log" ||
+                    grep -Fq -- /run/snosi-ukify-pcr.key "$case_log" || grep -Fq -- 'BEGIN PRIVATE KEY' "$case_log"; then
+                    die "candidate ukify failure status or redaction is incorrect"
+                fi
+                ;;
+            *)
+                [[ $status -ne 0 ]] ||
+                    die "candidate ukify $case_name did not fail closed"
+                ;;
+        esac
+    done
+)
 
 self_test() {
     local work key cert pcr pcr_cert rc=0
@@ -315,6 +490,7 @@ EOF
     openssl pkey -in "$work/pcr.key" -pubout -out "$work/pcr.pub" >/dev/null
     validate_keypair "$work/mok.key" "$work/mok.crt" MOK
     validate_pcr_key "$work/pcr.key" "$work/pcr.pub"
+    candidate_ukify_self_test
     return "$rc"
 }
 

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -565,13 +565,17 @@ EOF
     mkdir "$redaction_work"
     set +e
     (
-        redact_credentials() { return 1; }
+        redact_credentials() {
+            local line
+            while IFS= read -r line || [[ -n $line ]]; do :; done
+            return 73
+        }
         PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-redaction-failure.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
             run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$redaction_work" "$redaction_work/ukify.log" "$key" "$cert" "$pcr" "" -- build
     )
     status=$?
     set -e
-    [[ $status -ne 0 ]] || die "candidate ukify accepted a redaction failure"
+    [[ $status -eq 1 ]] || die "candidate ukify did not map redaction status"
     [[ -f "$top/podman-redaction-failure.args" ]] || die "candidate ukify redaction fixture did not run Podman"
     [[ -f "$redaction_work/ukify.log" ]] || die "candidate ukify redaction fixture did not reach tee"
 

--- a/shared/outformat/image/buildah-package.sh
+++ b/shared/outformat/image/buildah-package.sh
@@ -116,6 +116,7 @@ if [[ ${SNOSI_BOOTC_SECURE:-0} == 1 ]]; then
         bootc container compute-composefs-digest-from-storage "$first_image" | tr -d '\n')
     [[ $digest =~ ^[[:xdigit:]]{128}$ ]] || { echo "Error: unsupported bootc storage-digest interface" >&2; exit 1; }
     SNOSI_BOOTC_SECURE_COMPOSEFS_DIGEST="$digest" SNOSI_BOOTC_SECURE_BOOTC_VERSION=1.16.3 \
+        SNOSI_BOOTC_SECURE_UKIFY_IMAGE="$first_image" \
         SNOSI_BOOTC_PREVIOUS_PCR_KEY="${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-}" \
         "$ASSEMBLER" "$ROOTFS_DIR" \
         "$SNOSI_BOOTC_MOK_KEY" "$SNOSI_BOOTC_MOK_CERT" "$SNOSI_BOOTC_PCR_KEY" "$SNOSI_BOOTC_PCR_CERT" \

--- a/test/bootc-secure-package-cleanup-test.sh
+++ b/test/bootc-secure-package-cleanup-test.sh
@@ -79,6 +79,9 @@ count=0
 [[ ! -f "$count_file" ]] || count=$(<"$count_file")
 count=$((count + 1))
 printf '%s' "$count" >"$count_file"
+if [[ $count -eq 1 ]]; then
+    printf '%s\n' "$@" >"$BUILD_FIXTURE_STATE/podman-first-args"
+fi
 if [[ ${BUILD_FIXTURE_FINAL_PROBE_FAIL:-0} == 1 && $count -eq 2 ]]; then
     exit 86
 fi
@@ -104,6 +107,7 @@ if [[ $1 == --prepare-systemd-boot-source ]]; then
     printf 'immutable-bootloader\n' >"$2/usr/lib/snosi/bootc/systemd-bootx64.efi"
     exit 0
 fi
+printf '%s\n' "${SNOSI_BOOTC_SECURE_UKIFY_IMAGE:-}" >"$BUILD_FIXTURE_STATE/ukify-image"
 touch "$BUILD_FIXTURE_STATE/assembler-invoked"
 mkdir -p "$1/boot/EFI/Linux" "$1/boot/EFI/BOOT"
 printf 'injected-uki\n' >"$1/boot/EFI/Linux/test-kernel.efi"
@@ -115,8 +119,14 @@ EOF
 }
 
 assert_cleanup() { # state root first final published
-    local state=$1 root=$2 first=$3 final=$4 published=$5
+    local state=$1 root=$2 first=$3 final=$4 published=$5 ukify_image
     [[ -f "$state/assembler-invoked" ]] || fail "controlled assembler was not invoked"
+    [[ -f "$state/ukify-image" ]] || fail "assembler did not receive a ukify image"
+    ukify_image=$(<"$state/ukify-image")
+    [[ $ukify_image == localhost/snosi-bootc-secure-first-[0-9]* ]] ||
+        fail "assembler did not receive the exact first-pass ukify image"
+    { [[ -f "$state/podman-first-args" ]] && grep -Fxq -- "$ukify_image" "$state/podman-first-args"; } ||
+        fail "assembler ukify image differs from the first digest candidate"
     [[ -f "$state/mount-invoked" && $(<"$state/mount-invoked") == "--bind /proc $root/proc" ]] || fail "rootfs proc bind was not exact"
     [[ -f "$state/chroot-invoked" && $(<"$state/chroot-invoked") == "$root /usr/bin/bootc --version" ]] || fail "bootc version did not use rootfs chroot"
     [[ -f "$state/umount-invoked" && $(<"$state/umount-invoked") == "$root/proc" ]] || fail "rootfs proc unmount was not exact"

--- a/test/bootc-secure-package-cleanup-test.sh
+++ b/test/bootc-secure-package-cleanup-test.sh
@@ -79,9 +79,7 @@ count=0
 [[ ! -f "$count_file" ]] || count=$(<"$count_file")
 count=$((count + 1))
 printf '%s' "$count" >"$count_file"
-if [[ $count -eq 1 ]]; then
-    printf '%s\n' "$@" >"$BUILD_FIXTURE_STATE/podman-first-args"
-fi
+printf '%s\n' "$@" >"$BUILD_FIXTURE_STATE/podman-$count-args"
 if [[ ${BUILD_FIXTURE_FINAL_PROBE_FAIL:-0} == 1 && $count -eq 2 ]]; then
     exit 86
 fi
@@ -118,21 +116,26 @@ EOF
         "$state/bin/umount" "$state/bin/buildah" "$state/bin/podman" "$state/assembler"
 }
 
-assert_cleanup() { # state root first final published
-    local state=$1 root=$2 first=$3 final=$4 published=$5 ukify_image
+assert_cleanup() { # state root published
+    local state=$1 root=$2 published=$3 ukify_image first final
     [[ -f "$state/assembler-invoked" ]] || fail "controlled assembler was not invoked"
     [[ -f "$state/ukify-image" ]] || fail "assembler did not receive a ukify image"
     ukify_image=$(<"$state/ukify-image")
     [[ $ukify_image == localhost/snosi-bootc-secure-first-[0-9]* ]] ||
         fail "assembler did not receive the exact first-pass ukify image"
-    { [[ -f "$state/podman-first-args" ]] && grep -Fxq -- "$ukify_image" "$state/podman-first-args"; } ||
+    first=$(grep -m1 -E '^localhost/snosi-bootc-secure-first-[0-9]+$' "$state/podman-1-args" || true)
+    final=""
+    [[ ! -f "$state/podman-2-args" ]] || final=$(grep -m1 -E '^localhost/snosi-bootc-secure-final-[0-9]+$' "$state/podman-2-args" || true)
+    [[ -n $first ]] || fail "first probe image was not captured from Podman"
+    [[ ! -f "$state/podman-2-args" || -n $final ]] || fail "final probe image was not captured from Podman"
+    { [[ -f "$state/podman-1-args" ]] && grep -Fxq -- "$ukify_image" "$state/podman-1-args"; } ||
         fail "assembler ukify image differs from the first digest candidate"
     [[ -f "$state/mount-invoked" && $(<"$state/mount-invoked") == "--bind /proc $root/proc" ]] || fail "rootfs proc bind was not exact"
     [[ -f "$state/chroot-invoked" && $(<"$state/chroot-invoked") == "$root /usr/bin/bootc --version" ]] || fail "bootc version did not use rootfs chroot"
     [[ -f "$state/umount-invoked" && $(<"$state/umount-invoked") == "$root/proc" ]] || fail "rootfs proc unmount was not exact"
     [[ ! -e "$state/proc-mounted" ]] || fail "rootfs proc mount survived"
     [[ ! -e "$state/images/$(image_path "$first")" ]] || fail "first probe image survived"
-    [[ ! -e "$state/images/$(image_path "$final")" ]] || fail "final probe image survived"
+    [[ -z $final || ! -e "$state/images/$(image_path "$final")" ]] || fail "final probe image survived"
     [[ ! -e "$state/images/$(image_path "$published")" ]] || fail "published image survived"
     [[ ! -e "$root/boot/EFI/Linux/test-kernel.efi" ]] || fail "Task 5 UKI residue survived"
     [[ ! -e "$root/boot/EFI/BOOT/grubx64.efi" ]] || fail "Task 5 bootloader residue survived"
@@ -142,12 +145,10 @@ assert_cleanup() { # state root first final published
 }
 
 run_case() { # name assembler-fails|final-probe-fails|published-digest-mismatch
-    local name=$1 work state root first final published status
+    local name=$1 work state root published status
     work=$(mktemp -d)
     trap 'rm -rf -- "$work"' RETURN
     state="$work/state"; root="$work/root"
-    first="localhost/snosi-bootc-secure-first-$$"
-    final="localhost/snosi-bootc-secure-final-$$"
     published="localhost/task5-cleanup-$name:latest"
     write_fixtures "$state" "$root"
     set +e
@@ -162,7 +163,7 @@ run_case() { # name assembler-fails|final-probe-fails|published-digest-mismatch
     status=$?
     set -e
     [[ $status -ne 0 ]] || fail "$name unexpectedly succeeded"
-    assert_cleanup "$state" "$root" "$first" "$final" "$published"
+    assert_cleanup "$state" "$root" "$published"
 
     # A fresh secure invocation must not be blocked by leftovers from the failure.
     set +e

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -73,7 +73,13 @@ fail-closed maintained compatibility contract, not
 an upstream interface; see `docs/bootc-secure-assembly-compatibility.md` for
 the mandatory revalidation triggers. Private keys remain caller-owned and must
 not enter this fragment, its tree, OCI layers, labels, logs, or retained temp
-state. Native A/B profiles do not include it and continue using
+state. Direct ukify runs as `/usr/bin/ukify` in the first-pass candidate with
+`--network=none`, `--security-opt label=type:unconfined_t`, and a fixed
+entrypoint. The assembler translates rootfs kernel/initrd paths to candidate
+paths, mounts each caller credential read-only at fixed `/run/snosi-ukify-*`
+paths, and gives it exactly one writable `/run/snosi-ukify-work` mount. The
+work directory is scanned for caller credentials both before and after candidate
+execution, so it carries only public inputs and output. Native A/B profiles do not include it and continue using
 `shared/native-ab-secure/` independently.
 
 **Bootc shim second-stage reconciliation (Task 7):** the secure tree ships

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -79,8 +79,8 @@ entrypoint. The assembler translates rootfs kernel/initrd paths to candidate
 paths, mounts each caller credential read-only at fixed `/run/snosi-ukify-*`
 paths, and gives it exactly one writable `/run/snosi-ukify-work` mount. The
 work directory is scanned for caller credentials both before and after candidate
-execution, so it carries only public inputs and output. Native A/B profiles do not include it and continue using
-`shared/native-ab-secure/` independently.
+execution, so it carries only public inputs and output. Native A/B profiles do
+not include it and continue using `shared/native-ab-secure/` independently.
 
 **Bootc shim second-stage reconciliation (Task 7):** the secure tree ships
 `snosi-bootc-bootloader-reconcile.service` with a static

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -74,13 +74,16 @@ an upstream interface; see `docs/bootc-secure-assembly-compatibility.md` for
 the mandatory revalidation triggers. Private keys remain caller-owned and must
 not enter this fragment, its tree, OCI layers, labels, logs, or retained temp
 state. Direct ukify runs as `/usr/bin/ukify` in the first-pass candidate with
-`--network=none`, `--security-opt label=type:unconfined_t`, and a fixed
-entrypoint. The assembler translates rootfs kernel/initrd paths to candidate
-paths, mounts each caller credential read-only at fixed `/run/snosi-ukify-*`
+`--network=none`, `--cap-drop=all`, `--security-opt label=type:unconfined_t`,
+and a fixed entrypoint. The assembler resolves and translates in-root
+kernel/initrd paths to candidate paths, mounts each caller credential read-only
+at fixed `/run/snosi-ukify-*`
 paths, and gives it exactly one writable `/run/snosi-ukify-work` mount. The
 work directory is scanned for caller credentials both before and after candidate
-execution, so it carries only public inputs and output. Native A/B profiles do
-not include it and continue using `shared/native-ab-secure/` independently.
+execution, so it carries only public inputs and output. The authoritative active
+and optional previous PCR public identities stay in the unmounted gate directory;
+the work copies must match them after candidate execution. Native A/B profiles
+do not include it and continue using `shared/native-ab-secure/` independently.
 
 **Bootc shim second-stage reconciliation (Task 7):** the secure tree ships
 `snosi-bootc-bootloader-reconcile.service` with a static


### PR DESCRIPTION
## Summary
- pass the exact pristine first-pass OCI candidate from the secure packager to the UKI assembler
- run pinned `/usr/bin/ukify` inside that candidate with no network, no Linux capabilities, individual read-only credentials, and one public writable work mount
- preserve protected PCR identities outside the candidate, fail closed on path/status/output mutations, and strengthen cleanup/redaction fixtures
- document the pinned candidate-ukify compatibility and security boundary

## Testing
- `test/bootc-secure-artifact-test.sh --fixtures`
- `test/bootc-secure-artifact-negative-test.sh --fixtures`
- `test/bootc-secure-package-cleanup-test.sh`
- `test/bootc-publication-guard-test.sh` (29/29)
- `./check-bootc-publication-guard.sh`
- `shellcheck shared/bootc-secure/assemble-uki.sh shared/outformat/image/buildah-package.sh test/bootc-secure-package-cleanup-test.sh`
- `git diff --check origin/main..HEAD`

## Evidence Boundary
The protected three-profile build remains the live compatibility proof that Forky `systemd-ukify 261.1-3` completes signing inside real Cayo, Snow, and Snowfield first-pass candidates. A successful build is one candidate set, not distinct update-window evidence.