### PR TITLE
feat: add k3s sysext

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -89,6 +89,19 @@ jobs:
             echo "coder_version=$LATEST_CODER" >> $GITHUB_OUTPUT
           fi
 
+          # Check k3s — track the upstream *stable* channel (update.k3s.io),
+          # not GitHub "latest": k3s promotes new minor releases to latest
+          # before they reach the stable channel. The channel URL redirects to
+          # the release tag; normalize the tag ("v1.36.2+k3s1", '+' sometimes
+          # arriving percent-encoded) to the pinned version form.
+          CURRENT_K3S=$(jq -r '.k3s.version' "$CHECKSUMS")
+          LATEST_K3S=$(curl -fsSL --retry 3 --retry-delay 2 -o /dev/null -w '%{url_effective}' https://update.k3s.io/v1-release/channels/stable | sed -e 's|.*/tag/||' -e 's/%2B/+/' -e 's/^v//' || true)
+          if [[ -n "$LATEST_K3S" ]] && ver_gt "$LATEST_K3S" "$CURRENT_K3S"; then
+            UPDATES="${UPDATES}k3s: $CURRENT_K3S -> $LATEST_K3S\n"
+            echo "k3s_update=true" >> "$GITHUB_OUTPUT"
+            echo "k3s_version=$LATEST_K3S" >> "$GITHUB_OUTPUT"
+          fi
+
           # Check Lemonade Server
           CURRENT_LEM=$(jq -r '.lemonade.version' "$CHECKSUMS")
           LATEST_LEM=$(gh_api https://api.github.com/repos/lemonade-sdk/lemonade/releases/latest | jq -r '.tag_name' | sed 's/^v//')
@@ -166,6 +179,8 @@ jobs:
           CODESERVER_VERSION: ${{ steps.check.outputs.codeserver_version }}
           CODER_UPDATE: ${{ steps.check.outputs.coder_update }}
           CODER_VERSION: ${{ steps.check.outputs.coder_version }}
+          K3S_UPDATE: ${{ steps.check.outputs.k3s_update }}
+          K3S_VERSION: ${{ steps.check.outputs.k3s_version }}
           LEMONADE_UPDATE: ${{ steps.check.outputs.lemonade_update }}
           LEMONADE_VERSION: ${{ steps.check.outputs.lemonade_version }}
           PASEO_UPDATE: ${{ steps.check.outputs.paseo_update }}
@@ -227,6 +242,22 @@ jobs:
               '.coder.url=$u | .coder.sha256=$s | .coder.version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
+          fi
+
+          if [[ "$K3S_UPDATE" == "true" ]]; then
+            VER="$K3S_VERSION"
+            # '+' must be percent-encoded in the release-asset URL path
+            TAG="v${VER/+/%2B}"
+            URL="https://github.com/k3s-io/k3s/releases/download/${TAG}/k3s"
+            # k3s publishes official per-release checksums; pin from those
+            # instead of hashing our own download so a tampered transfer at
+            # update time cannot become the pinned truth.
+            SHA=$(curl -fsSL "https://github.com/k3s-io/k3s/releases/download/${TAG}/sha256sum-amd64.txt" | awk '$2 == "k3s" {print $1}')
+            # the official checksum file must list the bare k3s binary
+            [[ -n "$SHA" ]]
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.k3s.url=$u | .k3s.sha256=$s | .k3s.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
           fi
 
           if [[ "$LEMONADE_UPDATE" == "true" ]]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 20 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode).
+**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 21 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 20 sysexts
+just sysexts            # Build base + all 21 sysexts
 just snow               # Build snow desktop image
 just snowfield          # Build snowfield (Surface kernel)
 just cayo               # Build cayo server image
@@ -531,7 +531,7 @@ persistence.
 builds two real `cayo-ab-raw` versions itself, boots N, and asserts no failed
 systemd units and the bootc/nbc/systemd-sysupdate masks from above; that
 `/usr/lib/sysupdate.d/` contains only the three OS transfers (no `.feature`
-files) while `systemd-sysupdate components` enumerates all 20 shipped sysext
+files) while `systemd-sysupdate components` enumerates all 21 shipped sysext
 components; that two independently versioned ad hoc test components
 (`testa`/`testb`, created under `/etc/sysupdate.<name>.d/`) update via
 `--component=` without touching OS partitions, the ESP, or each other's

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The project produces:
 | **edge**            | Microsoft Edge browser                                          | sysext        |
 | **github-copilot**  | GitHub Copilot agent-native desktop application                 | sysext        |
 | **incus**           | Incus container/VM manager                                      | sysext        |
+| **k3s**             | k3s lightweight Kubernetes node (server or agent)               | sysext        |
 | **lemonade**        | Lemonade local LLM server (GPU/NPU accelerated)                 | sysext        |
 | **nix**             | Nix package manager                                             | sysext        |
 | **paseo**           | Paseo coding agent workspace desktop application                | sysext        |
@@ -204,7 +205,7 @@ sudo test/native-ab-update-test.sh \
              sysexts                         profiles
     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
     │    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
-  1password 1password-cli azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge github-copilot incus lemonade nix paseo pilothouse podman tailscale vscode
+  1password 1password-cli azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge github-copilot incus k3s lemonade nix paseo pilothouse podman tailscale vscode
                                      snow            cayo
                                       │
                                   snowfield
@@ -568,7 +569,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode)
+1. Builds the base image and all sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode)
 2. Publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Uploads package manifests for version tracking
 

--- a/check-profile-dependencies.sh
+++ b/check-profile-dependencies.sh
@@ -18,6 +18,7 @@ sysexts=(
     edge
     github-copilot
     incus
+    k3s
     lemonade
     nix
     paseo

--- a/docs/native-ab-contracts.md
+++ b/docs/native-ab-contracts.md
@@ -175,7 +175,7 @@ Every independently versioned sysext lives in its own named component:
 Component name = sysext name. Admin overrides live at
 `/etc/sysupdate.<name>.d/<name>.feature.d/*.conf`.
 
-All 20 sysext transfer/feature pairs ship in component-scoped
+All 21 sysext transfer/feature pairs ship in component-scoped
 `/usr/lib/sysupdate.<name>.d/` directories under
 `mkosi.images/base/mkosi.extra/`. `/usr/lib/sysupdate.d/` is reserved for the
 three OS transfers above; sysext pairs must never be added there.

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -14,6 +14,7 @@ Dependencies=base
              edge
              github-copilot
              incus
+             k3s
              lemonade
              nix
              paseo

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.k3s.d/k3s.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.k3s.d/k3s.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=k3s lightweight Kubernetes node (server or agent)
+Documentation=https://docs.k3s.io
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.k3s.d/k3s.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.k3s.d/k3s.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=k3s
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/k3s/
+MatchPattern=k3s_@v_%w_%a.raw.zst \
+             k3s_@v_%w_%a.raw.xz \
+             k3s_@v_%w_%a.raw.gz \
+             k3s_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=k3s_@v_%w_%a.raw.zst \
+             k3s_@v_%w_%a.raw.xz \
+             k3s_@v_%w_%a.raw.gz \
+             k3s_@v_%w_%a.raw
+CurrentSymlink=k3s.raw

--- a/mkosi.images/k3s/mkosi.conf
+++ b/mkosi.images/k3s/mkosi.conf
@@ -1,0 +1,23 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=k3s
+Output=k3s
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+
+[Build]
+# k3s ships as a single static binary from GitHub releases (no apt repo, no
+# deb). mkosi.postinst.chroot downloads it via verified_download and registers
+# it with dpkg through a locally built stub deb so the shared postoutput
+# script can resolve KEYPACKAGE/version from the merged dpkg database, same
+# as every other sysext.
+Environment=KEYPACKAGE=k3s

--- a/mkosi.images/k3s/mkosi.extra/usr/lib/systemd/system-preset/40-k3s.preset
+++ b/mkosi.images/k3s/mkosi.extra/usr/lib/systemd/system-preset/40-k3s.preset
@@ -1,0 +1,7 @@
+# Both units are preset-enabled; their Conditions select the role at start
+# time (server unless /etc/default/k3s-agent exists, agent when it does), so
+# exactly one of the two ever runs on a given node. Merging the sysext on a
+# fresh node therefore starts a standalone k3s server, matching upstream's
+# curl|sh installer behavior.
+enable k3s.service
+enable k3s-agent.service

--- a/mkosi.images/k3s/mkosi.extra/usr/lib/systemd/system/k3s-agent.service
+++ b/mkosi.images/k3s/mkosi.extra/usr/lib/systemd/system/k3s-agent.service
@@ -1,0 +1,30 @@
+# Agent (worker-node) counterpart of k3s.service. Inert until the admin
+# creates /etc/default/k3s-agent with at least K3S_URL= and K3S_TOKEN=
+# (K3S_TOKEN_FILE= also works) — the same file's existence stops
+# k3s.service, so writing it is the single switch that turns this node
+# from a standalone server into an agent joining an existing cluster.
+[Unit]
+Description=Lightweight Kubernetes (k3s agent)
+Documentation=https://docs.k3s.io
+Wants=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/etc/default/k3s-agent
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/default/k3s-agent
+KillMode=process
+Delegate=yes
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Restart=always
+RestartSec=5s
+ExecStartPre=-/sbin/modprobe br_netfilter
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/bin/k3s agent
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi.images/k3s/mkosi.extra/usr/lib/systemd/system/k3s.service
+++ b/mkosi.images/k3s/mkosi.extra/usr/lib/systemd/system/k3s.service
@@ -1,0 +1,32 @@
+# Adapted from the unit the upstream k3s installer generates, with the
+# binary at /usr/bin/k3s (sysexts ship only /usr) and snosi's declarative
+# role selection: this node runs as a server unless the admin creates
+# /etc/default/k3s-agent, which hands the node to k3s-agent.service instead
+# (see 40-k3s.preset). Server configuration goes in the natively-read
+# /etc/rancher/k3s/config.yaml or /etc/default/k3s (both persist in the
+# /etc overlay); state lives under /var/lib/rancher.
+[Unit]
+Description=Lightweight Kubernetes (k3s server)
+Documentation=https://docs.k3s.io
+Wants=network-online.target
+After=network-online.target
+ConditionPathExists=!/etc/default/k3s-agent
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/default/k3s
+KillMode=process
+Delegate=yes
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Restart=always
+RestartSec=5s
+ExecStartPre=-/sbin/modprobe br_netfilter
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/bin/k3s server
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi.images/k3s/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-k3s.conf
+++ b/mkosi.images/k3s/mkosi.extra/usr/lib/systemd/system/multi-user.target.d/10-k3s.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=k3s.service k3s-agent.service

--- a/mkosi.images/k3s/mkosi.postinst.chroot
+++ b/mkosi.images/k3s/mkosi.postinst.chroot
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+# shellcheck disable=SC1091
+source "$SRCDIR/shared/download/verified-download.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+verified_download "k3s" "$WORK/k3s"
+
+# k3s is a bare static binary, not a deb. The shared postoutput script
+# resolves the sysext version from the merged dpkg database (KEYPACKAGE), so
+# build a minimal deb around the verified binary and install it — dpkg then
+# tracks /usr/bin/k3s and carries the pinned upstream version. The version
+# comes from the same sysext-checksums.json entry that pinned the download.
+VERSION=$(jq -r '.k3s.version' "$SRCDIR/shared/download/sysext-checksums.json")
+VERSION="${VERSION#v}"
+
+mkdir -p "$WORK/pkg/DEBIAN" "$WORK/pkg/usr/bin"
+install -m 0755 "$WORK/k3s" "$WORK/pkg/usr/bin/k3s"
+cat > "$WORK/pkg/DEBIAN/control" <<EOF
+Package: k3s
+Version: $VERSION
+Section: admin
+Priority: optional
+Architecture: amd64
+Maintainer: Frostyard <noreply@frostyard.org>
+Homepage: https://k3s.io
+Description: Lightweight Kubernetes
+ Single-binary Kubernetes distribution from the CNCF k3s project, packaged
+ locally by the snosi sysext build from the pinned upstream release binary.
+EOF
+# -Znone: the payload is one already-compressed-ish 80+ MiB Go binary and the
+# deb is a build-local intermediate that dpkg extracts immediately; the sysext
+# erofs output is what actually gets compressed for publishing.
+dpkg-deb --build --root-owner-group -Znone "$WORK/pkg" "$WORK/k3s.deb"
+dpkg -i "$WORK/k3s.deb"
+
+# Multicall entry points, same set the upstream installer creates minus ctr:
+# the docker sysext's containerd.io already ships a real /usr/bin/ctr, and two
+# merged sysexts claiming the same path would shadow each other — use
+# `k3s ctr` instead. Relative symlinks so they resolve inside the buildroot,
+# the sysext overlay, and the merged root alike.
+ln -sf k3s /usr/bin/kubectl
+ln -sf k3s /usr/bin/crictl

--- a/mkosi.images/k3s/required-paths.txt
+++ b/mkosi.images/k3s/required-paths.txt
@@ -1,0 +1,8 @@
+# k3s sysext: static binary installed via verified_download + local stub deb
+/usr/bin/k3s
+/usr/bin/kubectl
+/usr/bin/crictl
+/usr/lib/systemd/system/k3s.service
+/usr/lib/systemd/system/k3s-agent.service
+/usr/lib/systemd/system-preset/40-k3s.preset
+/usr/lib/systemd/system/multi-user.target.d/10-k3s.conf

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -34,6 +34,11 @@
     "sha256": "df80379b8e624eaf751c33758534f111bed7faf09b8d988e59ac7e0ab3dc9ff4",
     "version": "1.1.2"
   },
+  "k3s": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.2%2Bk3s1/k3s",
+    "sha256": "65a55ec56c24eab44383086166ec620a491952b7e23941a49ddca6e8a4c4b4de",
+    "version": "1.36.2+k3s1"
+  },
   "lemonade": {
     "url": "https://github.com/lemonade-sdk/lemonade/releases/download/v11.5.0/lemonade-server_11.5.0-debian13_amd64.deb",
     "sha256": "cd7448b1b577815a75b4596a9611d29a37db737c036dd9bc9b18d258ddd4204e",

--- a/test/native-ab-components-test.sh
+++ b/test/native-ab-components-test.sh
@@ -15,7 +15,7 @@
 # in QEMU, and validates in order:
 #
 #   1. No failed legacy updaters; bootc/nbc/sysupdate auto-update units masked.
-#   2. The OS default sysupdate.d target and the 20 shipped sysext components
+#   2. The OS default sysupdate.d target and the 21 shipped sysext components
 #      are structurally separate (component discovery via `systemd-sysupdate
 #      components`).
 #   3. Two ad hoc test sysext components (testa, testb; independently
@@ -525,8 +525,8 @@ assert_eq "/usr/lib/sysupdate.d/ contains exactly the OS transfers, no features"
     "$default_target_listing" "$expected_default_listing"
 
 expected_sysext_components=(1password 1password-cli azurevpn bitwarden claude-desktop
-    code-server coder debdev dev docker edge github-copilot incus lemonade nix paseo
-    pilothouse podman tailscale vscode)
+    code-server coder debdev dev docker edge github-copilot incus k3s lemonade nix
+    paseo pilothouse podman tailscale vscode)
 
 components_raw="$(vm_ssh '/usr/lib/systemd/systemd-sysupdate components --no-legend')"
 echo "systemd-sysupdate components --no-legend:"

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1007,7 +1007,7 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
-1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode
+1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode
 
 ## Architecture
 
@@ -1017,10 +1017,10 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 20 sysexts)
+mkosi.images/               # Image definitions (base + 21 sysexts)
   base/                     # Foundation image: systemd, bootc/ostree (frostyard debs), firmware, core utils
     mkosi.extra/            # Base filesystem overlay (dracut, systemd units/timers, sysupdate, tmpfiles, sysusers)
-      usr/lib/sysupdate.<name>.d/  # per-sysext .transfer + .feature component dirs (one pair each, 20 total)
+      usr/lib/sysupdate.<name>.d/  # per-sysext .transfer + .feature component dirs (one pair each, 21 total)
     mkosi.postinst.chroot   # Mount enablement, useradd home dir, bls-garbage-collect removal
     mkosi.finalize.chroot   # Masks systemd-networkd-wait-online
   docker/                   # Each sysext: mkosi.conf + optional extra/scripts
@@ -1315,7 +1315,7 @@ Use build-time enablement/presets for desired service state. For run-once runtim
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 20 sysexts
+just sysexts            # Build base + all 21 sysexts
 just snow               # Build snow desktop
 just snowfield          # Build snowfield (Surface)
 just cayo               # Build cayo server

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -8,7 +8,7 @@
 `shared/download/image-checksums.json` when that is the only changed path;
 image-only direct-download updates should rebuild OCI profiles instead.
 
-Builds the base image and all 20 sysexts, publishes to the Frostyard repository on Cloudflare R2.
+Builds the base image and all 21 sysexts, publishes to the Frostyard repository on Cloudflare R2.
 
 **Steps:**
 1. Aggressive cleanup of runner (removes JDK, .NET, Android SDK, etc. to free disk space)

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -30,6 +30,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **edge** | microsoft-edge-stable | Microsoft Edge browser (pinned .deb via verified_download, relocated from /opt) |
 | **github-copilot** | github | GitHub Copilot desktop app (official pinned .deb via verified_download; Tauri; native /usr layout) |
 | **incus** | incus | Incus container/VM manager, QEMU/KVM, dnsmasq, OVMF, virt-viewer |
+| **k3s** | k3s | k3s lightweight Kubernetes node — pinned static binary via `verified_download()` from k3s-io/k3s GitHub releases, dpkg-registered through a build-local stub deb |
 | **lemonade** | lemonade-server | Lemonade local LLM server (lemond) — downloaded via `verified_download()` from lemonade-sdk/lemonade GitHub releases; libcpp-httplib0.41 dep from trixie-backports |
 | **nix** | nix-setup-systemd | Nix package manager with systemd integration |
 | **paseo** | paseo | Paseo coding agent workspace desktop app (pinned .deb via verified_download from getpaseo/paseo GitHub releases, relocated from /opt) |
@@ -195,6 +196,13 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `usr/lib/incus/incus-sysext-setup` — The setup script the service runs
 - `usr/lib/sysusers.d/{dnsmasq,rdma}.conf` — User/group definitions
 - `usr/lib/tmpfiles.d/incus.conf` — Factory config injection + runtime dirs + xz alternatives links
+
+### k3s
+- `mkosi.postinst.chroot` — Downloads the pinned k3s static binary (bare binary on k3s-io/k3s GitHub releases, no deb/apt repo) via `verified_download()`, then builds a minimal stub deb around it (`dpkg-deb -Znone`, version read from the same `sysext-checksums.json` entry) and installs with `dpkg -i` so the shared postoutput script can resolve `KEYPACKAGE=k3s` from the merged dpkg database like every other sysext. The pinned sha256 is upstream's own published `sha256sum-amd64.txt` value, and the URL percent-encodes the `+` in the release tag (`v1.36.2%2Bk3s1`)
+- Multicall symlinks `kubectl` and `crictl` -> `k3s` (relative, so they resolve in buildroot and merged root alike). Deliberately NO `ctr` symlink: docker's containerd.io ships a real `/usr/bin/ctr`, and two merged sysexts claiming one path shadow each other — use `k3s ctr`
+- `usr/lib/systemd/system/k3s.service` / `k3s-agent.service` — adapted from the upstream installer's generated units (`/usr/bin/k3s`, `Type=notify`, `Delegate=yes`, modprobe br_netfilter/overlay). Declarative role selection: both are preset-enabled and upheld, but `k3s.service` has `ConditionPathExists=!/etc/default/k3s-agent` while `k3s-agent.service` has `ConditionFileNotEmpty=/etc/default/k3s-agent` — a fresh node runs a standalone server (matching upstream curl|sh behavior); writing `/etc/default/k3s-agent` (K3S_URL= + K3S_TOKEN=) is the single switch that turns the node into an agent
+- No `/etc` factory capture or tmpfiles needed: k3s reads `/etc/rancher/k3s/config.yaml` and `/etc/default/k3s{,-agent}` (admin-written, persistent `/etc` overlay) and keeps all state under persistent `/var/lib/rancher`
+- Dependency check tracks the upstream *stable* channel (`update.k3s.io/v1-release/channels/stable`), not GitHub "latest" (new minors reach latest before stable)
 
 ### lemonade
 - `mkosi.postinst.chroot` — Downloads the lemonade-server .deb (GitHub release, no apt repo) via `verified_download()`, installs with `dpkg -i`. Everything ships natively under `/usr`; no relocation

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -371,7 +371,7 @@ install: `/var/lib/dpkg` is a symlink to `../../usr/lib/sysimage/dpkg`,
 `usr/share/snosi/var-inventory.txt` exists with at least one
 `image-metadata` line, and no unit failures were introduced; (2)
 `/usr/lib/sysupdate.d/` contains only the three OS transfers (no `.feature`
-files) and `systemd-sysupdate components` enumerates all 20 shipped sysext
+files) and `systemd-sysupdate components` enumerates all 21 shipped sysext
 components; (3) two ad hoc test components (`testa`, `testb`, independently
 versioned) created under `/etc/sysupdate.<name>.d/` update independently via
 `--component=`, leave the GPT partition table and ESP `/EFI/Linux` listing


### PR DESCRIPTION
## Summary

Adds **k3s** (lightweight Kubernetes) as the 21st sysext, pinned to the upstream **stable** channel (`v1.36.2+k3s1`).

- **Stub-deb registration**: k3s ships as a bare static binary (no deb, no apt repo), so `mkosi.postinst.chroot` wraps the `verified_download()`-pinned binary in a minimal build-local deb and installs it with `dpkg -i` — the shared postoutput then resolves `KEYPACKAGE=k3s` from the merged dpkg database like every other sysext. The pinned sha256 is upstream's own published `sha256sum-amd64.txt` value.
- **Declarative role selection**: `k3s.service` (server) and `k3s-agent.service` are both preset-enabled and upheld, with mirrored Conditions on `/etc/default/k3s-agent`. A fresh node runs a standalone server (matching upstream's `curl | sh` behavior); writing that file with `K3S_URL=`/`K3S_TOKEN=` is the single switch that turns the node into an agent. Config uses k3s's natively-read `/etc/rancher/k3s/config.yaml` (persistent `/etc` overlay); state lives under `/var/lib/rancher`.
- **Multicall symlinks**: `kubectl` and `crictl` (relative). `ctr` is deliberately omitted — docker's containerd.io ships a real `/usr/bin/ctr`, and two merged sysexts claiming one path would shadow each other; `k3s ctr` covers it.
- **Dependency check**: the weekly `check-dependencies.yml` follows `update.k3s.io/v1-release/channels/stable` rather than GitHub "latest" (new minors reach latest before stable) and pins new checksums from upstream's published sums instead of hashing its own download.
- **Wiring**: `sysupdate.k3s.d/` component (`Enabled=false`, all products), root `mkosi.conf` dependency, `check-profile-dependencies.sh`, components-test expected list, and doc updates (CLAUDE.md, README, yeti, native-ab contracts count).

## Test plan

- [x] Real `base` + `k3s` mkosi build passes: all 7 required paths present, postoutput resolves `1.36.2+k3s1`, artifact `k3s_1.36.2+k3s1_13_x86-64.raw` produced
- [x] Dissect-mounted artifact contains only `/usr`: the binary, relative `kubectl`/`crictl` symlinks, both units, preset, Upholds drop-in, correct Debian 13 extension-release
- [x] Downloaded binary's sha256 matches upstream's official `sha256sum-amd64.txt`
- [x] shellcheck clean; JSON valid; `mkosi summary` resolves the image with the correct script set
- [x] Stub-deb build + version comparison (`dpkg --compare-versions`) smoke-tested with the real binary
- [ ] CI `build.yml` publish path (glob-based `sysextmv.sh`/`manifestmv.sh` — no workflow change needed; `+` in versions already proven by incus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)