### PR TITLE
fix: pass registry auth to bootc verifier

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -284,8 +284,8 @@ jobs:
           cosign-release: "v2.6.1"
 
       - name: Sign immutable image digest
-        # docker/login-action writes the user-context registry credentials
-        # shared by Cosign, Skopeo verification, and latest promotion.
+        # docker/login-action writes the user-context registry credentials used
+        # directly by Cosign and passed explicitly to root Skopeo verification.
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
@@ -299,7 +299,10 @@ jobs:
           VERSION_TAG: ${{ steps.version.outputs.tag }}
           DIGEST: ${{ steps.push.outputs.digest }}
           LOCAL_REF: localhost/snosi-verified-${{ matrix.profile }}:${{ steps.version.outputs.tag }}
-        run: ./shared/bootc-secure/ci/verify-published-image.sh "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF"
+        run: |
+          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+          ./shared/bootc-secure/ci/verify-published-image.sh \
+            "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
       - name: Validate policy-copied secure artifact
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,9 @@ registry write, validates an immutable version digest, then moves `latest`.
 The protected package step forwards the secure flag and credential paths as
 explicit sudo command assignments; GitHub step environment values do not cross
 sudo implicitly, and secret bytes remain only in the mode-0600 files.
+The remote verifier passes Docker login's auth file explicitly to root Skopeo
+as source-only authentication; it never relies on sudo preserving a usable
+user runtime auth path or on root Buildah's credential-store defaults.
 Local and policy-copied artifact validation use host Podman to execute the
 candidate image's pinned bootc; they do not require or accept an independently
 installed host bootc as the storage-digest authority.

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -176,6 +176,10 @@ else
         if ! grep -Fq './shared/bootc-secure/ci/verify-published-image.sh' <<<"$verifier_step"; then
             fail_check "$workflow secure-build: missing secure image verifier call"
         fi
+        require_text "$workflow secure verifier auth path" \
+            "$verifier_step" '          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"'
+        require_text "$workflow secure verifier auth argument" \
+            "$verifier_step" '            "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"'
     fi
 
     ordered_steps=(
@@ -202,6 +206,8 @@ else
     verifier_text=$(<"$verifier")
     require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-capable"] == "true" and'
     require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.3-storage-digest-v1"'
+    require_text "$verifier" "$verifier_text" \
+        'sudo skopeo copy --src-authfile "$AUTH_FILE" \'
 fi
 
 if ((fail)); then

--- a/docs/bootc-secure-operations.md
+++ b/docs/bootc-secure-operations.md
@@ -48,12 +48,14 @@ immutable version digest before moving `latest`, deletes credentials before any
 registry write, and then advances the tracking tag.
 
 GitHub's `native-build` environment must be restricted to protected/default
-branches and have no required reviewer. Root Skopeo receives the Docker login
-auth file explicitly through --src-authfile. Do not rely on inherited
-`XDG_RUNTIME_DIR`, root Buildah credentials, or registry visibility as the
-authentication mechanism for the policy-copy gate. Candidate publication, tag
-movement, and an image labelled secure are not substitutes for the blocked live
-installation and hardware gates.
+branches and have no required reviewer. Root Skopeo receives the Docker login auth file explicitly through --src-authfile.
+The Docker auth file from `docker/login-action` must be directly consumable by
+root Skopeo without user-scoped credential-helper state; otherwise verification
+fails closed. The next protected run remains the live proof. Do not rely on
+inherited `XDG_RUNTIME_DIR`, root Buildah credentials, or registry visibility as
+the authentication mechanism for the policy-copy gate. Candidate publication,
+tag movement, and an image labelled secure are not substitutes for the blocked
+live installation and hardware gates.
 
 ## Fresh Installation
 

--- a/docs/bootc-secure-operations.md
+++ b/docs/bootc-secure-operations.md
@@ -48,10 +48,12 @@ immutable version digest before moving `latest`, deletes credentials before any
 registry write, and then advances the tracking tag.
 
 GitHub's `native-build` environment must be restricted to protected/default
-branches and have no required reviewer. GHCR packages must remain public for the
-current root Skopeo policy-copy gate unless root registry authentication is
-added. Candidate publication, tag movement, and an image labelled secure are
-not substitutes for the blocked live installation and hardware gates.
+branches and have no required reviewer. Root Skopeo receives the Docker login
+auth file explicitly through --src-authfile. Do not rely on inherited
+`XDG_RUNTIME_DIR`, root Buildah credentials, or registry visibility as the
+authentication mechanism for the policy-copy gate. Candidate publication, tag
+movement, and an image labelled secure are not substitutes for the blocked live
+installation and hardware gates.
 
 ## Fresh Installation
 

--- a/docs/superpowers/plans/2026-07-30-bootc-verifier-auth-boundary.md
+++ b/docs/superpowers/plans/2026-07-30-bootc-verifier-auth-boundary.md
@@ -1,0 +1,354 @@
+# Bootc Verifier Registry-Auth Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make protected root Skopeo verification consume the authenticated Docker source explicitly instead of inheriting an inaccessible runner `XDG_RUNTIME_DIR` path.
+
+**Architecture:** `docker/login-action` remains the user-context login authority. The workflow passes its Docker configuration path as a fifth verifier argument, and the verifier validates that file before supplying it only to root Skopeo's immutable registry source through `--src-authfile`; existing inspect, Cosign, policy, root containers-storage, and promotion boundaries remain unchanged.
+
+**Tech Stack:** Bash, GitHub Actions YAML, Skopeo, Cosign, jq, ShellCheck
+
+## Global Constraints
+
+- Keep the repair local to remote verification; do not change working Buildah push, Cosign signing, or promotion authentication.
+- The verifier interface is `verify-published-image.sh IMAGE VERSION_TAG EXPECTED_DIGEST LOCAL_REF AUTH_FILE`.
+- `AUTH_FILE` must name an existing regular file before any policy copy runs.
+- Pass credentials only as `sudo skopeo copy --src-authfile "$AUTH_FILE"`; never put a PAT or `username:password` in process arguments.
+- Do not infer root credentials from `XDG_RUNTIME_DIR`, root Buildah state, or earlier command defaults.
+- Do not print or copy credential contents into repository state.
+- Preserve immutable digest verification, exact secure labels, Cosign verification, restrictive policy copy, root containers-storage destination, and validation-before-`latest` ordering.
+- A protected workflow pass is one candidate set, not installed-system Task 9 evidence or distinct N/N+1/N+2 evidence.
+
+---
+
+### Task 1: Explicit Registry-Auth Handoff
+
+**Files:**
+- Modify: `test/bootc-secure-publication-test.sh:8-130`
+- Modify: `shared/bootc-secure/ci/verify-published-image.sh:10-56`
+- Modify: `.github/workflows/build-images.yml:286-302`
+- Modify: `test/bootc-publication-guard-test.sh:44-167`
+- Modify: `check-bootc-publication-guard.sh:171-205`
+
+**Interfaces:**
+- Consumes: Docker-compatible auth JSON written at `${DOCKER_CONFIG:-$HOME/.docker}/config.json` by `docker/login-action`.
+- Produces: `verify-published-image.sh IMAGE VERSION_TAG EXPECTED_DIGEST LOCAL_REF AUTH_FILE`, which imports the signed immutable source into root containers-storage using that exact source auth file.
+
+- [ ] **Step 1: Add a failing verifier fixture for the explicit source auth file**
+
+In `test/bootc-secure-publication-test.sh`, add an auth-file variable, create a harmless fixture after `WORK` is initialized, pass it as the fifth helper argument, and require the policy copy to carry it:
+
+```bash
+AUTH_FILE=""
+
+run_helper() { # image version digest local-ref auth-file
+    local output status
+    set +e
+    output=$(PATH="$WORK/bin:$PATH" COMMAND_LOG="$WORK/commands" COPIED_POLICY="$WORK/copied-policy.json" "$HELPER" "$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n%s\n' "$status" "$output"
+}
+
+run_case() { # description expected-status image version digest local-ref auth-file
+    local result status output
+    : >"$WORK/commands"
+    result=$(run_helper "$3" "$4" "$5" "$6" "$7")
+    status=${result%%$'\n'*}
+    output=${result#*$'\n'}
+    if [[ $2 == success ]]; then
+        assert_success "$1" "$status" "$output"
+    else
+        assert_failure "$1" "$status" "$output"
+    fi
+}
+
+WORK=$(mktemp -d)
+mkdir -p "$WORK/bin"
+AUTH_FILE="$WORK/auth.json"
+printf '{"auths":{}}\n' >"$AUTH_FILE"
+```
+
+Update every existing `run_case` invocation to append `"$AUTH_FILE"`. After the accepted-image command assertions, add:
+
+```bash
+grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" &&
+        pass "root policy copy receives the explicit source auth file" ||
+        fail "root policy copy receives the explicit source auth file"
+if ! sed -n '1,2p' "$WORK/commands" | grep -Fq -- '--src-authfile'; then
+    pass "inspect and Cosign do not receive the root copy auth option"
+else
+    fail "inspect and Cosign do not receive the root copy auth option"
+fi
+run_case "missing source auth file is rejected" failure \
+    "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$WORK/missing-auth.json"
+run_case "non-regular source auth path is rejected" failure \
+    "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$WORK"
+```
+
+- [ ] **Step 2: Run the verifier fixture and verify the new assertion fails for the intended reason**
+
+Run:
+
+```bash
+./test/bootc-secure-publication-test.sh
+```
+
+Expected: nonzero with `not ok - root policy copy receives the explicit source auth file`; the existing helper still accepts only four arguments and therefore cannot satisfy the new contract.
+
+- [ ] **Step 3: Implement the minimal verifier and workflow handoff**
+
+In `shared/bootc-secure/ci/verify-published-image.sh`, change argument parsing to:
+
+```bash
+if [[ $# -ne 5 ]]; then
+    printf 'usage: %s IMAGE VERSION_TAG EXPECTED_DIGEST LOCAL_REF AUTH_FILE\n' "${0##*/}" >&2
+    exit 2
+fi
+
+IMAGE=$1
+VERSION_TAG=$2
+EXPECTED_DIGEST=$3
+LOCAL_REF=$4
+AUTH_FILE=$5
+
+if [[ ! -f $AUTH_FILE ]]; then
+    printf 'source registry auth file is not a regular file\n' >&2
+    exit 2
+fi
+```
+
+Change only the policy-copy invocation:
+
+```bash
+sudo skopeo copy --src-authfile "$AUTH_FILE" \
+    --policy "$work/policy.json" --registries.d "$work/registries.d" \
+    "docker://$IMAGE@$EXPECTED_DIGEST" "containers-storage:$LOCAL_REF"
+```
+
+In `.github/workflows/build-images.yml`, replace the verifier's one-line `run` with:
+
+```yaml
+        run: |
+          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+          ./shared/bootc-secure/ci/verify-published-image.sh \
+            "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
+```
+
+Correct the comment above signing so it no longer claims credentials are implicitly shared with root Skopeo:
+
+```yaml
+        # docker/login-action writes the user-context registry credentials used
+        # directly by Cosign and passed explicitly to root Skopeo verification.
+```
+
+- [ ] **Step 4: Run the verifier fixture and verify it passes**
+
+Run:
+
+```bash
+./test/bootc-secure-publication-test.sh
+```
+
+Expected: exit 0; all prior checks plus the explicit-auth and missing-auth checks pass.
+
+- [ ] **Step 5: Add failing publication-guard mutations for both halves of the handoff**
+
+Update the fixture verifier in `test/bootc-publication-guard-test.sh` to include the required command text:
+
+```bash
+sudo skopeo copy --src-authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST" "containers-storage:$LOCAL_REF"
+```
+
+Update its workflow fixture to use the exact approved call:
+
+```yaml
+      - name: Verify pushed secure image
+        run: |
+          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+          ./shared/bootc-secure/ci/verify-published-image.sh \
+            "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
+```
+
+Add mutations and assertions:
+
+```bash
+remove_workflow_auth_handoff() {
+    perl -0pi -e 's/^          AUTH_FILE=.*\n//m; s/ "\$AUTH_FILE"\n/\n/' \
+        "$1/.github/workflows/build-images.yml"
+}
+remove_verifier_src_authfile() {
+    perl -0pi -e 's/ --src-authfile "\$AUTH_FILE"//' \
+        "$1/shared/bootc-secure/ci/verify-published-image.sh"
+}
+
+assert_guard 'missing workflow auth handoff fails' 1 remove_workflow_auth_handoff
+assert_guard 'missing verifier source auth option fails' 1 remove_verifier_src_authfile
+```
+
+- [ ] **Step 6: Run the guard mutation suite and verify RED**
+
+Run:
+
+```bash
+./test/bootc-publication-guard-test.sh
+```
+
+Expected: nonzero because at least one new mutation unexpectedly passes the existing guard.
+
+- [ ] **Step 7: Enforce the explicit handoff in the production guard**
+
+In `check-bootc-publication-guard.sh`, extend the `verifier_step` checks:
+
+```bash
+        require_text "$workflow secure verifier auth path" \
+            "$verifier_step" '          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"'
+        require_text "$workflow secure verifier auth argument" \
+            "$verifier_step" '            "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"'
+```
+
+Extend the verifier file checks:
+
+```bash
+    require_text "$verifier" "$verifier_text" \
+        'sudo skopeo copy --src-authfile "$AUTH_FILE" \'
+```
+
+- [ ] **Step 8: Run focused tests and static validation**
+
+Run:
+
+```bash
+./test/bootc-secure-publication-test.sh
+./test/bootc-publication-guard-test.sh
+./check-bootc-publication-guard.sh
+actionlint .github/workflows/build-images.yml
+shellcheck -S warning -x \
+  shared/bootc-secure/ci/verify-published-image.sh \
+  test/bootc-secure-publication-test.sh \
+  check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh
+git diff --check
+```
+
+Expected: every command exits 0; the guard mutation suite reports 31 passing assertions and 0 failures.
+
+- [ ] **Step 9: Commit the atomic auth handoff**
+
+```bash
+git add \
+  .github/workflows/build-images.yml \
+  shared/bootc-secure/ci/verify-published-image.sh \
+  test/bootc-secure-publication-test.sh \
+  check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh
+git commit -m "fix: pass registry auth to bootc verifier"
+```
+
+### Task 2: Operational Contract And Final Verification
+
+**Files:**
+- Modify: `test/bootc-secure-docs-test.sh:28-48`
+- Modify: `docs/bootc-secure-operations.md:42-54`
+- Modify: `CLAUDE.md:166-180`
+- Modify: `yeti/ci-cd.md:197-219`
+
+**Interfaces:**
+- Consumes: Task 1's explicit `AUTH_FILE` verifier contract.
+- Produces: Normative and AI-context documentation that no longer requires public GHCR visibility solely because root Skopeo lacked authentication.
+
+- [ ] **Step 1: Add a failing documentation-contract assertion**
+
+Add this exact string to `required_strings` in `test/bootc-secure-docs-test.sh`:
+
+```bash
+    'Root Skopeo receives the Docker login auth file explicitly through --src-authfile.'
+```
+
+- [ ] **Step 2: Run the documentation contract and verify RED**
+
+Run:
+
+```bash
+./test/bootc-secure-docs-test.sh
+```
+
+Expected: nonzero because `docs/bootc-secure-operations.md` does not yet contain the required statement.
+
+- [ ] **Step 3: Update normative and repository-context documentation**
+
+Replace the obsolete public-GHCR caveat in `docs/bootc-secure-operations.md` with:
+
+```markdown
+Root Skopeo receives the Docker login auth file explicitly through --src-authfile.
+Do not rely on inherited `XDG_RUNTIME_DIR`, root Buildah
+credentials, or registry visibility as the authentication mechanism for the
+policy-copy gate.
+```
+
+Add this operational fact to the Task 10 paragraph in `CLAUDE.md`:
+
+```markdown
+The remote verifier passes Docker login's auth file explicitly to root Skopeo
+as source-only authentication; it never relies on sudo preserving a usable
+user runtime auth path or on root Buildah's credential-store defaults.
+```
+
+Extend `yeti/ci-cd.md` immediately after the protected publication paragraph:
+
+```markdown
+The workflow's `docker/login-action` credentials serve user-context Cosign and
+are passed by path to the verifier. Root Skopeo receives that file only through
+`--src-authfile` for the immutable registry source; its local
+`containers-storage:` destination receives no registry credentials. Do not
+infer this handoff from `XDG_RUNTIME_DIR` or root Buildah login state.
+```
+
+- [ ] **Step 4: Run documentation and full relevant validation**
+
+Run:
+
+```bash
+./test/bootc-secure-docs-test.sh
+./test/bootc-secure-publication-test.sh
+./test/bootc-publication-guard-test.sh
+./check-bootc-publication-guard.sh
+actionlint .github/workflows/build-images.yml
+shellcheck -S warning -x \
+  shared/bootc-secure/ci/verify-published-image.sh \
+  test/bootc-secure-publication-test.sh \
+  check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh \
+  test/bootc-secure-docs-test.sh
+git diff --check
+```
+
+Expected: every command exits 0 with no actionlint or ShellCheck diagnostics; the publication guard reports 31 passing assertions and the docs test prints `Bootc secure operations documentation validation passed`.
+
+- [ ] **Step 5: Review the final diff for secret and scope safety**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat HEAD~1
+git status --short
+```
+
+Inspect the diff and confirm it contains no PAT, username/password pair, copied auth JSON, unrelated refactor, production-support claim, or modification outside the files listed by Tasks 1 and 2 plus this plan/spec history.
+
+- [ ] **Step 6: Commit documentation**
+
+```bash
+git add \
+  test/bootc-secure-docs-test.sh \
+  docs/bootc-secure-operations.md \
+  CLAUDE.md \
+  yeti/ci-cd.md
+git commit -m "docs: record bootc verifier auth boundary"
+```
+
+- [ ] **Step 7: Request review before protected execution**
+
+Request an adversarial review focused on credential scope, sudo boundary behavior, fail-closed validation, publication ordering, fixture fidelity, and unsupported support claims. Address findings with the same red-green discipline, then rerun Step 4 before opening a PR or triggering another protected build.

--- a/docs/superpowers/specs/2026-07-30-bootc-verifier-auth-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-30-bootc-verifier-auth-boundary-design.md
@@ -1,0 +1,95 @@
+# Bootc Verifier Registry-Auth Boundary Design
+
+## Problem
+
+Protected `build-images.yml` run `30590168012` proved that Cayo and Snow pass
+secure packaging, local artifact validation, protected credential deletion,
+chunking, immutable push, and Cosign signing. Both then fail at the root policy
+copy in `shared/bootc-secure/ci/verify-published-image.sh`:
+
+```text
+error reading credentials: stat /run/user/1001/containers/auth.json: permission denied
+```
+
+The preceding user-context Skopeo inspection and Cosign verification succeed.
+The failing command is `sudo skopeo copy`. `docker/login-action` creates
+user-context registry credentials, while sudo preserves the runner's
+`XDG_RUNTIME_DIR=/run/user/1001`. Root-side Skopeo consequently selects an
+inaccessible user runtime auth path instead of receiving an explicit source
+credential file. This is a registry-auth handoff defect after successful image
+assembly and signing; it is not a candidate ukify or artifact defect.
+
+## Decision
+
+Keep the repair local to the remote verifier. Add a fifth `AUTH_FILE` argument
+to `verify-published-image.sh`, require it to name an existing regular file, and
+pass it to the root policy copy as:
+
+```text
+sudo skopeo copy --src-authfile "$AUTH_FILE" ...
+```
+
+The workflow supplies the Docker login configuration written by
+`docker/login-action`:
+
+```text
+${DOCKER_CONFIG:-$HOME/.docker}/config.json
+```
+
+The path, not credential contents, crosses the command boundary. Skopeo receives
+the credentials only for the immutable `docker://` source; the local
+`containers-storage:` destination receives no registry credentials. User-context
+Skopeo inspection and Cosign verification remain unchanged.
+
+The verifier must not infer credentials from `XDG_RUNTIME_DIR`, root Buildah
+state, or an earlier command's implementation-specific defaults. It must not
+place a PAT or username/password pair in process arguments, copy registry
+credentials into repository state, or print credential contents.
+
+## Alternatives Rejected
+
+### Unset `XDG_RUNTIME_DIR`
+
+Running root Skopeo with `XDG_RUNTIME_DIR` removed could cause it to discover the
+credentials created by the earlier root Buildah login. This is smaller textually
+but creates an undocumented dependency between distant workflow steps and their
+credential-store defaults.
+
+### Copy Credentials Into Root Runtime State
+
+Copying the Docker configuration under a root runtime directory would work but
+duplicates sensitive material and introduces additional ownership, mode, and
+cleanup obligations without improving the verifier contract.
+
+### Unify Authentication Across the Publication Job
+
+A single explicit auth file shared by Buildah, Cosign, Skopeo, and promotion
+would be coherent but broadens a localized repair across already-working push,
+signing, and promotion paths. That additional regression surface is unnecessary.
+
+## Validation
+
+`test/bootc-secure-publication-test.sh` will provide the regression test. Before
+the production change, the new assertion must fail because the root policy-copy
+command lacks `--src-authfile`. After the change it must prove:
+
+- an accepted immutable secure image is copied with the exact supplied source
+  auth path;
+- the auth option appears only on the root policy-copy command;
+- a missing or non-regular auth file fails before remote copy;
+- existing digest, label, Cosign, policy, ordering, and no-promotion assertions
+  remain green.
+
+`check-bootc-publication-guard.sh` and its mutation fixtures will require the
+workflow verifier step to pass the Docker configuration path and require the
+verifier to use an explicit source auth file. ShellCheck, `git diff --check`,
+the publication fixture, the publication guard mutation suite, and relevant
+documentation tests must pass before another protected run.
+
+## Documentation
+
+Update `CLAUDE.md` and the relevant `yeti/` secure-publication context to record
+that root policy-copy verification receives the user login's auth file
+explicitly. Existing statements that user-context credentials are simply
+"shared" with root Skopeo must be corrected; sudo does not make that boundary
+reliable without an explicit source auth path.

--- a/shared/bootc-secure/ci/verify-published-image.sh
+++ b/shared/bootc-secure/ci/verify-published-image.sh
@@ -7,8 +7,8 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
 POLICY="$ROOT_DIR/shared/bootc-secure/tree/etc/containers/policy.json"
 REGISTRIES="$ROOT_DIR/shared/bootc-secure/tree/etc/containers/registries.d/frostyard.yaml"
 
-if [[ $# -ne 4 ]]; then
-    printf 'usage: %s IMAGE VERSION_TAG EXPECTED_DIGEST LOCAL_REF\n' "${0##*/}" >&2
+if [[ $# -ne 5 ]]; then
+    printf 'usage: %s IMAGE VERSION_TAG EXPECTED_DIGEST LOCAL_REF AUTH_FILE\n' "${0##*/}" >&2
     exit 2
 fi
 
@@ -16,6 +16,12 @@ IMAGE=$1
 VERSION_TAG=$2
 EXPECTED_DIGEST=$3
 LOCAL_REF=$4
+AUTH_FILE=$5
+
+if [[ ! -f $AUTH_FILE ]]; then
+    printf 'source registry auth file is not a regular file\n' >&2
+    exit 2
+fi
 
 if [[ ! $IMAGE =~ ^ghcr\.io/frostyard/(cayo|snow|snowfield)$ ]]; then
     printf 'invalid secure image reference\n' >&2
@@ -52,5 +58,6 @@ mkdir -p "$work/registries.d"
 cp "$REGISTRIES" "$work/registries.d/frostyard.yaml"
 
 cosign verify --key "$ROOT_DIR/cosign.pub" "$IMAGE@$EXPECTED_DIGEST" >/dev/null
-sudo skopeo copy --policy "$work/policy.json" --registries.d "$work/registries.d" \
+sudo skopeo copy --src-authfile "$AUTH_FILE" \
+    --policy "$work/policy.json" --registries.d "$work/registries.d" \
     "docker://$IMAGE@$EXPECTED_DIGEST" "containers-storage:$LOCAL_REF"

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -42,6 +42,8 @@ make_fixture() {
     : >"$fixture/shared/bootc-secure/tree/usr/lib/snosi/bootc-secure.json"
 
     cat >"$fixture/shared/bootc-secure/ci/verify-published-image.sh" <<'EOF'
+sudo skopeo copy --src-authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST" "containers-storage:$LOCAL_REF"
 jq -e --arg digest "$EXPECTED_DIGEST" '
     .Digest == $digest and
     .Labels["io.snosi.bootc.secureboot-capable"] == "true" and
@@ -88,7 +90,10 @@ jobs:
       - name: Push immutable version tag
       - name: Sign immutable image digest
       - name: Verify pushed secure image
-        run: ./shared/bootc-secure/ci/verify-published-image.sh "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF"
+        run: |
+          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+          ./shared/bootc-secure/ci/verify-published-image.sh \
+            "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
       - name: Validate policy-copied secure artifact
         run: |
           sudo ./test/bootc-secure-artifact-test.sh \
@@ -132,6 +137,14 @@ remove_sudo_tmpdir() { perl -0pi -e 's/^          sudo TMPDIR="\$TMPDIR" \\\n//m
 remove_cleanup_condition() { perl -0pi -e 's/        if: always\(\)\n//' "$1/.github/workflows/build-images.yml"; }
 break_label_check() { perl -0pi -e 's/== "true"/== "false"/' "$1/shared/bootc-secure/ci/verify-published-image.sh"; }
 remove_label_check() { perl -0pi -e 's/    \.Labels\["io\.snosi\.bootc\.secureboot-capable"\].*\n//' "$1/shared/bootc-secure/ci/verify-published-image.sh"; }
+remove_workflow_auth_handoff() {
+    perl -0pi -e 's/^          AUTH_FILE=.*\n//m; s/ "\$AUTH_FILE"\n/\n/' \
+        "$1/.github/workflows/build-images.yml"
+}
+remove_verifier_src_authfile() {
+    perl -0pi -e 's/ --src-authfile "\$AUTH_FILE"//' \
+        "$1/shared/bootc-secure/ci/verify-published-image.sh"
+}
 move_promotion_early() {
     perl -0pi -e 's/      - name: Promote validated digest to latest\n//; s/(      - name: Push immutable version tag\n)/$1      - name: Promote validated digest to latest\n/' "$1/.github/workflows/build-images.yml"
 }
@@ -164,6 +177,8 @@ assert_guard 'missing sudo TMPDIR forwarding fails' 1 remove_sudo_tmpdir
 assert_guard 'missing unconditional cleanup fails' 1 remove_cleanup_condition
 assert_guard 'false secure label check fails' 1 break_label_check
 assert_guard 'missing secure label check fails' 1 remove_label_check
+assert_guard 'missing workflow auth handoff fails' 1 remove_workflow_auth_handoff
+assert_guard 'missing verifier source auth option fails' 1 remove_verifier_src_authfile
 assert_guard 'early latest promotion fails' 1 move_promotion_early
 
 printf '%d passing assertions, %d failures\n' "$pass" "$fail"

--- a/test/bootc-secure-docs-test.sh
+++ b/test/bootc-secure-docs-test.sh
@@ -45,6 +45,7 @@ required_strings=(
     'Dual-PCR transition policy is not fallback across independent TPM tokens.'
     'Remove the old MOK only after every old-signed rollback deployment is retired.'
     'Loss of both TPM authorization and the external recovery passphrase is unrecoverable.'
+    'Root Skopeo receives the Docker login auth file explicitly through --src-authfile.'
 )
 
 for heading in "${required_headings[@]}"; do

--- a/test/bootc-secure-publication-test.sh
+++ b/test/bootc-secure-publication-test.sh
@@ -10,6 +10,7 @@ IMAGE="ghcr.io/frostyard/cayo"
 VERSION="20260729010101"
 LOCAL_REF="localhost/snosi-verified-cayo:$VERSION"
 WORK=""
+AUTH_FILE=""
 PASS=0
 FAIL=0
 
@@ -35,7 +36,7 @@ assert_failure() { # description command output
     fi
 }
 
-run_helper() { # image version digest local-ref
+run_helper() { # image version digest local-ref auth-file
     local output status
     set +e
     output=$(PATH="$WORK/bin:$PATH" COMMAND_LOG="$WORK/commands" COPIED_POLICY="$WORK/copied-policy.json" "$HELPER" "$@" 2>&1)
@@ -44,10 +45,10 @@ run_helper() { # image version digest local-ref
     printf '%s\n%s\n' "$status" "$output"
 }
 
-run_case() { # description expected-status image version digest local-ref
+run_case() { # description expected-status image version digest local-ref auth-file
     local result status output
     : >"$WORK/commands"
-    result=$(run_helper "$3" "$4" "$5" "$6")
+    result=$(run_helper "$3" "$4" "$5" "$6" "$7")
     status=${result%%$'\n'*}
     output=${result#*$'\n'}
     if [[ $2 == success ]]; then
@@ -59,6 +60,8 @@ run_case() { # description expected-status image version digest local-ref
 
 WORK=$(mktemp -d)
 mkdir -p "$WORK/bin"
+AUTH_FILE="$WORK/auth.json"
+printf '{"auths":{}}\n' >"$AUTH_FILE"
 cat >"$WORK/bin/skopeo" <<'EOF'
 #!/bin/bash
 set -euo pipefail
@@ -94,9 +97,9 @@ chmod +x "$WORK/bin/skopeo" "$WORK/bin/cosign" "$WORK/bin/sudo"
 export INSPECTION
 INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
 
-run_case "accepted immutable secure image is copied" success "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF"
+run_case "accepted immutable secure image is copied" success "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 grep -Fqx "cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" "$WORK/commands" && pass "Cosign verifies the immutable image with the committed key" || fail "Cosign verifies the immutable image with the committed key"
-grep -Fq "skopeo copy --policy " "$WORK/commands" && grep -Fq -- "--registries.d " "$WORK/commands" && grep -Fq "docker://$IMAGE@$DIGEST containers-storage:$LOCAL_REF" "$WORK/commands" && pass "policy copy uses immutable source and root containers storage" || fail "policy copy uses immutable source and root containers storage"
+grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" && grep -Fq -- "--registries.d " "$WORK/commands" && grep -Fq "docker://$IMAGE@$DIGEST containers-storage:$LOCAL_REF" "$WORK/commands" && pass "policy copy uses immutable source and root containers storage" || fail "policy copy uses immutable source and root containers storage"
 if jq -e '.default == [{"type":"reject"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains global reject"; else fail "copied policy retains global reject"; fi
 if jq -e --arg key "$ROOT_DIR/cosign.pub" '
     [.transports.docker | keys[]] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"] and
@@ -107,26 +110,38 @@ if jq -e --arg key "$ROOT_DIR/cosign.pub" '
     ]
 ' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains exactly the three scoped Cosign rules"; else fail "copied policy retains exactly the three scoped Cosign rules"; fi
 if jq -e '.transports["containers-storage"][""] == [{"type":"insecureAcceptAnything"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains the containers-storage exception"; else fail "copied policy retains the containers-storage exception"; fi
-if [[ $(sed -n '1p' "$WORK/commands") == "skopeo inspect docker://$IMAGE@$DIGEST" ]] && [[ $(sed -n '2p' "$WORK/commands") == "cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" ]] && [[ $(sed -n '4p' "$WORK/commands") == "skopeo copy --policy "* ]]; then pass "verification orders inspect before Cosign before policy copy"; else fail "verification orders inspect before Cosign before policy copy"; fi
+if [[ $(sed -n '1p' "$WORK/commands") == "skopeo inspect docker://$IMAGE@$DIGEST" ]] && [[ $(sed -n '2p' "$WORK/commands") == "cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" ]] && [[ $(sed -n '4p' "$WORK/commands") == "skopeo copy --src-authfile $AUTH_FILE "* ]]; then pass "verification orders inspect before Cosign before policy copy"; else fail "verification orders inspect before Cosign before policy copy"; fi
+grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" &&
+        pass "root policy copy receives the explicit source auth file" ||
+        fail "root policy copy receives the explicit source auth file"
+if ! sed -n '1,2p' "$WORK/commands" | grep -Fq -- '--src-authfile'; then
+    pass "inspect and Cosign do not receive the root copy auth option"
+else
+    fail "inspect and Cosign do not receive the root copy auth option"
+fi
+run_case "missing source auth file is rejected" failure \
+    "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$WORK/missing-auth.json"
+run_case "non-regular source auth path is rejected" failure \
+    "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$WORK"
 
-run_case "tagged image reference is rejected" failure "$IMAGE:$VERSION" "$VERSION" "$DIGEST" "$LOCAL_REF"
-run_case "wrong image repository is rejected" failure "ghcr.io/frostyard/untrusted" "$VERSION" "$DIGEST" "$LOCAL_REF"
-run_case "malformed digest is rejected" failure "$IMAGE" "$VERSION" "sha256:not-a-digest" "$LOCAL_REF"
-run_case "mismatched local reference is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "localhost/snosi-verified-snow:$VERSION"
-run_case "malformed version tag is rejected" failure "$IMAGE" "latest" "$DIGEST" "$LOCAL_REF"
+run_case "tagged image reference is rejected" failure "$IMAGE:$VERSION" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
+run_case "wrong image repository is rejected" failure "ghcr.io/frostyard/untrusted" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
+run_case "malformed digest is rejected" failure "$IMAGE" "$VERSION" "sha256:not-a-digest" "$LOCAL_REF" "$AUTH_FILE"
+run_case "mismatched local reference is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "localhost/snosi-verified-snow:$VERSION" "$AUTH_FILE"
+run_case "malformed version tag is rejected" failure "$IMAGE" "latest" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
 INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "false", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
-run_case "false secure capability is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF"
+run_case "false secure capability is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
-run_case "missing secure capability is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF"
+run_case "missing secure capability is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "wrong"}}')
-run_case "wrong secure assembly is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF"
+run_case "wrong secure assembly is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 INSPECTION=$(jq -nc --arg digest "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
-run_case "remote digest mismatch is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF"
+run_case "remote digest mismatch is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
 INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
-COSIGN_VERIFY_FAIL=1 run_case "failed Cosign verification is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF"
-SKOPEO_COPY_FAIL=1 run_case "failed policy copy is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF"
+COSIGN_VERIFY_FAIL=1 run_case "failed Cosign verification is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
+SKOPEO_COPY_FAIL=1 run_case "failed policy copy is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
 if [[ -f "$HELPER" ]] && ! grep -Eiq '(skopeo|docker)[^#]*(push|tag)|latest' "$HELPER"; then
     pass "helper has no publication or mutable-tag operation"

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -209,6 +209,11 @@ after local validation and before registry publication.
 Protected bootc publication pushes a version tag, validates its immutable
 digest and secure labels/signature/policy-copied artifact, then moves `latest`;
 failed immutable candidates never move `latest`.
+The workflow's `docker/login-action` credentials serve user-context Cosign and
+are passed by path to the verifier. Root Skopeo receives that file only through
+`--src-authfile` for the immutable registry source; its local
+`containers-storage:` destination receives no registry credentials. Do not
+infer this handoff from `XDG_RUNTIME_DIR` or root Buildah login state.
 `test-bootc-secure.yml` supplies PR/push fixture contracts,
 `bootc-secure-nightly.yml` supplies fixture coverage plus a self-hosted live
 full-window attempt, and `test-install.yml` remains explicitly insecure legacy

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -210,10 +210,13 @@ Protected bootc publication pushes a version tag, validates its immutable
 digest and secure labels/signature/policy-copied artifact, then moves `latest`;
 failed immutable candidates never move `latest`.
 The workflow's `docker/login-action` credentials serve user-context Cosign and
-are passed by path to the verifier. Root Skopeo receives that file only through
-`--src-authfile` for the immutable registry source; its local
-`containers-storage:` destination receives no registry credentials. Do not
-infer this handoff from `XDG_RUNTIME_DIR` or root Buildah login state.
+are passed by path to the verifier. The Docker auth file must be directly
+consumable by root Skopeo without user-scoped credential-helper state; otherwise
+the policy-copy verification fails closed and the next protected run remains the
+live proof. Root Skopeo receives that file only through `--src-authfile` for the
+immutable registry source; its local `containers-storage:` destination receives
+no registry credentials. Do not infer this handoff from `XDG_RUNTIME_DIR` or
+root Buildah login state.
 `test-bootc-secure.yml` supplies PR/push fixture contracts,
 `bootc-secure-nightly.yml` supplies fixture coverage plus a self-hosted live
 full-window attempt, and `test-install.yml` remains explicitly insecure legacy


### PR DESCRIPTION
## Summary
- pass the Docker login auth file explicitly to root Skopeo as source-only authentication
- fail closed when the auth path is missing or non-regular
- guard the workflow and verifier handoff with positive and mutation fixtures
- document the sudo/auth boundary and protected-run assumption

## Failure evidence
Protected run 30590168012 passed secure packaging, local validation, credential deletion, immutable push, and Cosign signing for Cayo and Snow, then failed `Verify pushed secure image` because root Skopeo tried `/run/user/1001/containers/auth.json` and received permission denied. No failed candidate moved `latest`.

## Validation
- `test/bootc-secure-publication-test.sh`: 23 passed, 0 failed
- `test/bootc-publication-guard-test.sh`: 31 passing assertions, 0 failures
- `test/bootc-secure-docs-test.sh`: passed
- `check-bootc-publication-guard.sh`: passed
- actionlint and ShellCheck: clean
- `git diff --check`: clean

## Remaining gate
The next protected `secure-build` is the live proof that the hosted runner auth file is directly consumable by root Skopeo. This PR does not establish Task 9 install/update/hardware evidence or production support.