### PR TITLE
fix: stage candidate ukify kernel inputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,18 @@ refuses pre-mounted/missing rootfs proc paths and unmounts before any image
 mutation. Storage-digest authority remains bootc inside the candidate OCI image.
 Direct ukify executes as `/usr/bin/ukify` inside the pristine first-pass
 candidate with network disabled, individual read-only credential mounts, and a
-public-only writable work mount. The candidate supplies pinned systemd-ukify
-261.1-3 and its dependencies; no host ukify is accepted. The disposable
-container and mounts never enter a layer. Host `.linux`/`.initrd` byte checks
-remain valid because first-pass packaging is a byte-identical `cp -a` snapshot.
+public-only writable work mount. Protected run 30579247524 reached this point
+but cayo job 90995134482 failed because the unprivileged candidate could not
+read its mode-restricted in-image initramfs; no validation, push, signing, or
+promotion ran. Before execution, the assembler canonicalizes the discovered
+in-root kernel/initrd paths, copies their bytes to mode-0644 `linux`/`initrd`
+work inputs, and passes only those fixed work paths to ukify. It compares both
+work inputs against the canonical protected rootfs originals after execution,
+then compares final UKI sections against those same originals. The candidate
+supplies pinned systemd-ukify 261.1-3 and its dependencies; no host ukify is
+accepted. The disposable container and mounts never enter a layer. Host
+`.linux`/`.initrd` byte checks remain valid because first-pass packaging is a
+byte-identical `cp -a` snapshot.
 Candidate execution drops all Linux capabilities and runs as the common numeric
 owner of its mode-0600 credential files; it never adds read-bypass capabilities.
 The active and optional

--- a/README.md
+++ b/README.md
@@ -447,17 +447,22 @@ require a matching host bootc or host libostree ABI; candidate-image bootc
 remains the storage-digest authority.
 Direct ukify similarly runs as `/usr/bin/ukify` inside the pristine first-pass
 candidate, with networking disabled, individual read-only credential mounts,
-and a public-only writable work mount. Its pinned systemd-ukify 261.1-3 and
-dependencies therefore come from the candidate, never the host; the disposable
-container and mounts do not enter a layer. Host `.linux` and `.initrd` byte
-checks remain valid because first-pass packaging is a byte-identical `cp -a`
-snapshot.
+and a public-only writable work mount. Protected run `30579247524` exposed that
+the unprivileged candidate cannot read a mode-restricted in-image initramfs.
+The assembler therefore canonicalizes in-root kernel/initrd sources, stages
+byte-identical mode-0644 public copies at fixed work paths, compares them with
+the protected originals after ukify, and validates final UKI sections against
+those originals. Its pinned systemd-ukify 261.1-3 and dependencies therefore
+come from the candidate, never the host; the disposable container and mounts do
+not enter a layer. Host `.linux` and `.initrd` byte checks remain valid because
+first-pass packaging is a byte-identical `cp -a` snapshot.
 The candidate runs with all Linux capabilities dropped as the common numeric
 credential owner, retaining mode-0600 credentials without capabilities.
 Protected active
 and optional previous PCR public identities remain outside the writable mount;
 the copied public inputs are checked against those identities after execution.
-This is not production Secure Boot support: published `latest` images inspected
+This remains not production Secure Boot support: the failed protected run did
+not reach validation, push, signing, or promotion, and published `latest` images inspected
 on 2026-07-27 lacked `io.snosi.bootc.secureboot-capable` and are unsuitable for
 the secure install/update harnesses. MOK/TPM enrollment and full secure
 installation remain blocked pending signed secure N/N+1/N+2/transition OCI

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -27,6 +27,20 @@ The adapter relies on all of the following observed behavior:
    fail before Podman.
    Its authoritative active and optional previous PCR public identities remain
    outside the writable work mount; exposed copies must match after execution.
+9. Protected run `30579247524` showed that this unprivileged candidate cannot
+   read a mode-restricted in-image initramfs. The adapter canonicalizes each
+   discovered in-root kernel/initrd source, stages only byte-identical mode-0644
+   public copies at `/run/snosi-ukify-work/linux` and
+   `/run/snosi-ukify-work/initrd`, and passes those fixed paths to ukify. It
+   compares both exposed copies against their canonical protected rootfs sources
+   after execution and compares final UKI sections against those originals.
+   Symlink escapes are rejected; valid relative and rootfs-absolute internal
+   symlinks resolve to their canonical source. The work mount holds no
+   protected-mode duplicate or private credential; rootfs originals remain the
+   sole authoritative protected inputs.
+
+The cited protected run failed before validation, push, signing, or promotion;
+this fixture-covered behavior is not live secure-publication evidence.
 
 `buildah-package.sh` makes a first, unsigned-label OCI image, computes that
 storage digest through the image's own bootc binary, invokes the assembler,

--- a/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
+++ b/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
@@ -38,7 +38,8 @@ its file list contains executable `/usr/bin/ukify` and the
 `/usr/lib/systemd/ukify -> ../../bin/ukify` compatibility symlink. This is a
 pinned compatibility observation, not an assumed package layout.
 
-Ukify reads these immutable inputs directly from the candidate image:
+The original design expected ukify to read these immutable inputs directly from
+the candidate image:
 
 - `/usr/lib/modules/<kernel>/vmlinuz`;
 - `/usr/lib/modules/<kernel>/initramfs.img`;
@@ -56,6 +57,27 @@ rootfs, then translates every host-side path in the current ukify arguments:
 - output becomes `/run/snosi-ukify-work/uki.efi`.
 
 No host-rootfs or host-work path may remain in the container command.
+
+## Protected-Input Follow-Up
+
+Protected run `30579247524` (cayo job `90995134482`) proved the explicit
+credential-owner fix but then failed with `PermissionError: [Errno 13]` reading
+`/usr/lib/modules/7.1.3+deb13-amd64/initramfs.img`. The candidate correctly ran
+as the unprivileged credential UID with `--cap-drop=all`; it must not receive DAC
+capabilities, run as root, loosen rootfs modes, or mutate the first-pass image.
+Snow and Snowfield also failed Package image, and no validation, push, signing,
+or promotion ran.
+
+The revised design canonicalizes the discovered rootfs kernel and initrd,
+rejecting escape symlinks while allowing relative and rootfs-absolute internal
+symlinks. Before candidate execution it stages byte-identical mode-0644 public
+copies in the assembler-owned work directory. Ukify receives exactly
+`/run/snosi-ukify-work/linux` and `/run/snosi-ukify-work/initrd`. After execution
+the assembler compares those files against the canonical protected originals;
+any candidate rewrite fails closed. Final UKI `.linux` and `.initrd` validation
+also compares against those canonical originals. The originals remain outside
+the mount as the sole protected authority, so this does not expose secrets or
+retain another protected-mode copy.
 
 ## Ephemeral Mount Contract
 

--- a/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
+++ b/docs/superpowers/specs/2026-07-30-bootc-candidate-ukify-design.md
@@ -38,18 +38,15 @@ its file list contains executable `/usr/bin/ukify` and the
 `/usr/lib/systemd/ukify -> ../../bin/ukify` compatibility symlink. This is a
 pinned compatibility observation, not an assumed package layout.
 
-The original design expected ukify to read these immutable inputs directly from
-the candidate image:
-
-- `/usr/lib/modules/<kernel>/vmlinuz`;
-- `/usr/lib/modules/<kernel>/initramfs.img`;
-- `/usr/lib/os-release`;
-- the candidate's pinned `systemd-ukify` and all of its dependencies.
+Ukify reads `/usr/lib/os-release`, pinned `systemd-ukify`, and its dependencies
+from the candidate image. The kernel and initrd use the staged-input contract
+below.
 
 The assembler rejects a discovered kernel or initrd path outside the supplied
 rootfs, then translates every host-side path in the current ukify arguments:
 
-- kernel and initrd become their absolute paths below `/usr/lib/modules`;
+- kernel and initrd become `/run/snosi-ukify-work/linux` and
+  `/run/snosi-ukify-work/initrd` after canonical staging;
 - os-release becomes `@/usr/lib/os-release`;
 - active and previous PCR private keys become fixed credential mount paths;
 - MOK private key and certificate become fixed credential mount paths;

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -11,6 +11,8 @@ readonly CANDIDATE_UKIFY_MOK_CERT=/run/snosi-ukify-mok.crt
 readonly CANDIDATE_UKIFY_PCR_KEY=/run/snosi-ukify-pcr.key
 readonly CANDIDATE_UKIFY_PREVIOUS_KEY=/run/snosi-ukify-previous-pcr.key
 readonly CANDIDATE_UKIFY_WORK=/run/snosi-ukify-work
+readonly CANDIDATE_UKIFY_LINUX="$CANDIDATE_UKIFY_WORK/linux"
+readonly CANDIDATE_UKIFY_INITRD="$CANDIDATE_UKIFY_WORK/initrd"
 
 die() { echo "Error: $*" >&2; exit 1; }
 valid_digest() { [[ ${1:-} =~ ^[[:xdigit:]]{128}$ ]]; }
@@ -321,6 +323,32 @@ rootfs_image_path() { # rootfs host-path
     printf '/%s\n' "$relative"
 }
 
+rootfs_source_path() { # rootfs discovered-host-path
+    local root=$1 source=$2 canonical_root image_path
+    canonical_root=$(realpath -e "$root") || die "rootfs path cannot be resolved: $root"
+    image_path=$(rootfs_image_path "$root" "$source")
+    printf '%s%s\n' "$canonical_root" "$image_path"
+}
+
+stage_public_kernel_inputs() { # rootfs kernel initrd work-directory
+    local root=$1 kernel=$2 initrd=$3 work=$4 source_kernel source_initrd
+    source_kernel=$(rootfs_source_path "$root" "$kernel")
+    source_initrd=$(rootfs_source_path "$root" "$initrd")
+    [[ -f "$source_kernel" && -f "$source_initrd" ]] || die "canonical kernel inputs must be regular files"
+    install -m 0644 "$source_kernel" "$work/linux"
+    install -m 0644 "$source_initrd" "$work/initrd"
+    cmp -s "$source_kernel" "$work/linux" || die "staged kernel differs from canonical rootfs source"
+    cmp -s "$source_initrd" "$work/initrd" || die "staged initrd differs from canonical rootfs source"
+}
+
+verify_exposed_kernel_inputs() { # rootfs kernel initrd work-directory
+    local root=$1 kernel=$2 initrd=$3 work=$4 source_kernel source_initrd
+    source_kernel=$(rootfs_source_path "$root" "$kernel")
+    source_initrd=$(rootfs_source_path "$root" "$initrd")
+    cmp -s "$source_kernel" "$work/linux" || die "candidate changed staged kernel input"
+    cmp -s "$source_initrd" "$work/initrd" || die "candidate changed staged initrd input"
+}
+
 verify_exposed_pcr_public_keys() { # active-public work-directory [previous-public]
     local active=$1 work=$2 previous=${3:-}
     cmp -s "$active" "$work/pcr.pub" || die "candidate changed active PCR public key"
@@ -330,11 +358,10 @@ verify_exposed_pcr_public_keys() { # active-public work-directory [previous-publ
 
 candidate_ukify_args() { # rootfs kernel initrd digest version previous-key output-array
     local root=$1 kernel=$2 initrd=$3 digest=$4 version=$5 previous_key=$6 output_name=$7
-    local image_kernel image_initrd
     local -n output="$output_name"
-    image_kernel=$(rootfs_image_path "$root" "$kernel")
-    image_initrd=$(rootfs_image_path "$root" "$initrd")
-    output=(build --linux "$image_kernel" --initrd "$image_initrd"
+    rootfs_image_path "$root" "$kernel" >/dev/null
+    rootfs_image_path "$root" "$initrd" >/dev/null
+    output=(build --linux "$CANDIDATE_UKIFY_LINUX" --initrd "$CANDIDATE_UKIFY_INITRD"
         --os-release @/usr/lib/os-release --cmdline "rw composefs=?$digest"
         --uname "$version" --pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY"
         --secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
@@ -352,7 +379,7 @@ candidate_ukify_args() { # rootfs kernel initrd digest version previous-key outp
 
 assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     local root=$1 mok_key=$2 mok_cert=$3 pcr_key=$4 pcr_cert=$5 previous_cert=${6:-}
-    local previous_key=${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-} digest kernel_info version kernel initrd work gate primary_public previous_public uki ukify_status ukify_image
+    local previous_key=${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-} digest kernel_info version kernel initrd canonical_kernel canonical_initrd work gate primary_public previous_public uki ukify_status ukify_image
     local -a ukify_args
     [[ -d "$root" ]] || die "rootfs directory is missing"
     validate_keypair "$mok_key" "$mok_cert" "MOK"
@@ -375,6 +402,8 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     refuse_existing_uki "$root"
     kernel_info=$(discover_kernel "$root")
     IFS=$'\t' read -r version kernel initrd <<<"$kernel_info"
+    canonical_kernel=$(rootfs_source_path "$root" "$kernel")
+    canonical_initrd=$(rootfs_source_path "$root" "$initrd")
     ukify_image=${SNOSI_BOOTC_SECURE_UKIFY_IMAGE:-}
     [[ -n $ukify_image ]] || die "missing first-pass candidate image for ukify"
     work=$(mktemp -d)
@@ -386,6 +415,7 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
         previous_public="$gate/previous.pub"
         install -m 0644 "$previous_public" "$work/previous.pub"
     fi
+    stage_public_kernel_inputs "$root" "$kernel" "$initrd" "$work"
     candidate_ukify_args "$root" "$kernel" "$initrd" "$digest" "$version" "$previous_key" ukify_args
     credential_gate_scan_tree "$gate" "ukify work directory before candidate execution" "$work"
     set +e
@@ -395,6 +425,7 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     ukify_status=$?
     set -e
     [[ $ukify_status -eq 0 ]] || die "ukify failed"
+    verify_exposed_kernel_inputs "$root" "$kernel" "$initrd" "$work"
     verify_exposed_pcr_public_keys "$primary_public" "$work" "$previous_public"
     credential_gate_scan_tree "$gate" "ukify work directory after candidate execution" "$work"
     credential_gate_scan_file "$gate" "sanitized ukify log" ukify.log "$work/ukify.log"
@@ -402,7 +433,7 @@ assemble() { # rootfs mok-key mok-cert pcr-key pcr-cert [previous-pcr-cert]
     mkdir -p "$(dirname "$uki")"
     install -m 0644 "$work/uki.efi" "$uki"
     sign_systemd_boot "$root" "$mok_cert"
-    validate_uki "$uki" "$kernel" "$initrd" "$mok_cert" "$primary_public" "$digest" "$previous_public"
+    validate_uki "$uki" "$canonical_kernel" "$canonical_initrd" "$mok_cert" "$primary_public" "$digest" "$previous_public"
     credential_gate_scan_tree "$gate" rootfs "$root"
 }
 
@@ -436,7 +467,7 @@ EOF
     fi
     candidate_ukify_args "$root" "$root/usr/lib/modules/one/vmlinuz" "$root/usr/lib/modules/one/initramfs.img" \
         fixture one "" fixture_args
-    expected_args=(build --linux /usr/lib/modules/one/vmlinuz --initrd /usr/lib/modules/one/initramfs.img
+    expected_args=(build --linux /run/snosi-ukify-work/linux --initrd /run/snosi-ukify-work/initrd
         --os-release @/usr/lib/os-release --cmdline 'rw composefs=?fixture' --uname one
         --pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY" --secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
         --secureboot-certificate "$CANDIDATE_UKIFY_MOK_CERT" --measure --output "$CANDIDATE_UKIFY_WORK/uki.efi"
@@ -479,6 +510,12 @@ if [[ ${CANDIDATE_UKIFY_TEST_OVERWRITE_ACTIVE_PUB:-0} == 1 ]]; then
 fi
 if [[ ${CANDIDATE_UKIFY_TEST_OVERWRITE_PREVIOUS_PUB:-0} == 1 ]]; then
     printf 'candidate-mutated-previous-public-key\n' >"$host_work/previous.pub"
+fi
+if [[ ${CANDIDATE_UKIFY_TEST_OVERWRITE_LINUX:-0} == 1 ]]; then
+    printf 'candidate-mutated-linux\n' >"$host_work/linux"
+fi
+if [[ ${CANDIDATE_UKIFY_TEST_OVERWRITE_INITRD:-0} == 1 ]]; then
+    printf 'candidate-mutated-initrd\n' >"$host_work/initrd"
 fi
 if [[ ${CANDIDATE_UKIFY_TEST_NO_OUTPUT:-0} != 1 ]]; then
     if [[ ${CANDIDATE_UKIFY_TEST_EMPTY_OUTPUT:-0} == 1 ]]; then
@@ -570,6 +607,54 @@ EOF
         die "internal rootfs symlink translation failed"
     [[ $(rootfs_image_path "$root" "$root/absolute-internal-link") == /usr/lib/modules/one/vmlinuz ]] ||
         die "absolute internal rootfs symlink translation failed"
+
+    # The source is mode 0600; unprivileged fixtures cannot emulate root ownership.
+    # The candidate receives public, byte-identical work copies instead.
+    printf 'fixture kernel bytes\n' >"$root/usr/lib/modules/one/vmlinuz"
+    printf 'fixture initrd bytes\n' >"$root/usr/lib/modules/one/initramfs.img"
+    chmod 0600 "$root/usr/lib/modules/one/vmlinuz" "$root/usr/lib/modules/one/initramfs.img"
+    local staged_work="$top/work-staged-inputs"
+    mkdir "$staged_work"
+    stage_public_kernel_inputs "$root" "$root/absolute-internal-link" \
+        "$root/usr/lib/modules/one/initramfs.img" "$staged_work"
+    [[ $(/usr/bin/stat -c '%a' "$staged_work/linux") == 644 && $(/usr/bin/stat -c '%a' "$staged_work/initrd") == 644 ]] ||
+        die "staged public kernel inputs are not mode 0644"
+    cmp -s "$root/usr/lib/modules/one/vmlinuz" "$staged_work/linux" || die "staged kernel differs from source"
+    cmp -s "$root/usr/lib/modules/one/initramfs.img" "$staged_work/initrd" || die "staged initrd differs from source"
+    verify_exposed_kernel_inputs "$root" "$root/absolute-internal-link" \
+        "$root/usr/lib/modules/one/initramfs.img" "$staged_work"
+    printf 'candidate-mutated-linux\n' >"$staged_work/linux"
+    if (verify_exposed_kernel_inputs "$root" "$root/absolute-internal-link" \
+        "$root/usr/lib/modules/one/initramfs.img" "$staged_work") >/dev/null 2>&1; then
+        die "candidate kernel input overwrite accepted"
+    fi
+    cp "$root/usr/lib/modules/one/vmlinuz" "$staged_work/linux"
+    printf 'candidate-mutated-initrd\n' >"$staged_work/initrd"
+    if (verify_exposed_kernel_inputs "$root" "$root/absolute-internal-link" \
+        "$root/usr/lib/modules/one/initramfs.img" "$staged_work") >/dev/null 2>&1; then
+        die "candidate initrd input overwrite accepted"
+    fi
+
+    cp "$root/usr/lib/modules/one/vmlinuz" "$staged_work/linux"
+    cp "$root/usr/lib/modules/one/initramfs.img" "$staged_work/initrd"
+    PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-overwrite-linux.args" \
+        CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" CANDIDATE_UKIFY_TEST_OVERWRITE_LINUX=1 \
+        run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$staged_work" \
+        "$staged_work/ukify.log" "$key" "$cert" "$pcr" "" -- build
+    if (verify_exposed_kernel_inputs "$root" "$root/absolute-internal-link" \
+        "$root/usr/lib/modules/one/initramfs.img" "$staged_work") >/dev/null 2>&1; then
+        die "candidate kernel overwrite through work mount accepted"
+    fi
+    cp "$root/usr/lib/modules/one/vmlinuz" "$staged_work/linux"
+    cp "$root/usr/lib/modules/one/initramfs.img" "$staged_work/initrd"
+    PATH="$top/bin:$PATH" CANDIDATE_UKIFY_TEST_ARGS="$top/podman-overwrite-initrd.args" \
+        CANDIDATE_UKIFY_TEST_PRIVATE_KEY="$pcr" CANDIDATE_UKIFY_TEST_OVERWRITE_INITRD=1 \
+        run_candidate_ukify localhost/snosi-bootc-secure-first-fixture "$staged_work" \
+        "$staged_work/ukify.log" "$key" "$cert" "$pcr" "" -- build
+    if (verify_exposed_kernel_inputs "$root" "$root/absolute-internal-link" \
+        "$root/usr/lib/modules/one/initramfs.img" "$staged_work") >/dev/null 2>&1; then
+        die "candidate initrd overwrite through work mount accepted"
+    fi
 
     local previous="$top/previous.key" protected="$top/protected" overwrite_work="$top/work-overwrite-active"
     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$previous" >/dev/null 2>&1
@@ -801,9 +886,11 @@ EOF
 }
 
 validate() { # rootfs image mok-cert pcr-cert [previous-pcr-cert]
-    local root=$1 image=$2 mok=$3 pcr=$4 previous=${5:-} version kernel initrd digest uki loader source work
+    local root=$1 image=$2 mok=$3 pcr=$4 previous=${5:-} version kernel initrd canonical_kernel canonical_initrd digest uki loader source work
     validate_root_contract "$root"
     kernel_info=$(discover_kernel "$root"); IFS=$'\t' read -r version kernel initrd <<<"$kernel_info"
+    canonical_kernel=$(rootfs_source_path "$root" "$kernel")
+    canonical_initrd=$(rootfs_source_path "$root" "$initrd")
     uki="$root/boot/EFI/Linux/$version.efi"; [[ -f "$uki" ]] || die "missing assembled UKI"
     loader="$root/boot/EFI/BOOT/grubx64.efi"; [[ -f "$loader" ]] || die "missing signed systemd-boot"
     source="$root/usr/lib/snosi/bootc/systemd-bootx64.efi"; [[ -f "$source" ]] || die "missing immutable signed systemd-boot source"
@@ -815,7 +902,7 @@ validate() { # rootfs image mok-cert pcr-cert [previous-pcr-cert]
     work=$(mktemp -d); trap 'rm -rf -- "$work"' RETURN
     openssl pkey -pubin -in "$pcr" -pubout -out "$work/pcr.pub"
     [[ -z "$previous" ]] || openssl pkey -pubin -in "$previous" -pubout -out "$work/previous.pub"
-    validate_uki "$uki" "$kernel" "$initrd" "$mok" "$work/pcr.pub" "$digest" "${previous:+$work/previous.pub}"
+    validate_uki "$uki" "$canonical_kernel" "$canonical_initrd" "$mok" "$work/pcr.pub" "$digest" "${previous:+$work/previous.pub}"
 }
 
 case ${1:-} in

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -76,15 +76,22 @@ not enter this fragment, its tree, OCI layers, labels, logs, or retained temp
 state. Direct ukify runs as `/usr/bin/ukify` in the first-pass candidate with
 `--network=none`, `--cap-drop=all`, `--security-opt label=type:unconfined_t`,
 a fixed entrypoint, and the common numeric credential owner via `--user`.
-Mismatched owners fail before Podman. The assembler resolves and translates in-root
-kernel/initrd paths to candidate paths, mounts each caller credential read-only
-at fixed `/run/snosi-ukify-*`
-paths, and gives it exactly one writable `/run/snosi-ukify-work` mount. The
+Mismatched owners fail before Podman. Protected run 30579247524 then exposed
+that this unprivileged, capability-free candidate cannot read a mode-restricted
+in-image initramfs. The assembler canonicalizes the discovered in-root
+kernel/initrd paths, stages byte-identical mode-0644 copies as fixed
+`/run/snosi-ukify-work/linux` and `/run/snosi-ukify-work/initrd` arguments, and
+mounts each caller credential read-only at fixed `/run/snosi-ukify-*` paths.
+It gives the candidate exactly one writable `/run/snosi-ukify-work` mount. The
 work directory is scanned for caller credentials both before and after candidate
-execution, so it carries only public inputs and output. The authoritative active
-and optional previous PCR public identities stay in the unmounted gate directory;
-the work copies must match them after candidate execution. Native A/B profiles
-do not include it and continue using `shared/native-ab-secure/` independently.
+execution; its staged inputs must compare with the canonical protected rootfs
+sources after execution, and final UKI sections compare with those originals.
+The authoritative active and optional previous PCR public identities stay in the
+unmounted gate directory; their work copies must also match after candidate
+execution. This fixture-covered fix has no live protected-build success claim:
+the failed run did not reach validation, push, signing, or promotion. Native A/B
+profiles do not include it and continue using `shared/native-ab-secure/`
+independently.
 
 **Bootc shim second-stage reconciliation (Task 7):** the secure tree ships
 `snosi-bootc-bootloader-reconcile.service` with a static


### PR DESCRIPTION
## Summary
- stage canonical kernel and initrd bytes as mode-0644 public inputs in the existing candidate work mount
- pass fixed `/run/snosi-ukify-work/linux` and `initrd` paths to candidate ukify without adding capabilities or weakening rootfs modes
- reject candidate rewrites by comparing staged inputs and final UKI sections against canonical protected rootfs originals
- document the protected failure and revised staged-input compatibility boundary

## Root Cause
Protected run [30579247524](https://github.com/frostyard/snosi/actions/runs/30579247524), cayo job [90995134482](https://github.com/frostyard/snosi/actions/runs/30579247524/job/90995134482), confirmed the credential-owner fix and then failed because the unprivileged, capability-free candidate could not read the root-owned mode-restricted in-image initramfs. Snow and Snowfield failed in the same `Package image` stage. Validation, push, signing, and promotion did not run.

## Testing
- `test/bootc-secure-artifact-test.sh --fixtures`
- `test/bootc-secure-artifact-negative-test.sh --fixtures`
- `test/bootc-secure-package-cleanup-test.sh`
- `test/bootc-publication-guard-test.sh` (29/29)
- `./check-bootc-publication-guard.sh`
- `test/bootc-secure-publication-test.sh --fixtures` (19/19)
- `test/bootc-secure-docs-test.sh`
- `shellcheck shared/bootc-secure/assemble-uki.sh shared/outformat/image/buildah-package.sh test/bootc-secure-package-cleanup-test.sh`
- `git diff --check origin/main..HEAD`

## Evidence Boundary
The next protected three-profile run remains the live proof of candidate ukify against the staged immutable inputs. No production Secure Boot support is claimed.