### PR TITLE
fix: run candidate ukify as credential owner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,9 @@ public-only writable work mount. The candidate supplies pinned systemd-ukify
 261.1-3 and its dependencies; no host ukify is accepted. The disposable
 container and mounts never enter a layer. Host `.linux`/`.initrd` byte checks
 remain valid because first-pass packaging is a byte-identical `cp -a` snapshot.
-Candidate execution drops all Linux capabilities. The active and optional
-Candidate ukify runs as the common numeric owner of its mode-0600 credential files; it never adds read-bypass capabilities.
+Candidate execution drops all Linux capabilities and runs as the common numeric
+owner of its mode-0600 credential files; it never adds read-bypass capabilities.
+The active and optional
 previous PCR public identities remain in the unmounted assembler gate directory;
 only copies enter the writable work mount and must compare byte-for-byte with
 the protected identities after execution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ public-only writable work mount. The candidate supplies pinned systemd-ukify
 container and mounts never enter a layer. Host `.linux`/`.initrd` byte checks
 remain valid because first-pass packaging is a byte-identical `cp -a` snapshot.
 Candidate execution drops all Linux capabilities. The active and optional
+Candidate ukify runs as the common numeric owner of its mode-0600 credential files; it never adds read-bypass capabilities.
 previous PCR public identities remain in the unmounted assembler gate directory;
 only copies enter the writable work mount and must compare byte-for-byte with
 the protected identities after execution.

--- a/README.md
+++ b/README.md
@@ -451,8 +451,9 @@ dependencies therefore come from the candidate, never the host; the disposable
 container and mounts do not enter a layer. Host `.linux` and `.initrd` byte
 checks remain valid because first-pass packaging is a byte-identical `cp -a`
 snapshot.
-The candidate also runs with all Linux capabilities dropped. Protected active
-It runs as the common numeric credential owner, retaining mode-0600 credentials without capabilities.
+The candidate runs with all Linux capabilities dropped as the common numeric
+credential owner, retaining mode-0600 credentials without capabilities.
+Protected active
 and optional previous PCR public identities remain outside the writable mount;
 the copied public inputs are checked against those identities after execution.
 This is not production Secure Boot support: published `latest` images inspected

--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ container and mounts do not enter a layer. Host `.linux` and `.initrd` byte
 checks remain valid because first-pass packaging is a byte-identical `cp -a`
 snapshot.
 The candidate also runs with all Linux capabilities dropped. Protected active
+It runs as the common numeric credential owner, retaining mode-0600 credentials without capabilities.
 and optional previous PCR public identities remain outside the writable mount;
 the copied public inputs are checked against those identities after execution.
 This is not production Secure Boot support: published `latest` images inspected

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -23,7 +23,8 @@ The adapter relies on all of the following observed behavior:
    storage-digest authority.
 7. Final host byte comparisons depend on first-pass `cp -a` identity.
 8. Candidate ukify runs with network disabled and all Linux capabilities dropped.
-   It runs as the common numeric owner of its mode-0600 credentials; mismatches fail before Podman.
+   It runs as the common numeric owner of its mode-0600 credentials; mismatches
+   fail before Podman.
    Its authoritative active and optional previous PCR public identities remain
    outside the writable work mount; exposed copies must match after execution.
 

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -23,6 +23,7 @@ The adapter relies on all of the following observed behavior:
    storage-digest authority.
 7. Final host byte comparisons depend on first-pass `cp -a` identity.
 8. Candidate ukify runs with network disabled and all Linux capabilities dropped.
+   It runs as the common numeric owner of its mode-0600 credentials; mismatches fail before Podman.
    Its authoritative active and optional previous PCR public identities remain
    outside the writable work mount; exposed copies must match after execution.
 

--- a/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
+++ b/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
@@ -85,7 +85,8 @@ Use `--security-opt label=type:unconfined_t`, matching existing candidate-image
 storage probes, rather than `:z`/`:Z` bind suffixes that mutate host labels.
 Use `--network=none` and `--cap-drop=all`; ukify requires neither network nor
 Linux capabilities.
-It runs as the common numeric owner of every mode-0600 credential mount; owner mismatches fail before Podman.
+It runs as the common numeric owner of every mode-0600 credential mount; owner
+mismatches fail before Podman.
 
 The writable work directory is public-output-only by invariant. Before exposing
 it to the container, run the existing caller-credential gate over the directory

--- a/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
+++ b/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
@@ -85,6 +85,7 @@ Use `--security-opt label=type:unconfined_t`, matching existing candidate-image
 storage probes, rather than `:z`/`:Z` bind suffixes that mutate host labels.
 Use `--network=none` and `--cap-drop=all`; ukify requires neither network nor
 Linux capabilities.
+It runs as the common numeric owner of every mode-0600 credential mount; owner mismatches fail before Podman.
 
 The writable work directory is public-output-only by invariant. Before exposing
 it to the container, run the existing caller-credential gate over the directory

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -462,6 +462,7 @@ if [[ ${1:-} == --volume ]]; then
 fi
 [[ ${1:-} == localhost/snosi-bootc-secure-first-fixture ]] || exit 91
 [[ -n ${host_work:-} ]] || exit 88
+[[ $(/usr/bin/stat -c '%u:%g' "$host_work") == "$(id -u):$(id -g)" ]] || exit 92
 if [[ ${CANDIDATE_UKIFY_TEST_PODMAN_UNAVAILABLE:-0} == 1 ]]; then
     echo 'candidate ukify image is unavailable' >&2
     exit 127

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -231,11 +231,12 @@ sign_systemd_boot() { # rootfs mok-cert
 }
 
 common_credential_owner() { # credential [credential...]
-    local owner file
+    local owner file file_owner
     owner=$(stat -c '%u:%g' "$1") || die "cannot stat candidate credential"
     for file in "$@"; do
         [[ -n $file ]] || continue
-        [[ $(stat -c '%u:%g' "$file") == "$owner" ]] || die "candidate credential owners differ"
+        file_owner=$(stat -c '%u:%g' "$file") || die "cannot stat candidate credential"
+        [[ $file_owner == "$owner" ]] || die "candidate credential owners differ"
     done
     printf '%s\n' "$owner"
 }
@@ -247,7 +248,9 @@ run_candidate_ukify() { # image work log mok-key mok-cert pcr-key previous-key -
     shift 7
     [[ ${1:-} == -- ]] || die "candidate ukify argument separator is missing"
     shift
-    owner=$(common_credential_owner "$mok_key" "$mok_cert" "$pcr_key" "$previous_key")
+    if ! owner=$(common_credential_owner "$mok_key" "$mok_cert" "$pcr_key" "$previous_key"); then
+        die "candidate credential owner validation failed"
+    fi
     chown "$owner" "$work" || die "cannot set candidate ukify work owner"
 
     podman_args=(run --rm --network=none --cap-drop=all --user "$owner"
@@ -488,6 +491,23 @@ printf 'safe diagnostic; key path %s\n' /run/snosi-ukify-pcr.key >&2
 cat "$CANDIDATE_UKIFY_TEST_PRIVATE_KEY" >&2
 EOF
     chmod +x "$top/bin/podman"
+    local mismatch_work="$top/work-owner-mismatch" mismatch_output mismatch_owner
+    mkdir "$mismatch_work"
+    mismatch_owner=$(/usr/bin/stat -c '%u:%g' "$mismatch_work")
+    set +e
+    mismatch_output=$(PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_MISMATCH="$pcr" \
+        CANDIDATE_UKIFY_TEST_ARGS="$top/podman-owner-mismatch.args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
+        run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$mismatch_work" \
+        "$mismatch_work/ukify.log" "$key" "$cert" "$pcr" "" -- build 2>&1)
+    status=$?
+    set -e
+    [[ $status -ne 0 ]] || die "candidate unequal credential owners reached Podman"
+    grep -Fq -- 'candidate credential owner validation failed' <<<"$mismatch_output" ||
+        die "candidate unequal credential owners lacked validation diagnostic"
+    [[ $(/usr/bin/stat -c '%u:%g' "$mismatch_work") == "$mismatch_owner" ]] ||
+        die "candidate unequal credential owners changed work ownership"
+    [[ ! -e "$top/podman-owner-mismatch.args" ]] ||
+        die "candidate unequal credential owners invoked Podman"
     empty_args="$top/podman-empty.args"
     if (PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$empty_args" CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" \
         run_candidate_ukify "" "$work" "$top/empty.log" "$key" "$cert" "$pcr" "" -- build) >"$top/empty-output" 2>&1; then

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -230,15 +230,27 @@ sign_systemd_boot() { # rootfs mok-cert
     sbverify --cert "$mok_cert" "$out" >/dev/null || die "systemd-boot MOK signature failed"
 }
 
+common_credential_owner() { # credential [credential...]
+    local owner file
+    owner=$(stat -c '%u:%g' "$1") || die "cannot stat candidate credential"
+    for file in "$@"; do
+        [[ -n $file ]] || continue
+        [[ $(stat -c '%u:%g' "$file") == "$owner" ]] || die "candidate credential owners differ"
+    done
+    printf '%s\n' "$owner"
+}
+
 run_candidate_ukify() { # image work log mok-key mok-cert pcr-key previous-key -- ukify-args...
-    local image=$1 work=$2 log=$3 mok_key=$4 mok_cert=$5 pcr_key=$6 previous_key=$7 status
+    local image=$1 work=$2 log=$3 mok_key=$4 mok_cert=$5 pcr_key=$6 previous_key=$7 status owner
     local -a podman_args pipeline_status
     [[ -n $image ]] || die "candidate ukify image is missing"
     shift 7
     [[ ${1:-} == -- ]] || die "candidate ukify argument separator is missing"
     shift
+    owner=$(common_credential_owner "$mok_key" "$mok_cert" "$pcr_key" "$previous_key")
+    chown "$owner" "$work" || die "cannot set candidate ukify work owner"
 
-    podman_args=(run --rm --network=none --cap-drop=all
+    podman_args=(run --rm --network=none --cap-drop=all --user "$owner"
         --security-opt label=type:unconfined_t
         --entrypoint=/usr/bin/ukify
         --volume "$mok_key:$CANDIDATE_UKIFY_MOK_KEY:ro"
@@ -411,6 +423,14 @@ candidate_ukify_self_test() (
     openssl req -new -x509 -key "$key" -subj /CN=mok -days 1 -out "$cert" >/dev/null 2>&1
     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$pcr" >/dev/null 2>&1
     openssl pkey -in "$pcr" -pubout -out "$work/pcr.pub" >/dev/null
+    cat >"$top/bin/stat" <<'EOF'
+#!/bin/bash
+if [[ ${3:-} == "$CANDIDATE_UKIFY_TEST_MISMATCH" ]]; then printf '999:999\n'; else /usr/bin/stat "$@"; fi
+EOF
+    chmod +x "$top/bin/stat"
+    if (PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_MISMATCH="$pcr" common_credential_owner "$key" "$cert" "$pcr") >/dev/null 2>&1; then
+        die "candidate unequal credential owners accepted"
+    fi
     candidate_ukify_args "$root" "$root/usr/lib/modules/one/vmlinuz" "$root/usr/lib/modules/one/initramfs.img" \
         fixture one "" fixture_args
     expected_args=(build --linux /usr/lib/modules/one/vmlinuz --initrd /usr/lib/modules/one/initramfs.img
@@ -426,7 +446,7 @@ candidate_ukify_self_test() (
 #!/bin/bash
 set -euo pipefail
 printf '%s\n' "$@" >"$CANDIDATE_UKIFY_TEST_ARGS"
-expected=(run --rm --network=none --cap-drop=all --security-opt label=type:unconfined_t --entrypoint=/usr/bin/ukify)
+expected=(run --rm --network=none --cap-drop=all --user "$(id -u):$(id -g)" --security-opt label=type:unconfined_t --entrypoint=/usr/bin/ukify)
 for expected_arg in "${expected[@]}"; do
     [[ ${1:-} == "$expected_arg" ]] || exit 87
     shift

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -75,8 +75,8 @@ the mandatory revalidation triggers. Private keys remain caller-owned and must
 not enter this fragment, its tree, OCI layers, labels, logs, or retained temp
 state. Direct ukify runs as `/usr/bin/ukify` in the first-pass candidate with
 `--network=none`, `--cap-drop=all`, `--security-opt label=type:unconfined_t`,
-and the common numeric credential owner via `--user`; mismatched owners fail before Podman.
-and a fixed entrypoint. The assembler resolves and translates in-root
+a fixed entrypoint, and the common numeric credential owner via `--user`.
+Mismatched owners fail before Podman. The assembler resolves and translates in-root
 kernel/initrd paths to candidate paths, mounts each caller credential read-only
 at fixed `/run/snosi-ukify-*`
 paths, and gives it exactly one writable `/run/snosi-ukify-work` mount. The

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -75,6 +75,7 @@ the mandatory revalidation triggers. Private keys remain caller-owned and must
 not enter this fragment, its tree, OCI layers, labels, logs, or retained temp
 state. Direct ukify runs as `/usr/bin/ukify` in the first-pass candidate with
 `--network=none`, `--cap-drop=all`, `--security-opt label=type:unconfined_t`,
+and the common numeric credential owner via `--user`; mismatched owners fail before Podman.
 and a fixed entrypoint. The assembler resolves and translates in-root
 kernel/initrd paths to candidate paths, mounts each caller credential read-only
 at fixed `/run/snosi-ukify-*`


### PR DESCRIPTION
## Summary
- run candidate ukify as the common numeric owner of its mode-0600 credential mounts while retaining `--cap-drop=all`
- chown only the assembler-owned public work directory and reject credential-owner mismatches before work mutation or Podman
- preserve read-only source credentials without adding DAC-bypass capabilities or weakening file modes
- document the explicit-user compatibility boundary and add owner/mismatch fixtures

## Root Cause
Protected run [30576875379](https://github.com/frostyard/snosi/actions/runs/30576875379), job [90987228304](https://github.com/frostyard/snosi/actions/runs/30576875379/job/90987228304), reached candidate `/usr/bin/ukify` but failed reading `/run/snosi-ukify-mok.crt`. The credentials were mode 0600 and runner-owned, while rootful Podman defaulted to UID 0 with all capabilities dropped. All profiles failed in `Package image`; validation, push, signing, and promotion did not run.

## Testing
- `test/bootc-secure-artifact-test.sh --fixtures`
- `test/bootc-secure-artifact-negative-test.sh --fixtures`
- `test/bootc-secure-package-cleanup-test.sh`
- `test/bootc-publication-guard-test.sh` (29/29)
- `./check-bootc-publication-guard.sh`
- `shellcheck shared/bootc-secure/assemble-uki.sh shared/outformat/image/buildah-package.sh test/bootc-secure-package-cleanup-test.sh`
- `git diff --check origin/main..HEAD`

## Evidence Boundary
The next protected three-profile run remains the live proof of cross-UID rootful Podman execution and candidate ukify behavior.