### PR TITLE
feat: add Sunshine sysext

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -69,6 +69,15 @@ jobs:
             echo "github_copilot_version=$LATEST_GITHUB_COPILOT" >> "$GITHUB_OUTPUT"
           fi
 
+          # Check Sunshine
+          CURRENT_SUNSHINE=$(jq -r '.sunshine.version' "$CHECKSUMS")
+          LATEST_SUNSHINE=$(gh_api https://api.github.com/repos/LizardByte/Sunshine/releases | jq -r '[.[] | select(.draft == false and .prerelease == false)][0].tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_SUNSHINE" && "$LATEST_SUNSHINE" != "null" ]] && ver_gt "$LATEST_SUNSHINE" "$CURRENT_SUNSHINE"; then
+            UPDATES="${UPDATES}sunshine: $CURRENT_SUNSHINE -> $LATEST_SUNSHINE\n"
+            echo "sunshine_update=true" >> "$GITHUB_OUTPUT"
+            echo "sunshine_version=$LATEST_SUNSHINE" >> "$GITHUB_OUTPUT"
+          fi
+
           # Check code-server
           CURRENT_CS=$(jq -r '.["code-server"].version' "$CHECKSUMS")
           LATEST_CS=$(gh_api https://api.github.com/repos/coder/code-server/releases/latest | jq -r '.tag_name' | sed 's/^v//')
@@ -175,6 +184,8 @@ jobs:
           BITWARDEN_VERSION: ${{ steps.check.outputs.bitwarden_version }}
           GITHUB_COPILOT_UPDATE: ${{ steps.check.outputs.github_copilot_update }}
           GITHUB_COPILOT_VERSION: ${{ steps.check.outputs.github_copilot_version }}
+          SUNSHINE_UPDATE: ${{ steps.check.outputs.sunshine_update }}
+          SUNSHINE_VERSION: ${{ steps.check.outputs.sunshine_version }}
           CODESERVER_UPDATE: ${{ steps.check.outputs.codeserver_update }}
           CODESERVER_VERSION: ${{ steps.check.outputs.codeserver_version }}
           CODER_UPDATE: ${{ steps.check.outputs.coder_update }}
@@ -216,6 +227,18 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
               '."github-copilot".url=$u | ."github-copilot".sha256=$s | ."github-copilot".version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$SUNSHINE_UPDATE" == "true" ]]; then
+            VER="$SUNSHINE_VERSION"
+            URL="https://github.com/LizardByte/Sunshine/releases/download/v${VER}/sunshine-debian-trixie-amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.sunshine.url=$u | .sunshine.sha256=$s | .sunshine.version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -149,6 +149,18 @@ jobs:
         # required-paths.txt entries. No root, network, or image build.
         run: ./test/sysext-required-paths-test.sh
 
+      - name: Validate Sunshine package dependencies
+        # Fixture check for Sunshine's .deb dependencies. No root, network, or build.
+        run: ./test/sunshine-package-dependencies-test.sh
+
+      - name: Validate local mkosi profile dependency check
+        # Fixture check for pinned local mkosi use. No root, network, or build.
+        run: ./test/check-profile-dependencies-local-mkosi-test.sh
+
+      - name: Validate Sunshine file capabilities
+        # PATH-stubbed capability assertion fixture. No root, network, or build.
+        run: ./test/sunshine-capabilities-test.sh
+
   runtime-etc-guard:
     runs-on: ubuntu-latest
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1503,8 +1503,10 @@ units.
 host for Moonlight installed from its official pinned Trixie deb through
 `verified_download()`. Its native `/usr` layout retains the package's
 `cap_sys_admin,cap_sys_nice` capability, `uhid` modules-load entry, and udev
-access rules. Its upstream user service is available for manual user startup;
-do not add a preset or `Upholds=` activation.
+access rules. After first enabling and merging the sysext, the modules-load
+entry and virtual-input udev rules take effect on the next boot unless manually
+applied. Its upstream user service is available for manual user startup; do not
+add a preset or `Upholds=` activation.
 
 Sysexts can ONLY provide files under `/usr`. They cannot modify `/etc` or `/var` at runtime. Configs needed in `/etc` must be:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,7 +533,7 @@ persistence.
 builds two real `cayo-ab-raw` versions itself, boots N, and asserts no failed
 systemd units and the bootc/nbc/systemd-sysupdate masks from above; that
 `/usr/lib/sysupdate.d/` contains only the three OS transfers (no `.feature`
-files) while `systemd-sysupdate components` enumerates all 21 shipped sysext
+files) while `systemd-sysupdate components` enumerates all 22 shipped sysext
 components; that two independently versioned ad hoc test components
 (`testa`/`testb`, created under `/etc/sysupdate.<name>.d/`) update via
 `--component=` without touching OS partitions, the ESP, or each other's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 21 sysexts
+just sysexts            # Build base + all 22 sysexts
 just snow               # Build snow desktop image
 just snowfield          # Build snowfield (Surface kernel)
 just cayo               # Build cayo server image

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 21 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode).
+**Outputs:** 2 OCI desktop images (snow, snowfield), 1 OCI server image (cayo), and 22 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, sunshine, tailscale, vscode).
 
 ## Build Commands
 
@@ -1498,6 +1498,13 @@ systemd`/`dpkg-query -W 'linux-image-*'` both resolving,
 units.
 
 ### Sysext Constraints
+
+**Sunshine sysext:** Sunshine is a desktop-only, self-hosted game-streaming
+host for Moonlight installed from its official pinned Trixie deb through
+`verified_download()`. Its native `/usr` layout retains the package's
+`cap_sys_admin,cap_sys_nice` capability, `uhid` modules-load entry, and udev
+access rules. Its upstream user service is available for manual user startup;
+do not add a preset or `Upholds=` activation.
 
 Sysexts can ONLY provide files under `/usr`. They cannot modify `/etc` or `/var` at runtime. Configs needed in `/etc` must be:
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ use a system-installed mkosi instead.
 # List available build targets
 just
 
-# Build base + all 21 system extensions, including Sunshine
+# Build base + all 22 system extensions, including Sunshine
 just sysexts
 
 # Build snow desktop image

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ The project produces:
 | **paseo**           | Paseo coding agent workspace desktop application                | sysext        |
 | **pilothouse**      | Pilothouse local web administration console for Snosi           | sysext        |
 | **podman**          | Podman + Distrobox                                              | sysext        |
-| **tailscale**       | Tailscale VPN client                                            | sysext        |
 | **sunshine**        | Sunshine self-hosted game streaming host for Moonlight          | sysext        |
+| **tailscale**       | Tailscale VPN client                                            | sysext        |
 | **vscode**          | Visual Studio Code desktop application                          | sysext        |
 
 Protected bootc publication validates each candidate with host Podman while
@@ -247,8 +247,8 @@ Sysexts are overlay images that extend the base system without modifying it. The
 | **paseo**         | Paseo desktop app (Electron)                  | [mkosi.images/paseo/mkosi.conf](mkosi.images/paseo/mkosi.conf)                 |
 | **pilothouse**    | Pilothouse local web administration console   | [mkosi.images/pilothouse/mkosi.conf](mkosi.images/pilothouse/mkosi.conf)       |
 | **podman**        | Podman, Distrobox, buildah, crun              | [mkosi.images/podman/mkosi.conf](mkosi.images/podman/mkosi.conf)               |
-| **tailscale**     | Tailscale VPN client                          | [mkosi.images/tailscale/mkosi.conf](mkosi.images/tailscale/mkosi.conf)         |
 | **sunshine**      | Sunshine self-hosted game streaming host for Moonlight | [mkosi.images/sunshine/mkosi.conf](mkosi.images/sunshine/mkosi.conf)     |
+| **tailscale**     | Tailscale VPN client                          | [mkosi.images/tailscale/mkosi.conf](mkosi.images/tailscale/mkosi.conf)         |
 | **vscode**        | Visual Studio Code desktop application         | [mkosi.images/vscode/mkosi.conf](mkosi.images/vscode/mkosi.conf)               |
 
 ## How Profiles Work

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The project produces:
 | **pilothouse**      | Pilothouse local web administration console for Snosi           | sysext        |
 | **podman**          | Podman + Distrobox                                              | sysext        |
 | **tailscale**       | Tailscale VPN client                                            | sysext        |
+| **sunshine**        | Sunshine self-hosted game streaming host for Moonlight          | sysext        |
 | **vscode**          | Visual Studio Code desktop application                          | sysext        |
 
 Protected bootc publication validates each candidate with host Podman while
@@ -205,7 +206,7 @@ sudo test/native-ab-update-test.sh \
              sysexts                         profiles
     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
     │    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
-  1password 1password-cli azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge github-copilot incus k3s lemonade nix paseo pilothouse podman tailscale vscode
+  1password 1password-cli azurevpn bitwarden claude-desktop code-server coder debdev dev docker edge github-copilot incus k3s lemonade nix paseo pilothouse podman sunshine tailscale vscode
                                      snow            cayo
                                       │
                                   snowfield
@@ -247,6 +248,7 @@ Sysexts are overlay images that extend the base system without modifying it. The
 | **pilothouse**    | Pilothouse local web administration console   | [mkosi.images/pilothouse/mkosi.conf](mkosi.images/pilothouse/mkosi.conf)       |
 | **podman**        | Podman, Distrobox, buildah, crun              | [mkosi.images/podman/mkosi.conf](mkosi.images/podman/mkosi.conf)               |
 | **tailscale**     | Tailscale VPN client                          | [mkosi.images/tailscale/mkosi.conf](mkosi.images/tailscale/mkosi.conf)         |
+| **sunshine**      | Sunshine self-hosted game streaming host for Moonlight | [mkosi.images/sunshine/mkosi.conf](mkosi.images/sunshine/mkosi.conf)     |
 | **vscode**        | Visual Studio Code desktop application         | [mkosi.images/vscode/mkosi.conf](mkosi.images/vscode/mkosi.conf)               |
 
 ## How Profiles Work
@@ -381,7 +383,7 @@ use a system-installed mkosi instead.
 # List available build targets
 just
 
-# Build base + all system extensions
+# Build base + all 21 system extensions, including Sunshine
 just sysexts
 
 # Build snow desktop image
@@ -571,7 +573,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode)
+1. Builds the base image and all 22 sysexts (1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, sunshine, tailscale, vscode)
 2. Publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Uploads package manifests for version tracking
 

--- a/check-profile-dependencies.sh
+++ b/check-profile-dependencies.sh
@@ -24,6 +24,7 @@ sysexts=(
     paseo
     pilothouse
     podman
+    sunshine
     tailscale
     vscode
 )

--- a/check-profile-dependencies.sh
+++ b/check-profile-dependencies.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+mkosi=mkosi
+if [[ -x .mkosi/bin/mkosi ]]; then
+    mkosi=.mkosi/bin/mkosi
+fi
+
 profiles=(cayo snow snowfield)
 sysexts=(
     1password
@@ -32,7 +37,7 @@ sysexts=(
 failed=0
 
 for profile in "${profiles[@]}"; do
-    summary=$(mkosi -f --profile "$profile" summary)
+    summary=$("$mkosi" -f --profile "$profile" summary)
 
     for sysext in "${sysexts[@]}"; do
         if grep -q "^IMAGE: ${sysext}$" <<<"$summary"; then

--- a/docs/native-ab-contracts.md
+++ b/docs/native-ab-contracts.md
@@ -175,7 +175,7 @@ Every independently versioned sysext lives in its own named component:
 Component name = sysext name. Admin overrides live at
 `/etc/sysupdate.<name>.d/<name>.feature.d/*.conf`.
 
-All 21 sysext transfer/feature pairs ship in component-scoped
+All 22 sysext transfer/feature pairs ship in component-scoped
 `/usr/lib/sysupdate.<name>.d/` directories under
 `mkosi.images/base/mkosi.extra/`. `/usr/lib/sysupdate.d/` is reserved for the
 three OS transfers above; sysext pairs must never be added there.

--- a/docs/superpowers/plans/2026-07-30-sunshine-sysext.md
+++ b/docs/superpowers/plans/2026-07-30-sunshine-sysext.md
@@ -1,0 +1,501 @@
+# Sunshine Sysext Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add LizardByte Sunshine as an independently updateable, desktop-only `sunshine` sysext that users start explicitly from its desktop launcher.
+
+**Architecture:** Download the immutable official Debian Trixie package through Snosi's checksum-verifying helper, install its native `/usr` payload and runtime dependencies into an overlay image, and publish it through the existing component-scoped systemd-sysupdate path. Preserve upstream's user service, udev rules, module loading, and file capabilities, but add no automatic user-session activation.
+
+**Tech Stack:** mkosi, Debian packages, Bash, systemd-sysext/systemd-sysupdate, systemd user units, udev, Linux file capabilities, GitHub Actions YAML, jq.
+
+## Global Constraints
+
+- The component and dpkg package names are exactly `sunshine`.
+- The initial artifact is `https://github.com/LizardByte/Sunshine/releases/download/v2026.516.143833/sunshine-debian-trixie-amd64.deb` with SHA-256 `b9b65f2be93b3e30be0710a940a616b1381da5bc6d858dce33bc0094d7fd4131` and version `2026.516.143833`.
+- Install the official `.deb` through `verified_download()` and `dpkg -i`; do not extract or maintain a downstream repack.
+- The sysext may ship only `/usr` content and must not add runtime `/etc` or `/var` mutations.
+- Preserve `cap_sys_admin,cap_sys_nice+p` on `/usr/bin/sunshine`, `60-sunshine.rules`, and `60-sunshine.conf`.
+- Preserve upstream's user service and desktop launcher, but do not add a user preset, static target link, or `Upholds=` activation.
+- The feature is disabled by default and offered only to `snow,snowfield`.
+- Retain `Verify=false`, matching the repository's accepted native sysext-signature risk.
+- Strip any hicolor icon cache from the sysext delta.
+- Update relevant documentation in `CLAUDE.md`, `README.md`, and `yeti/`.
+
+---
+
+### Task 1: Package And Register Sunshine
+
+**Files:**
+- Create: `mkosi.images/sunshine/mkosi.conf`
+- Create: `mkosi.images/sunshine/mkosi.postinst.chroot`
+- Create: `mkosi.images/sunshine/required-paths.txt`
+- Create: `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.sunshine.d/sunshine.transfer`
+- Create: `mkosi.images/base/mkosi.extra/usr/lib/sysupdate.sunshine.d/sunshine.feature`
+- Modify: `shared/download/sysext-checksums.json`
+- Modify: `mkosi.conf:3-23`
+- Modify: `check-profile-dependencies.sh:7-28`
+- Modify: `test/native-ab-components-test.sh:527-529`
+
+**Interfaces:**
+- Consumes: `verified_download <key> <destination>` from `shared/download/verified-download.sh`; the shared sysext post-output, required-path, and icon-cache finalizers.
+- Produces: image `sunshine`, dpkg version source `sunshine`, systemd-sysupdate component `sunshine`, and current symlink `/var/lib/extensions.d/sunshine.raw`.
+
+- [ ] **Step 1: Add failing inventory assertions**
+
+Add `sunshine` in alphabetical position to `check-profile-dependencies.sh`'s `sysexts` array and `test/native-ab-components-test.sh`'s `expected_sysext_components` array. Do not add it to `mkosi.conf` yet.
+
+- [ ] **Step 2: Prove the new registration assertion fails**
+
+Run:
+
+```bash
+grep -q '^[[:space:]]*sunshine$' mkosi.conf
+```
+
+Expected: exit 1 because the root dependency is not registered yet.
+
+- [ ] **Step 3: Add immutable download metadata**
+
+Add this object to `shared/download/sysext-checksums.json` and retain valid JSON:
+
+```json
+"sunshine": {
+  "url": "https://github.com/LizardByte/Sunshine/releases/download/v2026.516.143833/sunshine-debian-trixie-amd64.deb",
+  "sha256": "b9b65f2be93b3e30be0710a940a616b1381da5bc6d858dce33bc0094d7fd4131",
+  "version": "2026.516.143833"
+}
+```
+
+- [ ] **Step 4: Create the sysext configuration**
+
+Create `mkosi.images/sunshine/mkosi.conf`:
+
+```ini
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=sunshine
+Output=sunshine
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+Packages=debianutils
+         libcap2
+         libcurl4t64
+         libdrm2
+         libevdev2
+         libgbm1
+         libglib2.0-0t64
+         libgtk-3-0t64
+         libayatana-appindicator3-1
+         libicu76
+         libminiupnpc18
+         libnotify4
+         libnuma1
+         libopus0
+         libpipewire-0.3-0t64
+         libpulse0
+         libssl3t64
+         libva2
+         libva-drm2
+         libvulkan1
+         libwayland-client0
+         libx11-6
+
+[Build]
+Environment=KEYPACKAGE=sunshine
+```
+
+Use the Trixie package names from the upstream package's generated dependency list; do not retain duplicate compatibility alternatives such as both `libcurl4` and `libcurl4t64`.
+
+- [ ] **Step 5: Create the verified package installer**
+
+Create executable `mkosi.images/sunshine/mkosi.postinst.chroot`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+# shellcheck disable=SC1091
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "sunshine" "$DEBS/sunshine.deb"
+
+dpkg -i "$DEBS/sunshine.deb"
+```
+
+Set mode `0755`. Let mkosi discover the conventionally named postinstall; do not duplicate it in `PostInstallationScripts=`.
+
+- [ ] **Step 6: Define the shipped-payload contract**
+
+Create `mkosi.images/sunshine/required-paths.txt`:
+
+```text
+# sunshine sysext: self-hosted game streaming host for Moonlight
+/usr/bin/sunshine
+/usr/lib/modules-load.d/60-sunshine.conf
+/usr/lib/systemd/user/app-dev.lizardbyte.app.Sunshine.service
+/usr/lib/udev/rules.d/60-sunshine.rules
+/usr/share/applications/dev.lizardbyte.app.Sunshine.desktop
+/usr/share/icons/hicolor/scalable/apps/dev.lizardbyte.app.Sunshine.svg
+/usr/share/sunshine/apps.json
+/usr/share/sunshine/web/index.html
+```
+
+- [ ] **Step 7: Add component-scoped update metadata**
+
+Create `sunshine.transfer`:
+
+```ini
+[Transfer]
+Features=sunshine
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/sunshine/
+MatchPattern=sunshine_@v_%w_%a.raw.zst \
+             sunshine_@v_%w_%a.raw.xz \
+             sunshine_@v_%w_%a.raw.gz \
+             sunshine_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=sunshine_@v_%w_%a.raw.zst \
+             sunshine_@v_%w_%a.raw.xz \
+             sunshine_@v_%w_%a.raw.gz \
+             sunshine_@v_%w_%a.raw
+CurrentSymlink=sunshine.raw
+```
+
+Create `sunshine.feature`:
+
+```ini
+[Feature]
+Description=Self-hosted game streaming host for Moonlight
+Documentation=https://docs.lizardbyte.dev/projects/sunshine/
+Enabled=false
+X-Snosi-Products=snow,snowfield
+```
+
+- [ ] **Step 8: Register the image**
+
+Add `sunshine` in alphabetical position to root `mkosi.conf`'s `Dependencies=` list. Keep the guard and native component arrays alphabetically aligned with the root inventory.
+
+- [ ] **Step 9: Run focused static checks**
+
+Run:
+
+```bash
+jq -e '.sunshine == {
+  url: "https://github.com/LizardByte/Sunshine/releases/download/v2026.516.143833/sunshine-debian-trixie-amd64.deb",
+  sha256: "b9b65f2be93b3e30be0710a940a616b1381da5bc6d858dce33bc0094d7fd4131",
+  version: "2026.516.143833"
+}' shared/download/sysext-checksums.json
+shellcheck mkosi.images/sunshine/mkosi.postinst.chroot
+./test/native-ab-contracts-test.sh
+```
+
+Expected: all commands exit 0 with no findings.
+
+- [ ] **Step 10: Commit the package and component**
+
+```bash
+git add mkosi.images/sunshine mkosi.images/base/mkosi.extra/usr/lib/sysupdate.sunshine.d \
+  shared/download/sysext-checksums.json mkosi.conf check-profile-dependencies.sh \
+  test/native-ab-components-test.sh
+git commit -m "feat: add Sunshine sysext"
+```
+
+---
+
+### Task 2: Automate Sunshine Release Updates
+
+**Files:**
+- Modify: `.github/workflows/check-dependencies.yml:54-147,155-300`
+
+**Interfaces:**
+- Consumes: workflow helpers `gh_api()` and `ver_gt()` plus checksum key `.sunshine` from Task 1.
+- Produces: outputs `sunshine_update` and `sunshine_version`, passed as `SUNSHINE_UPDATE` and `SUNSHINE_VERSION` to checksum regeneration.
+
+- [ ] **Step 1: Prove updater wiring is absent**
+
+Run:
+
+```bash
+if grep -q 'sunshine_update' .github/workflows/check-dependencies.yml; then
+    exit 1
+fi
+```
+
+Expected: exit 0 before implementation.
+
+- [ ] **Step 2: Add latest stable release detection**
+
+Add after the GitHub Copilot check:
+
+```bash
+# Check Sunshine
+CURRENT_SUNSHINE=$(jq -r '.sunshine.version' "$CHECKSUMS")
+LATEST_SUNSHINE=$(gh_api https://api.github.com/repos/LizardByte/Sunshine/releases | jq -r '[.[] | select(.draft == false and .prerelease == false)][0].tag_name' | sed 's/^v//')
+if [[ -n "$LATEST_SUNSHINE" && "$LATEST_SUNSHINE" != "null" ]] && ver_gt "$LATEST_SUNSHINE" "$CURRENT_SUNSHINE"; then
+  UPDATES="${UPDATES}sunshine: $CURRENT_SUNSHINE -> $LATEST_SUNSHINE\n"
+  echo "sunshine_update=true" >> "$GITHUB_OUTPUT"
+  echo "sunshine_version=$LATEST_SUNSHINE" >> "$GITHUB_OUTPUT"
+fi
+```
+
+- [ ] **Step 3: Pass outputs through environment variables**
+
+Add to the checksum-update step's `env:` block:
+
+```yaml
+SUNSHINE_UPDATE: ${{ steps.check.outputs.sunshine_update }}
+SUNSHINE_VERSION: ${{ steps.check.outputs.sunshine_version }}
+```
+
+- [ ] **Step 4: Add checksum regeneration**
+
+Add after the GitHub Copilot updater branch:
+
+```bash
+if [[ "$SUNSHINE_UPDATE" == "true" ]]; then
+  VER="$SUNSHINE_VERSION"
+  URL="https://github.com/LizardByte/Sunshine/releases/download/v${VER}/sunshine-debian-trixie-amd64.deb"
+  TMP=$(mktemp)
+  curl -fsSL -o "$TMP" "$URL"
+  SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+  jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+    '.sunshine.url=$u | .sunshine.sha256=$s | .sunshine.version=$v' \
+    "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+  rm -f "$TMP"
+fi
+```
+
+- [ ] **Step 5: Validate workflow syntax and data flow**
+
+Run:
+
+```bash
+actionlint .github/workflows/check-dependencies.yml
+grep -q 'sunshine_update=true' .github/workflows/check-dependencies.yml
+grep -q 'SUNSHINE_VERSION.*steps.check.outputs.sunshine_version' .github/workflows/check-dependencies.yml
+grep -q 'LizardByte/Sunshine/releases/download/v${VER}/sunshine-debian-trixie-amd64.deb' .github/workflows/check-dependencies.yml
+```
+
+Expected: all commands exit 0 and actionlint emits no findings.
+
+- [ ] **Step 6: Commit updater automation**
+
+```bash
+git add .github/workflows/check-dependencies.yml
+git commit -m "ci: track Sunshine releases"
+```
+
+---
+
+### Task 3: Document And Prove The Runtime Contract
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `yeti/OVERVIEW.md`
+- Modify: `yeti/sysexts.md`
+- Modify: any exact sysext count/list found by the inventory search
+
+**Interfaces:**
+- Consumes: component behavior implemented in Tasks 1 and 2.
+- Produces: synchronized human and AI documentation plus static and artifact-level verification evidence.
+
+- [ ] **Step 1: Inventory exact sysext lists and counts**
+
+Run:
+
+```bash
+rg -n '20 sysext|20 shipped|github-copilot.*incus|pilothouse.*podman|vscode\)' CLAUDE.md README.md yeti docs test check-profile-dependencies.sh mkosi.conf
+```
+
+Expected: output identifies all complete inventories that must become 21-component inventories. Do not update historical statements whose count is intentionally tied to an earlier event.
+
+- [ ] **Step 2: Update project inventories**
+
+Apply these semantic changes:
+
+```text
+CLAUDE.md:
+- Change the current output count from 20 to 21 and insert sunshine alphabetically in the complete list.
+- Add a concise Sunshine sysext note recording the official pinned Trixie deb, manual user-service startup, retained capability, uhid modules-load entry, udev rules, and desktop-only scope.
+
+README.md:
+- Add Sunshine to output, detailed sysext, command/example, architecture, and CI inventory lists.
+- Describe it as a self-hosted game streaming host for Moonlight.
+- Reconcile current complete counts to 21.
+
+yeti/OVERVIEW.md:
+- Add Sunshine to complete sysext lists and direct-download dependency descriptions.
+- Reconcile current complete counts to 21.
+
+yeti/sysexts.md:
+- Add `sunshine | sunshine | Sunshine self-hosted game streaming host (official pinned Trixie .deb via verified_download)` to Current Sysexts.
+- Add Sunshine to the direct-download exception list.
+- Add a Sunshine subsection documenting native /usr layout, upstream user unit and manual launcher, no preset/Upholds activation, retained cap_sys_admin/cap_sys_nice file capability, uhid modules-load and udev access rules, and hicolor cache stripping.
+```
+
+- [ ] **Step 3: Run repository static validation**
+
+Run:
+
+```bash
+jq empty shared/download/sysext-checksums.json
+actionlint .github/workflows/check-dependencies.yml
+shellcheck mkosi.images/sunshine/mkosi.postinst.chroot
+./test/verified-download-split-checksums-test.sh
+./test/sysext-required-paths-test.sh
+./test/native-ab-contracts-test.sh
+./check-runtime-etc-guard.sh
+git diff --check
+```
+
+Expected: every command exits 0 with no new findings.
+
+- [ ] **Step 4: Validate resolved mkosi configuration**
+
+Run:
+
+```bash
+sudo .mkosi/bin/mkosi summary > /dev/null
+./check-profile-dependencies.sh
+sudo .mkosi/bin/mkosi --image sunshine summary
+```
+
+Expected: all commands exit 0; Sunshine resolves as an overlay sysext with `KEYPACKAGE=sunshine`, while each OCI profile remains dependent only on `base`.
+
+- [ ] **Step 5: Build Sunshine and inspect its artifacts**
+
+Run:
+
+```bash
+sudo .mkosi/bin/mkosi --image sunshine build
+```
+
+Expected: checksum verification succeeds, dpkg installs Sunshine `2026.516.143833`, every required path passes, the icon cache is stripped, and post-output emits a versioned `sunshine_2026.516.143833_*` sysext plus manifest.
+
+Identify the uncompressed sysext artifact emitted in `output/`, then mount it read-only at a temporary directory and run:
+
+```bash
+getcap <mountpoint>/usr/bin/sunshine
+test ! -e <mountpoint>/usr/share/icons/hicolor/icon-theme.cache
+test -f <mountpoint>/usr/lib/modules-load.d/60-sunshine.conf
+test -f <mountpoint>/usr/lib/udev/rules.d/60-sunshine.rules
+test -f <mountpoint>/usr/lib/systemd/user/app-dev.lizardbyte.app.Sunshine.service
+grep -qx 'uhid' <mountpoint>/usr/lib/modules-load.d/60-sunshine.conf
+```
+
+Expected: `getcap` prints `<mountpoint>/usr/bin/sunshine cap_sys_admin,cap_sys_nice=p`; every other command exits 0. Keep the artifact mounted through Step 6. If mkosi emits only a compressed artifact, decompress it to `/tmp/opencode` before mounting; do not alter tracked outputs.
+
+- [ ] **Step 6: Verify manifest and manual-start policy**
+
+Run against the emitted manifest and mounted artifact:
+
+```bash
+jq -e '.. | objects | select(.name? == "sunshine") | .version == "2026.516.143833"' output/sunshine*.manifest
+grep -q '^WantedBy=graphical-session.target$' <mountpoint>/usr/lib/systemd/user/app-dev.lizardbyte.app.Sunshine.service
+! test -e <mountpoint>/usr/lib/systemd/user-preset/40-sunshine.preset
+! find <mountpoint>/usr/lib/systemd/user -path '*/graphical-session.target.wants/*Sunshine*' -print -quit | grep -q .
+```
+
+Expected: all commands exit 0, proving the package version and that Sunshine is available through its installable user unit without sysext-added automatic activation.
+
+Unmount the artifact and remove its temporary mount directory after these checks.
+
+- [ ] **Step 7: Commit documentation and any verification fixes**
+
+```bash
+git add CLAUDE.md README.md yeti/OVERVIEW.md yeti/sysexts.md
+git add -u
+git commit -m "docs: document Sunshine sysext"
+```
+
+- [ ] **Step 8: Inspect the complete branch**
+
+Run:
+
+```bash
+git status --short
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected: the worktree is clean; only the design, plan, Sunshine implementation, inventories/tests, updater, and documentation differ from `origin/main`.
+
+---
+
+### Task 4: Publish The Pull Request
+
+**Files:**
+- Create remotely: pull request targeting `main`
+
+**Interfaces:**
+- Consumes: verified commits from Tasks 1-3.
+- Produces: a GitHub pull request for review.
+
+- [ ] **Step 1: Rebase the implementation on current main if needed**
+
+Run:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+```
+
+Expected: exit 0. If it exits 1, merge `origin/main` non-interactively, resolve only Sunshine-related conflicts, and rerun the full Task 3 static validation.
+
+- [ ] **Step 2: Push the feature branch**
+
+Run:
+
+```bash
+git push -u origin HEAD
+```
+
+Expected: push succeeds and establishes upstream tracking.
+
+- [ ] **Step 3: Open the pull request**
+
+Run:
+
+```bash
+gh pr create --base main --head "$(git branch --show-current)" \
+  --title "feat: add Sunshine sysext" \
+  --body-file /tmp/opencode/sunshine-pr-body.md
+```
+
+Before the command, create `/tmp/opencode/sunshine-pr-body.md` containing:
+
+```markdown
+## Summary
+- add the official pinned Sunshine Trixie package as a desktop-only sysext
+- preserve upstream uhid, udev, file-capability, and manual user-service behavior
+- add component publication metadata and automated release tracking
+
+## Testing
+- list each static command run and its result
+- record the real sysext build and capability inspection result
+- identify any environment-blocked check explicitly instead of claiming it passed
+```
+
+Expected: `gh` returns the new pull request URL targeting `main`.

--- a/docs/superpowers/specs/2026-07-30-sunshine-sysext-design.md
+++ b/docs/superpowers/specs/2026-07-30-sunshine-sysext-design.md
@@ -1,0 +1,154 @@
+# Sunshine Sysext Design
+
+## Goal
+
+Add LizardByte Sunshine as an independently updateable, desktop-only system
+extension named `sunshine`. Build it from the official Debian Trixie amd64
+package at version `2026.516.143833`, publish it through the existing sysext
+pipeline, and expose Sunshine through its upstream desktop launcher without
+starting it automatically for graphical users.
+
+## Upstream Artifact
+
+- URL: `https://github.com/LizardByte/Sunshine/releases/download/v2026.516.143833/sunshine-debian-trixie-amd64.deb`
+- Package: `sunshine`
+- Version: `2026.516.143833`
+- Architecture: `amd64`
+- SHA-256: `b9b65f2be93b3e30be0710a940a616b1381da5bc6d858dce33bc0094d7fd4131`
+
+Record the artifact in `shared/download/sysext-checksums.json`. The build must
+retrieve it through `verified_download()` and install it with `dpkg -i` so the
+dpkg database remains the source of the package version used by the shared
+post-output naming logic.
+
+Add a GitHub-release update check for `LizardByte/Sunshine` to
+`.github/workflows/check-dependencies.yml`. It must select the latest
+non-draft, non-prerelease release, compare versions with the workflow's
+downgrade guard, construct the release's Trixie amd64 asset URL, download it,
+and refresh the checksum metadata.
+
+## Sysext Build
+
+Create `mkosi.images/sunshine/` using the standard overlay sysext structure:
+
+- `ImageId=sunshine`
+- `Output=sunshine`
+- `Overlay=yes`
+- `Format=sysext`
+- `BaseTrees=%O/base`
+- shared required-path and icon-cache finalize scripts
+- shared sysext post-output script
+- `KEYPACKAGE=sunshine`
+
+The package installs natively under `/usr`; no `/opt` relocation or factory
+`/etc` capture is required. The sysext configuration must explicitly install
+the runtime dependencies declared by the upstream package because `dpkg -i`
+cannot resolve them. Dependencies already supplied by `base` are harmless in
+the merged build and do not need to be listed as required sysext-delta paths.
+
+The package post-install script performs three relevant operations:
+
+1. Loads `uhid` for virtual gamepad support.
+2. Applies `cap_sys_admin,cap_sys_nice+p` to `/usr/bin/sunshine` for KMS capture
+   and scheduling priority.
+3. Reloads and triggers its udev rules for `/dev/uinput` and `/dev/uhid`.
+
+Keep the upstream package installation behavior rather than maintaining a
+downstream repack. The built sysext must retain the resulting file capability,
+`usr/lib/modules-load.d/60-sunshine.conf`, and
+`usr/lib/udev/rules.d/60-sunshine.rules`. EROFS preserves the capability in
+the same way as the existing Azure VPN sysext. A real build is the acceptance
+check for whether these maintainer-script operations work in mkosi's chroot;
+fail the work rather than silently publishing a capability-free payload.
+
+## Runtime Behavior
+
+Sunshine remains opt-in at runtime. Preserve the upstream user unit
+`app-dev.lizardbyte.app.Sunshine.service` and desktop entry, whose launcher
+starts that unit. Do not add a user preset, static target link, or `Upholds=`
+drop-in. Enabling the sysext makes Sunshine available but does not expose its
+streaming service until a user launches it.
+
+The package's modules-load and udev files provide virtual input support after
+the extension is merged. The base image's existing sysext reload path runs
+`systemd-tmpfiles`, `systemd-sysusers`, and `daemon-reload`; no `/etc` writes or
+runtime `systemctl enable` operations are needed.
+
+The package ships hicolor icons. Retain the shared
+`sysext-strip-icon-cache.sh` finalize step so Sunshine and other merged sysext
+icons remain discoverable.
+
+## Required Payload Contract
+
+Add `mkosi.images/sunshine/required-paths.txt` covering at least:
+
+- `/usr/bin/sunshine`
+- the upstream user service
+- the modules-load file
+- the udev rules
+- the primary desktop entry
+- the primary hicolor application icon
+- `/usr/share/sunshine/apps.json`
+- a representative web UI entry point
+
+Separately verify the Sunshine binary's expected capability after a real build;
+path existence alone cannot prove it survived packaging.
+
+## Distribution Metadata
+
+Create the systemd-sysupdate component under
+`mkosi.images/base/mkosi.extra/usr/lib/sysupdate.sunshine.d/`:
+
+- Feature name: `sunshine`
+- Description: self-hosted game streaming host for Moonlight
+- Documentation: `https://docs.lizardbyte.dev/projects/sunshine/`
+- `Enabled=false`
+- `X-Snosi-Products=snow,snowfield`
+- Source: `https://repository.frostyard.org/ext/sunshine/`
+- Target: `/var/lib/extensions.d/`
+- Current symlink: `sunshine.raw`
+- Existing compressed and uncompressed sysext match-pattern convention
+- `Verify=false`, matching the repository's currently accepted native sysext
+  publication risk
+
+Add `sunshine` to the root dependency list so standard sysext builds produce
+it. Add it to `check-profile-dependencies.sh` so OCI profile builds remain
+isolated from every optional sysext, and to the native component topology test
+so installed native images must advertise it as a distinct component.
+
+## Documentation
+
+Update the sysext counts and enumerations in `CLAUDE.md`, `README.md`, and
+`yeti/OVERVIEW.md`. Add Sunshine to the human-facing image tables and document
+its direct-download packaging, manual user-service startup, capabilities,
+modules-load behavior, udev rules, and icon-cache requirement in
+`yeti/sysexts.md`. Update any other exact sysext lists discovered during
+implementation.
+
+## Verification
+
+The implementation is complete when all applicable checks pass:
+
+1. The checksum metadata parses and the pinned URL hashes to the recorded
+   SHA-256.
+2. Shell scripts and edited workflow shell pass the repository's available
+   static checks.
+3. Static sysext/component tests include Sunshine and pass.
+4. A real `sunshine` sysext build succeeds against the base image.
+5. The built delta contains every required path and no hicolor icon cache.
+6. The built `/usr/bin/sunshine` retains
+   `cap_sys_admin,cap_sys_nice+p`.
+7. The generated manifest reports package `sunshine` version
+   `2026.516.143833`, and post-output naming follows the standard Sunshine
+   versioned sysext convention.
+
+If environment or privilege constraints prevent the real build, report that
+verification gap explicitly; static validation alone is not sufficient to
+claim the runtime capability contract is proven.
+
+## Pull Request
+
+Implement on a branch based on `main`, commit the complete source, tests, and
+documentation changes, push the branch, and open a pull request targeting
+`main`. The pull request must summarize the manual-start policy and list the
+verification performed, including any environment-blocked build checks.

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -20,6 +20,7 @@ Dependencies=base
              paseo
              pilothouse
              podman
+             sunshine
              tailscale
              vscode
 

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.sunshine.d/sunshine.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.sunshine.d/sunshine.feature
@@ -1,0 +1,5 @@
+[Feature]
+Description=Self-hosted game streaming host for Moonlight
+Documentation=https://docs.lizardbyte.dev/projects/sunshine/
+Enabled=false
+X-Snosi-Products=snow,snowfield

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.sunshine.d/sunshine.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.sunshine.d/sunshine.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=sunshine
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/sunshine/
+MatchPattern=sunshine_@v_%w_%a.raw.zst \
+             sunshine_@v_%w_%a.raw.xz \
+             sunshine_@v_%w_%a.raw.gz \
+             sunshine_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=sunshine_@v_%w_%a.raw.zst \
+             sunshine_@v_%w_%a.raw.xz \
+             sunshine_@v_%w_%a.raw.gz \
+             sunshine_@v_%w_%a.raw
+CurrentSymlink=sunshine.raw

--- a/mkosi.images/sunshine/mkosi.conf
+++ b/mkosi.images/sunshine/mkosi.conf
@@ -35,6 +35,7 @@ Packages=debianutils
          libvulkan1
          libwayland-client0
          libx11-6
+         miniupnpc
 
 [Build]
 Environment=KEYPACKAGE=sunshine

--- a/mkosi.images/sunshine/mkosi.conf
+++ b/mkosi.images/sunshine/mkosi.conf
@@ -1,0 +1,40 @@
+[Config]
+Dependencies=base
+
+[Output]
+ImageId=sunshine
+Output=sunshine
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+Packages=debianutils
+         libcap2
+         libcurl4t64
+         libdrm2
+         libevdev2
+         libgbm1
+         libglib2.0-0t64
+         libgtk-3-0t64
+         libayatana-appindicator3-1
+         libicu76
+         libminiupnpc18
+         libnotify4
+         libnuma1
+         libopus0
+         libpipewire-0.3-0t64
+         libpulse0
+         libssl3t64
+         libva2
+         libva-drm2
+         libvulkan1
+         libwayland-client0
+         libx11-6
+
+[Build]
+Environment=KEYPACKAGE=sunshine

--- a/mkosi.images/sunshine/mkosi.postinst.chroot
+++ b/mkosi.images/sunshine/mkosi.postinst.chroot
@@ -13,6 +13,7 @@ verified_download "sunshine" "$DEBS/sunshine.deb"
 
 dpkg -i "$DEBS/sunshine.deb"
 
+# libcap2-bin is supplied by base; fail closed if it no longer provides getcap.
 if command -v getcap >/dev/null; then
     getcap_bin=$(command -v getcap)
 elif [[ -x /usr/sbin/getcap ]]; then

--- a/mkosi.images/sunshine/mkosi.postinst.chroot
+++ b/mkosi.images/sunshine/mkosi.postinst.chroot
@@ -12,3 +12,30 @@ trap 'rm -rf "$DEBS"' EXIT
 verified_download "sunshine" "$DEBS/sunshine.deb"
 
 dpkg -i "$DEBS/sunshine.deb"
+
+if command -v getcap >/dev/null; then
+    getcap_bin=$(command -v getcap)
+elif [[ -x /usr/sbin/getcap ]]; then
+    getcap_bin=/usr/sbin/getcap
+else
+    printf 'Sunshine capability assertion requires getcap\n' >&2
+    exit 1
+fi
+
+normalize_capabilities() {
+    local capability_names capability_flags
+    capability_names=${1%=*}
+    capability_flags=${1##*=}
+    capability_names=$(printf '%s\n' "$capability_names" | tr ',' '\n' | LC_ALL=C sort | paste -sd, -)
+    printf '%s=%s\n' "$capability_names" "$capability_flags"
+}
+
+capability_output=$("$getcap_bin" /usr/bin/sunshine)
+actual_capabilities=${capability_output#* }
+expected_capabilities='cap_sys_admin,cap_sys_nice=p'
+if [[ $(normalize_capabilities "$actual_capabilities") != \
+    $(normalize_capabilities "$expected_capabilities") ]]; then
+    printf 'Sunshine capability assertion failed: expected %s, got %s\n' \
+        "$expected_capabilities" "$actual_capabilities" >&2
+    exit 1
+fi

--- a/mkosi.images/sunshine/mkosi.postinst.chroot
+++ b/mkosi.images/sunshine/mkosi.postinst.chroot
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
+    set -x
+fi
+
+# shellcheck disable=SC1091
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "sunshine" "$DEBS/sunshine.deb"
+
+dpkg -i "$DEBS/sunshine.deb"

--- a/mkosi.images/sunshine/required-paths.txt
+++ b/mkosi.images/sunshine/required-paths.txt
@@ -1,0 +1,9 @@
+# sunshine sysext: self-hosted game streaming host for Moonlight
+/usr/bin/sunshine
+/usr/lib/modules-load.d/60-sunshine.conf
+/usr/lib/systemd/user/app-dev.lizardbyte.app.Sunshine.service
+/usr/lib/udev/rules.d/60-sunshine.rules
+/usr/share/applications/dev.lizardbyte.app.Sunshine.desktop
+/usr/share/icons/hicolor/scalable/apps/dev.lizardbyte.app.Sunshine.svg
+/usr/share/sunshine/apps.json
+/usr/share/sunshine/web/index.html

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -53,5 +53,10 @@
     "url": "https://github.com/frostyard/pilothouse/releases/download/v0.6.0/frostyard-pilothouse_0.6.0_amd64.deb",
     "sha256": "17a18dfefd7f788cbe2d8d6994c6271d29d6e69e0071720a8105ad70a9d647c6",
     "version": "0.6.0"
+  },
+  "sunshine": {
+    "url": "https://github.com/LizardByte/Sunshine/releases/download/v2026.516.143833/sunshine-debian-trixie-amd64.deb",
+    "sha256": "b9b65f2be93b3e30be0710a940a616b1381da5bc6d858dce33bc0094d7fd4131",
+    "version": "2026.516.143833"
   }
 }

--- a/test/check-profile-dependencies-local-mkosi-test.sh
+++ b/test/check-profile-dependencies-local-mkosi-test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
-scratch=$(mktemp -d /tmp/opencode/check-profile-dependencies-test.XXXXXX)
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/check-profile-dependencies-test.XXXXXX")
 trap 'rm -rf "$scratch"' EXIT
 
 cp "$repo_root/check-profile-dependencies.sh" "$scratch/"

--- a/test/check-profile-dependencies-local-mkosi-test.sh
+++ b/test/check-profile-dependencies-local-mkosi-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+scratch=$(mktemp -d /tmp/opencode/check-profile-dependencies-test.XXXXXX)
+trap 'rm -rf "$scratch"' EXIT
+
+cp "$repo_root/check-profile-dependencies.sh" "$scratch/"
+mkdir -p "$scratch/.mkosi/bin" "$scratch/path"
+
+cat >"$scratch/.mkosi/bin/mkosi" <<'EOF'
+#!/bin/bash
+if [[ "$*" == *"summary"* ]]; then
+    printf 'IMAGE: base\n'
+fi
+EOF
+chmod +x "$scratch/.mkosi/bin/mkosi"
+
+cat >"$scratch/path/mkosi" <<'EOF'
+#!/bin/bash
+echo 'PATH mkosi was used instead of the local checkout' >&2
+exit 1
+EOF
+chmod +x "$scratch/path/mkosi"
+
+PATH="$scratch/path:$PATH" "$scratch/check-profile-dependencies.sh" \
+    | grep -qx 'Profile builds depend only on base.'
+
+printf 'check-profile-dependencies-local-mkosi-test: PASSED\n'

--- a/test/native-ab-components-test.sh
+++ b/test/native-ab-components-test.sh
@@ -526,7 +526,7 @@ assert_eq "/usr/lib/sysupdate.d/ contains exactly the OS transfers, no features"
 
 expected_sysext_components=(1password 1password-cli azurevpn bitwarden claude-desktop
     code-server coder debdev dev docker edge github-copilot incus k3s lemonade nix
-    pilothouse podman sunshine tailscale vscode)
+    paseo pilothouse podman sunshine tailscale vscode)
 
 components_raw="$(vm_ssh '/usr/lib/systemd/systemd-sysupdate components --no-legend')"
 echo "systemd-sysupdate components --no-legend:"

--- a/test/native-ab-components-test.sh
+++ b/test/native-ab-components-test.sh
@@ -15,7 +15,7 @@
 # in QEMU, and validates in order:
 #
 #   1. No failed legacy updaters; bootc/nbc/sysupdate auto-update units masked.
-#   2. The OS default sysupdate.d target and the 21 shipped sysext components
+#   2. The OS default sysupdate.d target and the 22 shipped sysext components
 #      are structurally separate (component discovery via `systemd-sysupdate
 #      components`).
 #   3. Two ad hoc test sysext components (testa, testb; independently

--- a/test/native-ab-components-test.sh
+++ b/test/native-ab-components-test.sh
@@ -526,7 +526,7 @@ assert_eq "/usr/lib/sysupdate.d/ contains exactly the OS transfers, no features"
 
 expected_sysext_components=(1password 1password-cli azurevpn bitwarden claude-desktop
     code-server coder debdev dev docker edge github-copilot incus k3s lemonade nix
-    paseo pilothouse podman tailscale vscode)
+    pilothouse podman sunshine tailscale vscode)
 
 components_raw="$(vm_ssh '/usr/lib/systemd/systemd-sysupdate components --no-legend')"
 echo "systemd-sysupdate components --no-legend:"

--- a/test/sunshine-capabilities-test.sh
+++ b/test/sunshine-capabilities-test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
-scratch=$(mktemp -d /tmp/opencode/sunshine-capabilities-test.XXXXXX)
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/sunshine-capabilities-test.XXXXXX")
 trap 'rm -rf "$scratch"' EXIT
 
 mkdir -p "$scratch/shared/download" "$scratch/bin"

--- a/test/sunshine-capabilities-test.sh
+++ b/test/sunshine-capabilities-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+scratch=$(mktemp -d /tmp/opencode/sunshine-capabilities-test.XXXXXX)
+trap 'rm -rf "$scratch"' EXIT
+
+mkdir -p "$scratch/shared/download" "$scratch/bin"
+cp "$repo_root/mkosi.images/sunshine/mkosi.postinst.chroot" "$scratch/postinst"
+
+cat >"$scratch/shared/download/verified-download.sh" <<'EOF'
+verified_download() {
+    :
+}
+EOF
+
+cat >"$scratch/bin/dpkg" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$scratch/bin/dpkg"
+
+cat >"$scratch/bin/getcap" <<'EOF'
+#!/bin/bash
+printf '%s cap_sys_nice,cap_sys_admin=p\n' "$1"
+EOF
+chmod +x "$scratch/bin/getcap"
+
+PATH="$scratch/bin:$PATH" SRCDIR="$scratch" "$scratch/postinst"
+
+cat >"$scratch/bin/getcap" <<'EOF'
+#!/bin/bash
+printf '%s cap_sys_admin=p\n' "$1"
+EOF
+chmod +x "$scratch/bin/getcap"
+
+if PATH="$scratch/bin:$PATH" SRCDIR="$scratch" "$scratch/postinst"; then
+    printf 'expected Sunshine capability assertion to reject missing cap_sys_nice\n' >&2
+    exit 1
+fi
+
+printf 'sunshine-capabilities-test: PASSED\n'

--- a/test/sunshine-package-dependencies-test.sh
+++ b/test/sunshine-package-dependencies-test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+config="$repo_root/mkosi.images/sunshine/mkosi.conf"
+
+grep -qx '[[:space:]]*miniupnpc' "$config"
+
+printf 'sunshine-package-dependencies-test: PASSED\n'

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1007,7 +1007,7 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 
 ### System Extensions (EROFS sysexts, published to Frostyard R2 repo)
 
-1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, tailscale, vscode
+1password, 1password-cli, azurevpn, bitwarden, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, sunshine, tailscale, vscode
 
 ## Architecture
 

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1017,10 +1017,10 @@ installed), plus a first-promotion assertion that `promote.sh` prints
 mkosi.conf                  # Root config: distribution, dependencies, build settings
 mkosi.version               # Version tag script (date-based, overridden by CI IMAGE_VERSION)
 mkosi.clean                 # Clean script (rm -rf output/*)
-mkosi.images/               # Image definitions (base + 21 sysexts)
+mkosi.images/               # Image definitions (base + 22 sysexts)
   base/                     # Foundation image: systemd, bootc/ostree (frostyard debs), firmware, core utils
     mkosi.extra/            # Base filesystem overlay (dracut, systemd units/timers, sysupdate, tmpfiles, sysusers)
-      usr/lib/sysupdate.<name>.d/  # per-sysext .transfer + .feature component dirs (one pair each, 21 total)
+      usr/lib/sysupdate.<name>.d/  # per-sysext .transfer + .feature component dirs (one pair each, 22 total)
     mkosi.postinst.chroot   # Mount enablement, useradd home dir, bls-garbage-collect removal
     mkosi.finalize.chroot   # Masks systemd-networkd-wait-online
   docker/                   # Each sysext: mkosi.conf + optional extra/scripts

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1263,8 +1263,8 @@ Docker, 1Password) are tracked separately in
 This file is only a rebuild sentinel; mkosi still resolves packages from APT.
 
 Current sysext checksum-managed downloads are 1Password, Bitwarden, Azure VPN,
-Microsoft Edge, code-server, coder, GitHub Copilot, Lemonade, Paseo, and
-Pilothouse. Current image checksum-managed downloads are Homebrew
+Microsoft Edge, code-server, coder, GitHub Copilot, Lemonade, Paseo, Pilothouse,
+and Sunshine. Current image checksum-managed downloads are Homebrew
 install script, Surface secure boot certificate, Hotedge, Logomenu, and Bazaar
 Companion. Current APT version tracking covers `code`, `docker-ce`,
 `1password-cli`, and `claude-desktop`; Edge is checksum-managed because the build installs a patched

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1315,7 +1315,7 @@ Use build-time enablement/presets for desired service state. For run-once runtim
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 21 sysexts
+just sysexts            # Build base + all 22 sysexts
 just snow               # Build snow desktop
 just snowfield          # Build snowfield (Surface)
 just cayo               # Build cayo server

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -410,7 +410,7 @@ by the build artifact that must be rebuilt when a dependency changes:
 
 Pins URL + SHA256 for direct downloads consumed by sysext builds. Current
 consumers are 1Password, Bitwarden, Azure VPN, Edge, code-server, coder,
-GitHub Copilot, Lemonade, Paseo, and Pilothouse.
+GitHub Copilot, Lemonade, Paseo, Pilothouse, and Sunshine.
 Updates to this file should trigger `build.yml` and skip the OCI image matrix.
 
 ### image-checksums.json

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -295,6 +295,7 @@ for the build artifact that must be rebuilt.
 - Microsoft Azure VPN Client
 - Microsoft Edge Stable .deb
 - GitHub Copilot desktop .deb
+- Sunshine Trixie .deb
 
 Version-based checks only propose an update when the candidate sorts
 **strictly newer** (`sort -V`) than the pinned version — a plain `!=`

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -8,7 +8,7 @@
 `shared/download/image-checksums.json` when that is the only changed path;
 image-only direct-download updates should rebuild OCI profiles instead.
 
-Builds the base image and all 21 sysexts, publishes to the Frostyard repository on Cloudflare R2.
+Builds the base image and all 22 sysexts, publishes to the Frostyard repository on Cloudflare R2.
 
 **Steps:**
 1. Aggressive cleanup of runner (removes JDK, .NET, Android SDK, etc. to free disk space)

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -37,6 +37,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **pilothouse** | frostyard-pilothouse | Pilothouse local web administration console for Snosi (pilothouse web UI + pilothoused root broker) — downloaded via `verified_download()` from frostyard/pilothouse GitHub releases |
 | **podman** | podman | Podman, distrobox, buildah, crun, slirp4netns |
 | **tailscale** | tailscale | Tailscale VPN client |
+| **sunshine** | sunshine | Sunshine self-hosted game streaming host (official pinned Trixie .deb via verified_download) |
 | **vscode** | code | Visual Studio Code desktop application (from packages.microsoft.com) |
 
 ## Sysext Configuration Pattern
@@ -117,7 +118,7 @@ installed" at build time, contributes nothing to the delta, and its paths will
 always fail the check even though they exist at runtime — caught live when
 `wget` in debdev's list failed CI on the first run.
 
-`code-server`, `coder`, `edge`, `bitwarden`, `github-copilot`, `paseo`, and `azurevpn` are the current exceptions to the `Packages=` line: each downloads a pinned upstream artifact with `verified_download()` and installs it with `dpkg -i`. `github-copilot` uses GitHub's official `.deb`; its Tauri payload already has a native `/usr` layout. The shared postoutput script resolves every `KEYPACKAGE` version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file `Exec=` rewrite, deps via `Include=`. `paseo` is the same shape again (`shared/packages/paseo/`), plus the `edge`-style update-alternatives repointing (its deb registers `/usr/bin/Paseo` through `/etc/alternatives`, which a sysext never ships).
+`code-server`, `coder`, `edge`, `bitwarden`, `github-copilot`, `paseo`, `sunshine`, and `azurevpn` are the current exceptions to the `Packages=` line: each downloads a pinned upstream artifact with `verified_download()` and installs it with `dpkg -i`. `github-copilot` uses GitHub's official `.deb`; its Tauri payload already has a native `/usr` layout. The shared postoutput script resolves every `KEYPACKAGE` version from the merged dpkg database. `edge` does the same via the shared `shared/packages/edge/mkosi.postinst.d/edge.chroot` (pinned Edge .deb, postinst repo hooks stripped, `/opt/microsoft/msedge` relocated to `/usr/lib/microsoft-edge`, product logos symlinked into hicolor); its runtime dependency list comes from `Include=%D/shared/packages/edge/mkosi.conf`, shared with the loaded profiles so the two never drift. `bitwarden` follows the same shape (`shared/packages/bitwarden/`): pinned .deb, `/opt/Bitwarden` relocated to `/usr/lib/Bitwarden`, SUID `chrome-sandbox`, desktop-file `Exec=` rewrite, deps via `Include=`. `paseo` is the same shape again (`shared/packages/paseo/`), plus the `edge`-style update-alternatives repointing (its deb registers `/usr/bin/Paseo` through `/etc/alternatives`, which a sysext never ships).
 
 ## Sysext-Specific Extra Files
 
@@ -150,6 +151,12 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `/usr/bin/paseo` symlinks the bundled CLI wrapper (`resources/bin/paseo`), which resolves symlinks back into the bundle itself
 - Its postinst's AppArmor block is a no-op in the buildroot, and would only write to `/etc` (stripped) anyway
 - Desktop app with no systemd service: no preset, no `Upholds=` drop-in; ships hicolor icons → `sysext-strip-icon-cache.sh` required
+
+### sunshine
+- `mkosi.postinst.chroot` downloads Sunshine's official pinned Trixie `.deb` with `verified_download()` and installs it with `dpkg -i`; its payload already uses the native `/usr` layout, so no relocation is needed
+- Desktop-only self-hosted game streaming host for Moonlight; retain the package's `cap_sys_admin,cap_sys_nice` file capability on `/usr/bin/sunshine`, `uhid` modules-load entry, and udev access rules
+- The upstream `app-dev.lizardbyte.app.Sunshine.service` user unit is available for manual user startup only: no user preset and no `Upholds=` drop-in provide automatic activation
+- Ships a hicolor icon, so `sysext-strip-icon-cache.sh` is required
 
 ### claude-desktop
 - No `mkosi.extra/` and no postinst — the Anthropic `claude-desktop` deb (apt repo at `downloads.claude.ai/claude-desktop/apt/stable`, registered in `mkosi.sandbox`) installs natively under `/usr` (`/usr/lib/claude-desktop` + `/usr/bin/claude-desktop` symlink), so no relocation is needed

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -155,6 +155,7 @@ Some sysexts include extra files via `mkosi.extra/`:
 ### sunshine
 - `mkosi.postinst.chroot` downloads Sunshine's official pinned Trixie `.deb` with `verified_download()` and installs it with `dpkg -i`; its payload already uses the native `/usr` layout, so no relocation is needed
 - Desktop-only self-hosted game streaming host for Moonlight; retain the package's `cap_sys_admin,cap_sys_nice` file capability on `/usr/bin/sunshine`, `uhid` modules-load entry, and udev access rules
+- After first enabling and merging the sysext, the `uhid` modules-load entry and virtual-input udev rules take effect on the next boot unless manually applied
 - The upstream `app-dev.lizardbyte.app.Sunshine.service` user unit is available for manual user startup only: no user preset and no `Upholds=` drop-in provide automatic activation
 - Ships a hicolor icon, so `sysext-strip-icon-cache.sh` is required
 

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -36,8 +36,8 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **paseo** | paseo | Paseo coding agent workspace desktop app (pinned .deb via verified_download from getpaseo/paseo GitHub releases, relocated from /opt) |
 | **pilothouse** | frostyard-pilothouse | Pilothouse local web administration console for Snosi (pilothouse web UI + pilothoused root broker) — downloaded via `verified_download()` from frostyard/pilothouse GitHub releases |
 | **podman** | podman | Podman, distrobox, buildah, crun, slirp4netns |
-| **tailscale** | tailscale | Tailscale VPN client |
 | **sunshine** | sunshine | Sunshine self-hosted game streaming host (official pinned Trixie .deb via verified_download) |
+| **tailscale** | tailscale | Tailscale VPN client |
 | **vscode** | code | Visual Studio Code desktop application (from packages.microsoft.com) |
 
 ## Sysext Configuration Pattern

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -371,7 +371,7 @@ install: `/var/lib/dpkg` is a symlink to `../../usr/lib/sysimage/dpkg`,
 `usr/share/snosi/var-inventory.txt` exists with at least one
 `image-metadata` line, and no unit failures were introduced; (2)
 `/usr/lib/sysupdate.d/` contains only the three OS transfers (no `.feature`
-files) and `systemd-sysupdate components` enumerates all 21 shipped sysext
+files) and `systemd-sysupdate components` enumerates all 22 shipped sysext
 components; (3) two ad hoc test components (`testa`, `testb`, independently
 versioned) created under `/etc/sysupdate.<name>.d/` update independently via
 `--component=`, leave the GPT partition table and ESP `/EFI/Linux` listing


### PR DESCRIPTION
## Summary
- add the official pinned Sunshine Trixie package as a desktop-only sysext
- preserve upstream uhid, udev, file-capability, and manual user-service behavior
- add component publication metadata and automated release tracking

## Testing
- built the real Sunshine sysext and verified package version `2026.516.143833`
- mounted the EROFS artifact and verified `cap_sys_admin,cap_sys_nice=p`, required paths, no hicolor cache, and manual-only activation
- passed Sunshine capability/dependency fixtures, verified-download and required-path fixtures, native contracts (129 checks), profile dependency guard, runtime `/etc` guard, ShellCheck, Actionlint, and diff checks
