### PR TITLE
fix: authenticate bootc publication end to end

### DIFF
--- a/.github/workflows/bootc-secure-nightly.yml
+++ b/.github/workflows/bootc-secure-nightly.yml
@@ -85,6 +85,8 @@ jobs:
         run: ./test/bootc-secure-rotation-test.sh --fixtures
       - name: Validate remote publication fixtures
         run: ./test/bootc-secure-publication-test.sh
+      - name: Validate authenticated promotion fixtures
+        run: ./test/bootc-secure-promotion-test.sh
 
   live-full-window:
     needs: fixtures

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -285,7 +285,8 @@ jobs:
 
       - name: Sign immutable image digest
         # docker/login-action writes the user-context registry credentials used
-        # directly by Cosign and passed explicitly to root Skopeo verification.
+        # directly by Cosign and passed explicitly to Skopeo verification and
+        # promotion. Pinned Cosign signing remains a user-context operation.
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
@@ -317,14 +318,9 @@ jobs:
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
         run: |
-          skopeo copy --all \
-            "docker://$IMAGE@${{ steps.push.outputs.digest }}" \
-            "docker://$IMAGE:latest"
-          latest_digest=$(skopeo inspect --format '{{.Digest}}' "docker://$IMAGE:latest")
-          [[ "$latest_digest" == "${{ steps.push.outputs.digest }}" ]] || {
-            echo "::error::latest resolved to $latest_digest instead of ${{ steps.push.outputs.digest }}" >&2
-            exit 1
-          }
+          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+          ./shared/bootc-secure/ci/promote-published-image.sh \
+            "$IMAGE" "${{ steps.push.outputs.digest }}" "$AUTH_FILE"
 
       - name: Record snow tag for release job
         # Runs only after the immutable candidate has become latest. The tag

--- a/.github/workflows/test-bootc-secure.yml
+++ b/.github/workflows/test-bootc-secure.yml
@@ -79,6 +79,8 @@ jobs:
         run: ./test/bootc-secure-rotation-test.sh --fixtures
       - name: Validate remote publication fixtures
         run: ./test/bootc-secure-publication-test.sh
+      - name: Validate authenticated promotion fixtures
+        run: ./test/bootc-secure-promotion-test.sh
 
   live-full-window:
     if: github.event_name == 'workflow_dispatch' && inputs.run_live

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -225,6 +225,8 @@ jobs:
         run: ./test/bootc-secure-rotation-test.sh --fixtures
       - name: Validate remote publication fixtures
         run: ./test/bootc-secure-publication-test.sh
+      - name: Validate authenticated promotion fixtures
+        run: ./test/bootc-secure-promotion-test.sh
 
   mkosi-config-sanity:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,9 +174,14 @@ registry write, validates an immutable version digest, then moves `latest`.
 The protected package step forwards the secure flag and credential paths as
 explicit sudo command assignments; GitHub step environment values do not cross
 sudo implicitly, and secret bytes remain only in the mode-0600 files.
-The remote verifier passes Docker login's auth file explicitly to root Skopeo
-as source-only authentication; it never relies on sudo preserving a usable
-user runtime auth path or on root Buildah's credential-store defaults.
+Every GHCR read and write in secure verification and promotion receives the
+Docker login config explicitly: inspections use `--authfile`, root policy copy
+uses source-only `--src-authfile`, and promotion uses source and destination
+auth files. Pinned Cosign v2.6.1 receives registry auth through command-scoped
+`DOCKER_CONFIG`; it has no registry-config flag. Version-tag resolution must
+equal the pushed digest before policy copy. The verifier never relies on sudo
+preserving a usable user runtime auth path or on root Buildah's credential-store
+defaults.
 Local and policy-copied artifact validation use host Podman to execute the
 candidate image's pinned bootc; they do not require or accept an independently
 installed host bootc as the storage-digest authority.
@@ -190,6 +195,10 @@ update, rotation, full-window, and Snowfield hardware validation remain
 BLOCKED until authorized signed secure N/N+1/N+2/transition OCI fixtures and
 prepared external runners exist. Do not claim production bootc Secure Boot
 support from these contracts.
+Deferred publication follow-ups: bind SBOM signing to the exact uploaded
+referrer digest, gate Snow release creation on complete metadata publication,
+decide whether `latest` moves only after metadata completion, and make general
+output cleanup unconditional where retained runners require it.
 
 **Bootc secure operations (Task 11, 2026-07-29):**
 `docs/bootc-secure-operations.md` is the normative reference for the secure

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -207,6 +207,17 @@ else
     require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-capable"] == "true" and'
     require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.3-storage-digest-v1"'
     require_text "$verifier" "$verifier_text" \
+        'inspection=$(skopeo inspect --authfile "$AUTH_FILE" \'
+    tag_inspect_line=$(cat <<'EOF'
+tag_digest=$(skopeo inspect --authfile "$AUTH_FILE" --format '{{.Digest}}' \
+EOF
+)
+    require_text "$verifier tag inspect auth" "$verifier_text" "$tag_inspect_line"
+    require_text "$verifier" "$verifier_text" \
+        'if [[ $tag_digest != "$EXPECTED_DIGEST" ]]; then'
+    require_text "$verifier" "$verifier_text" \
+        'DOCKER_CONFIG=$auth_dir cosign verify --key "$ROOT_DIR/cosign.pub" \'
+    require_text "$verifier" "$verifier_text" \
         'sudo skopeo copy --src-authfile "$AUTH_FILE" \'
 fi
 

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -180,10 +180,32 @@ else
             "$verifier_step" '          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"'
         require_text "$workflow secure verifier auth argument" \
             "$verifier_step" '            "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"'
+
+        login_step=$(awk '
+            /^      - name: Log in to ghcr.io$/ { capture=1 }
+            capture && /^      - name: / && $0 != "      - name: Log in to ghcr.io" { exit }
+            capture { print }
+        ' <<<"$secure_job")
+        require_text "$workflow secure registry login" "$login_step" \
+            '        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3'
+
+        promotion_step=$(awk '
+            /^      - name: Promote validated digest to latest$/ { capture=1 }
+            capture && /^      - name: / && $0 != "      - name: Promote validated digest to latest" { exit }
+            capture { print }
+        ' <<<"$secure_job")
+        if ! grep -Fq './shared/bootc-secure/ci/promote-published-image.sh' <<<"$promotion_step"; then
+            fail_check "$workflow secure-build: missing authenticated promotion helper call"
+        fi
+        require_text "$workflow secure promotion auth path" \
+            "$promotion_step" '          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"'
+        require_text "$workflow secure promotion auth argument" \
+            "$promotion_step" '            "$IMAGE" "${{ steps.push.outputs.digest }}" "$AUTH_FILE"'
     fi
 
     ordered_steps=(
         'Push immutable version tag'
+        'Log in to ghcr.io'
         'Sign immutable image digest'
         'Verify pushed secure image'
         'Validate policy-copied secure artifact'
@@ -219,6 +241,22 @@ EOF
         'DOCKER_CONFIG=$auth_dir cosign verify --key "$ROOT_DIR/cosign.pub" \'
     require_text "$verifier" "$verifier_text" \
         'sudo skopeo copy --src-authfile "$AUTH_FILE" \'
+fi
+
+promotion_helper="$guard_root/shared/bootc-secure/ci/promote-published-image.sh"
+if [[ ! -f $promotion_helper ]]; then
+    fail_check "missing secure image promotion helper: shared/bootc-secure/ci/promote-published-image.sh"
+else
+    promotion_text=$(<"$promotion_helper")
+    require_text "$promotion_helper" "$promotion_text" \
+        'skopeo copy --all \'
+    require_text "$promotion_helper promotion source auth" "$promotion_text" \
+        '    --src-authfile "$AUTH_FILE" --dest-authfile "$AUTH_FILE" \'
+    promotion_inspect_line=$(cat <<'EOF'
+latest_digest=$(skopeo inspect --authfile "$AUTH_FILE" \
+EOF
+)
+    require_text "$promotion_helper promotion inspect auth" "$promotion_text" "$promotion_inspect_line"
 fi
 
 if ((fail)); then

--- a/docs/bootc-secure-operations.md
+++ b/docs/bootc-secure-operations.md
@@ -49,6 +49,8 @@ registry write, and then advances the tracking tag.
 
 GitHub's `native-build` environment must be restricted to protected/default
 branches and have no required reviewer. Root Skopeo receives the Docker login auth file explicitly through --src-authfile.
+Every GHCR read and write in secure verification and promotion receives the Docker login config explicitly.
+Pinned Cosign v2.6.1 receives registry auth through command-scoped DOCKER_CONFIG.
 The Docker auth file from `docker/login-action` must be directly consumable by
 root Skopeo without user-scoped credential-helper state; otherwise verification
 fails closed. The next protected run remains the live proof. Do not rely on
@@ -56,6 +58,12 @@ inherited `XDG_RUNTIME_DIR`, root Buildah credentials, or registry visibility as
 the authentication mechanism for the policy-copy gate. Candidate publication,
 tag movement, and an image labelled secure are not substitutes for the blocked
 live installation and hardware gates.
+
+Skopeo inspections use `--authfile`, root policy copy uses source-only
+`--src-authfile`, and promotion uses source and destination auth files. Pinned
+Cosign has no registry-config flag; its command receives only the config
+directory through `DOCKER_CONFIG`. Version-tag resolution must equal the pushed
+digest before policy copy.
 
 ## Fresh Installation
 

--- a/docs/superpowers/plans/2026-07-31-bootc-publication-auth.md
+++ b/docs/superpowers/plans/2026-07-31-bootc-publication-auth.md
@@ -1,0 +1,510 @@
+# Bootc Publication Explicit-Auth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every critical-path GHCR operation use the Docker login config explicitly, bind the version tag to the expected digest, and fixture-test `latest` promotion before another protected build.
+
+**Architecture:** The existing verifier keeps one `AUTH_FILE` input and applies it to both Skopeo inspections, Cosign's command-scoped `DOCKER_CONFIG`, and root policy copy. A new promotion helper owns the only mutable-tag operation and explicitly authenticates both registry endpoints and the confirming inspect; static guards and faithful stubs enforce the complete path.
+
+**Tech Stack:** Bash, GitHub Actions YAML, Skopeo, Cosign 2.6.1, jq, ShellCheck, actionlint
+
+## Global Constraints
+
+- The verifier interface remains `verify-published-image.sh IMAGE VERSION_TAG EXPECTED_DIGEST LOCAL_REF AUTH_FILE`.
+- `AUTH_FILE` must be an existing regular file named exactly `config.json`.
+- Skopeo inspect uses `--authfile`, root policy copy uses source-only `--src-authfile`, and promotion copy uses both `--src-authfile` and `--dest-authfile`.
+- Pinned Cosign v2.6.1 has no `--registry-config`; verification uses command-scoped `DOCKER_CONFIG` equal to `AUTH_FILE`'s parent directory.
+- Never put credential contents, usernames, passwords, PATs, or tokens in command arguments, logs, outputs, repository state, or retained temporary state.
+- Require the version tag to resolve to `EXPECTED_DIGEST` before policy copy; do not claim registry-enforced tag immutability.
+- Preserve exact secure labels, immutable-digest Cosign verification, restrictive policy copy, root containers-storage validation, and validation-before-promotion ordering.
+- The promotion helper accepts exactly `IMAGE EXPECTED_DIGEST AUTH_FILE` and performs no signing, local-storage access, SBOM, provenance, manifest, or release operation.
+- Keep SBOM identity selection, metadata ordering, release gating, and general cleanup redesign out of this repair; document them as deferred findings.
+- A successful protected build is one candidate set, not Task 9 runtime evidence, distinct N/N+1/N+2 evidence, or Snowfield hardware proof.
+
+---
+
+### Task 1: Explicitly Authenticate Every Verifier Read
+
+**Files:**
+- Modify: `test/bootc-secure-publication-test.sh`
+- Modify: `shared/bootc-secure/ci/verify-published-image.sh`
+- Modify: `check-bootc-publication-guard.sh`
+- Modify: `test/bootc-publication-guard-test.sh`
+
+**Interfaces:**
+- Consumes: `AUTH_FILE` pointing to Docker-compatible `config.json`, `IMAGE`, `VERSION_TAG`, and `EXPECTED_DIGEST` from the protected workflow.
+- Produces: a policy-copied root containers-storage image only after explicit-auth metadata reads, version-tag binding, and explicit-auth Cosign verification pass.
+
+- [ ] **Step 1: Make the verifier fixture fail when remote reads omit explicit auth**
+
+In `test/bootc-secure-publication-test.sh`, pass both
+`EXPECTED_AUTH_FILE="$AUTH_FILE"` and `EXPECTED_DIGEST="$5"` into the helper
+invocation. Replace the Skopeo stub's inspect branch with logic that requires
+the exact auth path and distinguishes digest metadata from tag resolution:
+
+```bash
+inspect)
+    [[ " $* " == *" --authfile $EXPECTED_AUTH_FILE "* ]]
+    if [[ " $* " == *" --format {{.Digest}} "* ]]; then
+        printf '%s\n' "${TAG_DIGEST:-$EXPECTED_DIGEST}"
+    else
+        printf '%s\n' "$INSPECTION"
+    fi
+    ;;
+```
+
+Make the Cosign stub require and record the command-scoped config directory:
+
+```bash
+expected_dir=$(dirname -- "$EXPECTED_AUTH_FILE")
+printf 'DOCKER_CONFIG=%s cosign %s\n' "${DOCKER_CONFIG:-}" "$*" >>"$COMMAND_LOG"
+[[ ${DOCKER_CONFIG:-} == "$expected_dir" ]]
+[[ ${COSIGN_VERIFY_FAIL:-0} != 1 ]]
+```
+
+Change the positive assertions to require this exact order and authority:
+
+```bash
+grep -Fqx "skopeo inspect --authfile $AUTH_FILE docker://$IMAGE@$DIGEST" "$WORK/commands"
+grep -Fqx "skopeo inspect --authfile $AUTH_FILE --format {{.Digest}} docker://$IMAGE:$VERSION" "$WORK/commands"
+grep -Fqx "DOCKER_CONFIG=$(dirname -- "$AUTH_FILE") cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" "$WORK/commands"
+grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands"
+```
+
+Add negative cases:
+
+```bash
+cp "$AUTH_FILE" "$WORK/auth.json"
+run_case "non-config.json auth file is rejected" failure \
+    "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$WORK/auth.json"
+TAG_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+    run_case "version tag digest mismatch is rejected" failure \
+    "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
+```
+
+- [ ] **Step 2: Run the verifier fixture and verify RED**
+
+Run: `./test/bootc-secure-publication-test.sh`
+
+Expected: nonzero because the first Skopeo inspect lacks `--authfile`, and the new explicit-auth assertions fail before production edits.
+
+- [ ] **Step 3: Implement exact auth and version-tag binding in the verifier**
+
+After the regular-file check in `verify-published-image.sh`, add:
+
+```bash
+if [[ ${AUTH_FILE##*/} != config.json ]]; then
+    printf 'source registry auth file must be named config.json\n' >&2
+    exit 2
+fi
+```
+
+Replace the ambient metadata read and add tag binding:
+
+```bash
+inspection=$(skopeo inspect --authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST")
+
+tag_digest=$(skopeo inspect --authfile "$AUTH_FILE" --format '{{.Digest}}' \
+    "docker://$IMAGE:$VERSION_TAG")
+if [[ $tag_digest != "$EXPECTED_DIGEST" ]]; then
+    printf 'version tag resolved to %s instead of %s\n' \
+        "$tag_digest" "$EXPECTED_DIGEST" >&2
+    exit 1
+fi
+```
+
+Replace ambient Cosign verification with the pinned-v2.6.1 keychain binding:
+
+```bash
+auth_dir=$(dirname -- "$AUTH_FILE")
+DOCKER_CONFIG=$auth_dir cosign verify --key "$ROOT_DIR/cosign.pub" \
+    "$IMAGE@$EXPECTED_DIGEST" >/dev/null
+```
+
+Retain root policy copy unchanged with source-only `--src-authfile`.
+
+- [ ] **Step 4: Run the verifier fixture and verify GREEN**
+
+Run: `./test/bootc-secure-publication-test.sh`
+
+Expected: exit 0; explicit digest inspect, tag inspect, Cosign config, tag mismatch, and existing fail-closed cases pass.
+
+- [ ] **Step 5: Add failing guard mutations for each newly required verifier control**
+
+Update the guard fixture's verifier text to include the production lines, then add these mutation functions to `test/bootc-publication-guard-test.sh`:
+
+```bash
+remove_digest_inspect_auth() {
+    perl -0pi -e 's/skopeo inspect --authfile "\$AUTH_FILE"/skopeo inspect/' \
+        "$1/shared/bootc-secure/ci/verify-published-image.sh"
+}
+remove_cosign_docker_config() {
+    perl -0pi -e 's/DOCKER_CONFIG=\$auth_dir cosign/cosign/' \
+        "$1/shared/bootc-secure/ci/verify-published-image.sh"
+}
+remove_tag_binding() {
+    perl -0pi -e 's/^tag_digest=.*?^fi\n//ms' \
+        "$1/shared/bootc-secure/ci/verify-published-image.sh"
+}
+```
+
+Add one `assert_guard ... expected 1` call per mutation.
+
+- [ ] **Step 6: Run the guard suite and verify RED**
+
+Run: `./test/bootc-publication-guard-test.sh`
+
+Expected: nonzero because the existing guard does not reject at least one new mutation.
+
+- [ ] **Step 7: Enforce verifier auth and tag binding in the static guard**
+
+Add exact `require_text` markers in `check-bootc-publication-guard.sh`. Use a
+literal here-document for the line containing nested single quotes:
+
+```bash
+'inspection=$(skopeo inspect --authfile "$AUTH_FILE" \'
+'if [[ $tag_digest != "$EXPECTED_DIGEST" ]]; then'
+'DOCKER_CONFIG=$auth_dir cosign verify --key "$ROOT_DIR/cosign.pub" \'
+'sudo skopeo copy --src-authfile "$AUTH_FILE" \'
+
+tag_inspect_line=$(cat <<'EOF'
+tag_digest=$(skopeo inspect --authfile "$AUTH_FILE" --format '{{.Digest}}' \
+EOF
+)
+require_text "$verifier tag inspect auth" "$verifier_text" "$tag_inspect_line"
+```
+
+Use shell quoting that preserves each marker byte-for-byte; verify each marker against the real file before accepting the guard.
+
+- [ ] **Step 8: Run Task 1 validation**
+
+```bash
+./test/bootc-secure-publication-test.sh
+./test/bootc-publication-guard-test.sh
+./check-bootc-publication-guard.sh
+shellcheck -S warning -x \
+  shared/bootc-secure/ci/verify-published-image.sh \
+  test/bootc-secure-publication-test.sh \
+  check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh
+git diff --check
+```
+
+Expected: all commands exit 0 with no ShellCheck or whitespace diagnostics.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add \
+  shared/bootc-secure/ci/verify-published-image.sh \
+  test/bootc-secure-publication-test.sh \
+  check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh
+git commit -m "fix: authenticate all bootc verifier reads"
+```
+
+### Task 2: Fixture-Test Explicit-Auth Promotion
+
+**Files:**
+- Create: `shared/bootc-secure/ci/promote-published-image.sh`
+- Create: `test/bootc-secure-promotion-test.sh`
+- Modify: `.github/workflows/build-images.yml:274-327`
+- Modify: `check-bootc-publication-guard.sh`
+- Modify: `test/bootc-publication-guard-test.sh`
+- Modify: `.github/workflows/validate.yml`
+- Modify: `.github/workflows/test-bootc-secure.yml`
+- Modify: `.github/workflows/bootc-secure-nightly.yml`
+
+**Interfaces:**
+- Consumes: a verified `ghcr.io/frostyard/{cayo,snow,snowfield}@sha256:...` digest and Docker `config.json` after policy-copied artifact validation.
+- Produces: `latest` resolving to the exact supplied digest, or a nonzero fail-closed result.
+
+- [ ] **Step 1: Write the failing promotion fixture**
+
+Create `test/bootc-secure-promotion-test.sh` with `set -euo pipefail`, pass/fail counters, a temporary `bin/skopeo` stub, and these cases:
+
+```bash
+IMAGE=ghcr.io/frostyard/cayo
+DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+AUTH_FILE="$WORK/config.json"
+printf '{"auths":{}}\n' >"$AUTH_FILE"
+```
+
+The stub must reject copy unless all exact fragments are present:
+
+```bash
+--all
+--src-authfile $AUTH_FILE
+--dest-authfile $AUTH_FILE
+docker://$IMAGE@$DIGEST
+docker://$IMAGE:latest
+```
+
+It must reject inspect unless it contains:
+
+```bash
+--authfile $AUTH_FILE
+--format {{.Digest}}
+docker://$IMAGE:latest
+```
+
+Positive and negative assertions cover success, malformed repository, malformed digest, missing auth file, directory auth path, non-`config.json` auth file, copy failure, inspect failure, and latest digest mismatch.
+
+- [ ] **Step 2: Run the promotion fixture and verify RED**
+
+Run: `./test/bootc-secure-promotion-test.sh`
+
+Expected: nonzero because `shared/bootc-secure/ci/promote-published-image.sh` does not exist.
+
+- [ ] **Step 3: Implement the minimal promotion helper**
+
+Create executable `shared/bootc-secure/ci/promote-published-image.sh`:
+
+```bash
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+    printf 'usage: %s IMAGE EXPECTED_DIGEST AUTH_FILE\n' "${0##*/}" >&2
+    exit 2
+fi
+
+IMAGE=$1
+EXPECTED_DIGEST=$2
+AUTH_FILE=$3
+
+if [[ ! $IMAGE =~ ^ghcr\.io/frostyard/(cayo|snow|snowfield)$ ]] ||
+        [[ ! $EXPECTED_DIGEST =~ ^sha256:[a-f0-9]{64}$ ]]; then
+    printf 'invalid secure image reference\n' >&2
+    exit 2
+fi
+if [[ ! -f $AUTH_FILE || ${AUTH_FILE##*/} != config.json ]]; then
+    printf 'registry auth must be a regular config.json file\n' >&2
+    exit 2
+fi
+
+skopeo copy --all \
+    --src-authfile "$AUTH_FILE" --dest-authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST" "docker://$IMAGE:latest"
+
+latest_digest=$(skopeo inspect --authfile "$AUTH_FILE" \
+    --format '{{.Digest}}' "docker://$IMAGE:latest")
+if [[ $latest_digest != "$EXPECTED_DIGEST" ]]; then
+    printf 'latest resolved to %s instead of %s\n' \
+        "$latest_digest" "$EXPECTED_DIGEST" >&2
+    exit 1
+fi
+```
+
+Run:
+
+```bash
+chmod +x \
+  shared/bootc-secure/ci/promote-published-image.sh \
+  test/bootc-secure-promotion-test.sh
+```
+
+- [ ] **Step 4: Run the promotion fixture and verify GREEN**
+
+Run: `./test/bootc-secure-promotion-test.sh`
+
+Expected: exit 0 with every positive and negative assertion passing.
+
+- [ ] **Step 5: Replace inline promotion and strengthen workflow ordering**
+
+In `.github/workflows/build-images.yml`, replace the inline Skopeo block with:
+
+```yaml
+        run: |
+          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+          ./shared/bootc-secure/ci/promote-published-image.sh \
+            "$IMAGE" "${{ steps.push.outputs.digest }}" "$AUTH_FILE"
+```
+
+Correct the signing comment to state that Docker login credentials are passed
+explicitly to verification and promotion; pinned Cosign signing itself remains
+the already-working user-context operation.
+
+In the guard's ordered steps, require:
+
+```bash
+'Push immutable version tag'
+'Log in to ghcr.io'
+'Sign immutable image digest'
+'Verify pushed secure image'
+'Validate policy-copied secure artifact'
+'Promote validated digest to latest'
+```
+
+Require the exact pinned `docker/login-action` in the login step and exact promotion-helper invocation with `AUTH_FILE`.
+
+- [ ] **Step 6: Add promotion and login-order guard mutations, then verify RED**
+
+Extend the guard fixture with the login step, helper call, and helper source. Add mutations that remove login, move login after verification, remove helper source auth, remove helper destination auth, remove helper inspect auth, and replace helper invocation with inline `skopeo copy`.
+
+Run: `./test/bootc-publication-guard-test.sh`
+
+Expected: nonzero before the production guard learns every new mutation.
+
+- [ ] **Step 7: Wire the promotion fixture into all contract workflows**
+
+Add `./test/bootc-secure-promotion-test.sh` beside the existing publication fixture in:
+
+```text
+.github/workflows/validate.yml
+.github/workflows/test-bootc-secure.yml
+.github/workflows/bootc-secure-nightly.yml
+```
+
+Do not add it to live/full-window jobs; it is network-free fixture coverage.
+
+- [ ] **Step 8: Run Task 2 validation**
+
+```bash
+./test/bootc-secure-promotion-test.sh
+./test/bootc-secure-publication-test.sh
+./test/bootc-publication-guard-test.sh
+./check-bootc-publication-guard.sh
+actionlint \
+  .github/workflows/build-images.yml \
+  .github/workflows/validate.yml \
+  .github/workflows/test-bootc-secure.yml \
+  .github/workflows/bootc-secure-nightly.yml
+shellcheck -S warning -x \
+  shared/bootc-secure/ci/promote-published-image.sh \
+  test/bootc-secure-promotion-test.sh \
+  check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh
+git diff --check
+```
+
+Expected: all commands exit 0 with no actionlint, ShellCheck, or whitespace diagnostics.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add \
+  shared/bootc-secure/ci/promote-published-image.sh \
+  test/bootc-secure-promotion-test.sh \
+  .github/workflows/build-images.yml \
+  .github/workflows/validate.yml \
+  .github/workflows/test-bootc-secure.yml \
+  .github/workflows/bootc-secure-nightly.yml \
+  check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh
+git commit -m "fix: authenticate bootc latest promotion"
+```
+
+### Task 3: Correct Contracts And Record Deferred Findings
+
+**Files:**
+- Modify: `test/bootc-secure-docs-test.sh`
+- Modify: `docs/bootc-secure-operations.md`
+- Modify: `CLAUDE.md`
+- Modify: `yeti/ci-cd.md`
+
+**Interfaces:**
+- Consumes: Tasks 1-2 complete explicit-auth verifier and promotion contracts.
+- Produces: normative and AI-facing documentation that accurately separates completed auth controls from deferred publication redesign and blocked runtime evidence.
+
+- [ ] **Step 1: Add failing documentation contract strings**
+
+Add these exact single-line strings to `required_strings` in `test/bootc-secure-docs-test.sh`:
+
+```bash
+'Every GHCR read and write in secure verification and promotion receives the Docker login config explicitly.'
+'Pinned Cosign v2.6.1 receives registry auth through command-scoped DOCKER_CONFIG.'
+```
+
+- [ ] **Step 2: Run the docs contract and verify RED**
+
+Run: `./test/bootc-secure-docs-test.sh`
+
+Expected: nonzero because the operations runbook still describes only root Skopeo source auth.
+
+- [ ] **Step 3: Update normative and repository documentation**
+
+In `docs/bootc-secure-operations.md`, add both required sentences on separate physical lines and state:
+
+```markdown
+Skopeo inspections use `--authfile`, root policy copy uses source-only
+`--src-authfile`, and promotion uses source and destination auth files. Pinned
+Cosign has no registry-config flag; its command receives only the config
+directory through `DOCKER_CONFIG`. Version-tag resolution must equal the pushed
+digest before policy copy.
+```
+
+In `CLAUDE.md` and `yeti/ci-cd.md`, replace root-copy-only wording with the same
+architecture and record these deferred findings without claiming completion:
+
+```markdown
+Deferred publication follow-ups: bind SBOM signing to the exact uploaded
+referrer digest, gate Snow release creation on complete metadata publication,
+decide whether `latest` moves only after metadata completion, and make general
+output cleanup unconditional where retained runners require it.
+```
+
+Preserve all existing blocked-live-evidence and unsupported-production wording.
+
+- [ ] **Step 4: Run complete relevant validation**
+
+```bash
+./test/bootc-secure-docs-test.sh
+./test/bootc-secure-publication-test.sh
+./test/bootc-secure-promotion-test.sh
+./test/bootc-publication-guard-test.sh
+./check-bootc-publication-guard.sh
+actionlint \
+  .github/workflows/build-images.yml \
+  .github/workflows/validate.yml \
+  .github/workflows/test-bootc-secure.yml \
+  .github/workflows/bootc-secure-nightly.yml
+shellcheck -S warning -x \
+  shared/bootc-secure/ci/verify-published-image.sh \
+  shared/bootc-secure/ci/promote-published-image.sh \
+  test/bootc-secure-publication-test.sh \
+  test/bootc-secure-promotion-test.sh \
+  check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh \
+  test/bootc-secure-docs-test.sh
+git diff --check
+```
+
+Expected: all commands exit 0; both publication fixtures and every guard mutation pass with no lint diagnostics.
+
+- [ ] **Step 5: Review the final diff against protected-run evidence**
+
+Confirm from the diff that:
+
+```text
+- no remote verifier or promotion command uses ambient Skopeo auth;
+- Cosign verification receives command-scoped DOCKER_CONFIG;
+- no credential contents appear in arguments or logs;
+- version-tag mismatch fails before policy copy;
+- login precedes signing and verification;
+- policy-copied validation precedes promotion;
+- no SBOM/release redesign or unsupported support claim entered this repair.
+```
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add \
+  test/bootc-secure-docs-test.sh \
+  docs/bootc-secure-operations.md \
+  CLAUDE.md \
+  yeti/ci-cd.md
+git commit -m "docs: record explicit bootc publication auth"
+```
+
+- [ ] **Step 7: Request adversarial review before publication**
+
+Request review focused on real command semantics for Skopeo and pinned Cosign,
+auth-file scope, version-tag race behavior, promotion mutation safety, guard
+fidelity, workflow ordering, and unsupported claims. Address every Critical or
+Important finding and rerun Step 4 before opening the PR. After merge, watch all
+three protected profiles through policy-copy validation and `latest` promotion;
+record exact version tags and digests without treating the run as Task 9 runtime
+evidence.

--- a/docs/superpowers/specs/2026-07-31-bootc-publication-auth-design.md
+++ b/docs/superpowers/specs/2026-07-31-bootc-publication-auth-design.md
@@ -1,0 +1,184 @@
+# Bootc Publication Explicit-Auth Design
+
+## Problem
+
+Protected `build-images.yml` run `30594624886` proved that Cayo, Snow, and
+Snowfield all pass secure assembly, local artifact validation, protected-key
+deletion, immutable-digest push, Docker login, and Cosign signing. All three
+then fail at the first command in `verify-published-image.sh`:
+
+```text
+reading JSON file "/run/user/1001/containers/auth.json": permission denied
+```
+
+The workflow passes
+`${DOCKER_CONFIG:-$HOME/.docker}/config.json` to the verifier, but only the
+later root `skopeo copy` receives it through `--src-authfile`. The initial
+user-context `skopeo inspect` still performs ambient containers/image auth
+discovery and aborts before root policy copy runs. No policy-copied artifact
+validation or `latest` promotion ran.
+
+The same incomplete auth contract remains in adjacent remote operations:
+Cosign verification uses its default keychain, while `latest` promotion uses
+ambient Skopeo auth for both registry endpoints and its confirming inspect.
+Leaving those boundaries implicit would risk another long protected-run
+failure after fixing only the observed inspect.
+
+## Scope
+
+This repair closes the protected publication critical path:
+
+- every verifier registry read receives the supplied Docker auth config
+  explicitly;
+- the version tag is bound to the expected immutable digest before policy
+  copy;
+- every `latest` promotion registry read and write receives the same auth
+  config explicitly;
+- login ordering, auth flags, tag binding, and promotion behavior are enforced
+  by positive and mutation fixtures.
+
+The broader publication audit also found that SBOM discovery selects the last
+matching referrer instead of the exact artifact just uploaded, Snow release
+gating precedes some metadata completion, and general output cleanup is not
+unconditional. Those are real follow-ups but are intentionally excluded from
+this critical-path repair to avoid combining a publication transaction
+redesign with the immediate authentication fix.
+
+## Auth Contract
+
+`AUTH_FILE` remains the fifth argument to
+`verify-published-image.sh IMAGE VERSION_TAG EXPECTED_DIGEST LOCAL_REF AUTH_FILE`.
+It must be an existing regular file named `config.json`; this matches the
+Docker-compatible file written by the pinned `docker/login-action`. Only its
+path crosses command boundaries. Credential contents, usernames, passwords,
+and tokens never enter command arguments, logs, repository state, outputs, or
+retained temporary state.
+
+Every verifier command that contacts GHCR uses that same authority:
+
+```bash
+inspection=$(skopeo inspect --authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST")
+
+tag_digest=$(skopeo inspect --authfile "$AUTH_FILE" --format '{{.Digest}}' \
+    "docker://$IMAGE:$VERSION_TAG")
+
+DOCKER_CONFIG=$(dirname "$AUTH_FILE") \
+    cosign verify --key "$ROOT_DIR/cosign.pub" \
+    "$IMAGE@$EXPECTED_DIGEST" >/dev/null
+
+sudo skopeo copy --src-authfile "$AUTH_FILE" \
+    --policy "$work/policy.json" --registries.d "$work/registries.d" \
+    "docker://$IMAGE@$EXPECTED_DIGEST" "containers-storage:$LOCAL_REF"
+```
+
+The verifier rejects a version tag whose resolved digest differs from
+`EXPECTED_DIGEST`. This detects collision or concurrent replacement at the
+validation boundary. It does not claim that GHCR enforces immutable tags after
+validation; registry-side tag immutability remains a separate control.
+
+Pinned Cosign v2.6.1 has no `--registry-config` flag. Its
+`options.RegistryOptions` uses `authn.DefaultKeychain`, which honors
+`DOCKER_CONFIG`. Command-scoped `DOCKER_CONFIG` is therefore the maintained
+explicit path for Cosign verification. Requiring `AUTH_FILE` to be named
+`config.json` makes the mapping unambiguous and fail-closed. Do not replace it
+with `--registry-username`, `--registry-password`, or another secret-bearing
+argument.
+
+## Promotion Helper
+
+Move the inline `latest` mutation into a focused helper under
+`shared/bootc-secure/ci/`. It accepts exactly:
+
+```text
+promote-published-image.sh IMAGE EXPECTED_DIGEST AUTH_FILE
+```
+
+It validates the repository, digest, and regular `config.json` auth file, then
+runs:
+
+```bash
+skopeo copy --all \
+    --src-authfile "$AUTH_FILE" --dest-authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST" "docker://$IMAGE:latest"
+
+latest_digest=$(skopeo inspect --authfile "$AUTH_FILE" \
+    --format '{{.Digest}}' "docker://$IMAGE:latest")
+```
+
+The helper fails unless `latest_digest` equals `EXPECTED_DIGEST`. It performs
+no signing, policy copy, local-storage access, SBOM upload, or release action.
+It runs only after policy-copied artifact validation. Source and destination
+auth are explicit because both endpoints are remote GHCR references.
+
+## Workflow Ordering
+
+The protected publication order is:
+
+1. push the version tag and record its digest;
+2. run `docker/login-action`;
+3. sign the immutable digest;
+4. verify digest metadata, version-tag binding, Cosign signature, and policy
+   copy with explicit auth;
+5. validate policy-copied bytes from root containers-storage;
+6. promote the validated digest through the explicit-auth helper;
+7. continue existing SBOM, provenance, manifest, and release steps.
+
+The static guard must include `Log in to ghcr.io` in this ordered sequence and
+require the pinned login action to remain before signing and every consumer of
+its config. A failed auth read, tag-binding check, signature check, policy copy,
+artifact validation, promotion copy, or post-copy digest check prevents all
+later publication steps for that profile.
+
+## Testing
+
+The verifier fixture must stop treating auth as command-shape decoration.
+Skopeo and Cosign stubs reject each remote operation unless it receives the
+exact supplied authority:
+
+- digest inspect requires `--authfile AUTH_FILE`;
+- version-tag inspect requires `--authfile AUTH_FILE` and returns the expected
+  digest only in the positive case;
+- Cosign verify requires command-scoped `DOCKER_CONFIG` equal to the auth
+  file's parent directory;
+- root policy copy requires `--src-authfile AUTH_FILE` and no destination auth
+  option.
+
+Negative cases cover omitted or wrong auth paths, a missing auth file, a
+directory, a non-`config.json` filename, version-tag digest mismatch, failed
+Cosign verification, and failed policy copy.
+
+A new promotion fixture exercises the real helper with Skopeo stubbed only at
+the registry boundary. It requires explicit source and destination auth on
+copy, explicit auth on confirming inspect, immutable digest source, `latest`
+destination, exact post-copy digest equality, and rejection of malformed
+inputs and command failures.
+
+The publication guard and mutation suite require:
+
+- workflow auth-file derivation and verifier handoff;
+- explicit auth on both verifier inspections, Cosign's command-scoped
+  `DOCKER_CONFIG`, and root policy copy;
+- version-tag-to-digest comparison;
+- login ordering before signing and verification;
+- invocation of the promotion helper after policy-copied validation;
+- explicit source/destination/inspect auth inside the promotion helper;
+- no promotion or mutable-tag operation inside the verifier.
+
+ShellCheck, actionlint, documentation contracts, publication fixtures, guard
+mutations, and `git diff --check` must pass before another protected run. The
+next protected run remains the only live proof that the hosted runner's Docker
+config is directly consumable by Skopeo in both user and root contexts and by
+Cosign v2.6.1.
+
+## Documentation
+
+Update `CLAUDE.md`, `docs/bootc-secure-operations.md`, and `yeti/ci-cd.md` to
+replace the obsolete root-copy-only statement with the complete explicit-auth
+contract. Preserve the existing unsupported status: a successful protected
+publication is one candidate set, not Task 9 install/update/rollback/recovery
+evidence, not distinct N/N+1/N+2 evidence, and not Snowfield hardware proof.
+
+Record the deferred SBOM identity, metadata ordering, release gating, and
+cleanup findings as publication follow-ups without representing them as part
+of this repair or as completed controls.

--- a/shared/bootc-secure/ci/promote-published-image.sh
+++ b/shared/bootc-secure/ci/promote-published-image.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+    printf 'usage: %s IMAGE EXPECTED_DIGEST AUTH_FILE\n' "${0##*/}" >&2
+    exit 2
+fi
+
+IMAGE=$1
+EXPECTED_DIGEST=$2
+AUTH_FILE=$3
+
+if [[ ! $IMAGE =~ ^ghcr\.io/frostyard/(cayo|snow|snowfield)$ ]] ||
+        [[ ! $EXPECTED_DIGEST =~ ^sha256:[a-f0-9]{64}$ ]]; then
+    printf 'invalid secure image reference\n' >&2
+    exit 2
+fi
+if [[ ! -f $AUTH_FILE || ${AUTH_FILE##*/} != config.json ]]; then
+    printf 'registry auth must be a regular config.json file\n' >&2
+    exit 2
+fi
+
+skopeo copy --all \
+    --src-authfile "$AUTH_FILE" --dest-authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST" "docker://$IMAGE:latest"
+
+latest_digest=$(skopeo inspect --authfile "$AUTH_FILE" \
+    --format '{{.Digest}}' "docker://$IMAGE:latest")
+if [[ $latest_digest != "$EXPECTED_DIGEST" ]]; then
+    printf 'latest resolved to %s instead of %s\n' \
+        "$latest_digest" "$EXPECTED_DIGEST" >&2
+    exit 1
+fi

--- a/shared/bootc-secure/ci/verify-published-image.sh
+++ b/shared/bootc-secure/ci/verify-published-image.sh
@@ -22,6 +22,10 @@ if [[ ! -f $AUTH_FILE ]]; then
     printf 'source registry auth file is not a regular file\n' >&2
     exit 2
 fi
+if [[ ${AUTH_FILE##*/} != config.json ]]; then
+    printf 'source registry auth file must be named config.json\n' >&2
+    exit 2
+fi
 
 if [[ ! $IMAGE =~ ^ghcr\.io/frostyard/(cayo|snow|snowfield)$ ]]; then
     printf 'invalid secure image reference\n' >&2
@@ -40,12 +44,21 @@ if [[ ! $LOCAL_REF =~ ^localhost/snosi-verified-${IMAGE_NAME}:${VERSION_TAG}$ ]]
     exit 2
 fi
 
-inspection=$(skopeo inspect "docker://$IMAGE@$EXPECTED_DIGEST")
+inspection=$(skopeo inspect --authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST")
 jq -e --arg digest "$EXPECTED_DIGEST" '
     .Digest == $digest and
     .Labels["io.snosi.bootc.secureboot-capable"] == "true" and
     .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.3-storage-digest-v1"
 ' <<<"$inspection" >/dev/null
+
+tag_digest=$(skopeo inspect --authfile "$AUTH_FILE" --format '{{.Digest}}' \
+    "docker://$IMAGE:$VERSION_TAG")
+if [[ $tag_digest != "$EXPECTED_DIGEST" ]]; then
+    printf 'version tag resolved to %s instead of %s\n' \
+        "$tag_digest" "$EXPECTED_DIGEST" >&2
+    exit 1
+fi
 
 work=$(mktemp -d)
 chmod 700 "$work"
@@ -57,7 +70,9 @@ jq --arg key "$ROOT_DIR/cosign.pub" '
 mkdir -p "$work/registries.d"
 cp "$REGISTRIES" "$work/registries.d/frostyard.yaml"
 
-cosign verify --key "$ROOT_DIR/cosign.pub" "$IMAGE@$EXPECTED_DIGEST" >/dev/null
+auth_dir=$(dirname -- "$AUTH_FILE")
+DOCKER_CONFIG=$auth_dir cosign verify --key "$ROOT_DIR/cosign.pub" \
+    "$IMAGE@$EXPECTED_DIGEST" >/dev/null
 sudo skopeo copy --src-authfile "$AUTH_FILE" \
     --policy "$work/policy.json" --registries.d "$work/registries.d" \
     "docker://$IMAGE@$EXPECTED_DIGEST" "containers-storage:$LOCAL_REF"

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -42,6 +42,16 @@ make_fixture() {
     : >"$fixture/shared/bootc-secure/tree/usr/lib/snosi/bootc-secure.json"
 
     cat >"$fixture/shared/bootc-secure/ci/verify-published-image.sh" <<'EOF'
+inspection=$(skopeo inspect --authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST")
+tag_digest=$(skopeo inspect --authfile "$AUTH_FILE" --format '{{.Digest}}' \
+    "docker://$IMAGE:$VERSION_TAG")
+if [[ $tag_digest != "$EXPECTED_DIGEST" ]]; then
+    exit 1
+fi
+auth_dir=$(dirname -- "$AUTH_FILE")
+DOCKER_CONFIG=$auth_dir cosign verify --key "$ROOT_DIR/cosign.pub" \
+    "$IMAGE@$EXPECTED_DIGEST" >/dev/null
 sudo skopeo copy --src-authfile "$AUTH_FILE" \
     "docker://$IMAGE@$EXPECTED_DIGEST" "containers-storage:$LOCAL_REF"
 jq -e --arg digest "$EXPECTED_DIGEST" '
@@ -145,6 +155,18 @@ remove_verifier_src_authfile() {
     perl -0pi -e 's/ --src-authfile "\$AUTH_FILE"//' \
         "$1/shared/bootc-secure/ci/verify-published-image.sh"
 }
+remove_digest_inspect_auth() {
+    perl -0pi -e 's/skopeo inspect --authfile "\$AUTH_FILE"/skopeo inspect/' \
+        "$1/shared/bootc-secure/ci/verify-published-image.sh"
+}
+remove_cosign_docker_config() {
+    perl -0pi -e 's/DOCKER_CONFIG=\$auth_dir cosign/cosign/' \
+        "$1/shared/bootc-secure/ci/verify-published-image.sh"
+}
+remove_tag_binding() {
+    perl -0pi -e 's/^tag_digest=.*?^fi\n//ms' \
+        "$1/shared/bootc-secure/ci/verify-published-image.sh"
+}
 move_promotion_early() {
     perl -0pi -e 's/      - name: Promote validated digest to latest\n//; s/(      - name: Push immutable version tag\n)/$1      - name: Promote validated digest to latest\n/' "$1/.github/workflows/build-images.yml"
 }
@@ -179,6 +201,9 @@ assert_guard 'false secure label check fails' 1 break_label_check
 assert_guard 'missing secure label check fails' 1 remove_label_check
 assert_guard 'missing workflow auth handoff fails' 1 remove_workflow_auth_handoff
 assert_guard 'missing verifier source auth option fails' 1 remove_verifier_src_authfile
+assert_guard 'missing verifier digest inspect auth fails' 1 remove_digest_inspect_auth
+assert_guard 'missing Cosign Docker config fails' 1 remove_cosign_docker_config
+assert_guard 'missing version tag binding fails' 1 remove_tag_binding
 assert_guard 'early latest promotion fails' 1 move_promotion_early
 
 printf '%d passing assertions, %d failures\n' "$pass" "$fail"

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -61,6 +61,17 @@ jq -e --arg digest "$EXPECTED_DIGEST" '
 ' <<<"$inspection" >/dev/null
 EOF
 
+    cat >"$fixture/shared/bootc-secure/ci/promote-published-image.sh" <<'EOF'
+skopeo copy --all \
+    --src-authfile "$AUTH_FILE" --dest-authfile "$AUTH_FILE" \
+    "docker://$IMAGE@$EXPECTED_DIGEST" "docker://$IMAGE:latest"
+latest_digest=$(skopeo inspect --authfile "$AUTH_FILE" \
+    --format '{{.Digest}}' "docker://$IMAGE:latest")
+if [[ $latest_digest != "$EXPECTED_DIGEST" ]]; then
+    exit 1
+fi
+EOF
+
     cat >"$fixture/.github/workflows/build-images.yml" <<'EOF'
 jobs:
   secure-build:
@@ -94,11 +105,13 @@ jobs:
         run: |
           sudo ./test/bootc-secure-artifact-test.sh \
             "output/${{ matrix.profile }}" localhost/cayo:version mok.crt pcr.pub
-      - name: Remove protected bootc signing credentials
+       - name: Remove protected bootc signing credentials
         if: always()
         run: sudo rm -rf /var/tmp/bootc-secure-credentials
-      - name: Push immutable version tag
-      - name: Sign immutable image digest
+       - name: Push immutable version tag
+       - name: Log in to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+       - name: Sign immutable image digest
       - name: Verify pushed secure image
         run: |
           AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
@@ -108,8 +121,13 @@ jobs:
         run: |
           sudo ./test/bootc-secure-artifact-test.sh \
             "output/${{ matrix.profile }}" "$LOCAL_REF" mok.crt pcr.pub
-      - name: Promote validated digest to latest
+       - name: Promote validated digest to latest
+        run: |
+          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+          ./shared/bootc-secure/ci/promote-published-image.sh \
+            "$IMAGE" "${{ steps.push.outputs.digest }}" "$AUTH_FILE"
 EOF
+    perl -pi -e 's/^       - /      - /' "$fixture/.github/workflows/build-images.yml"
 }
 
 assert_guard() {
@@ -170,6 +188,19 @@ remove_tag_binding() {
 move_promotion_early() {
     perl -0pi -e 's/      - name: Promote validated digest to latest\n//; s/(      - name: Push immutable version tag\n)/$1      - name: Promote validated digest to latest\n/' "$1/.github/workflows/build-images.yml"
 }
+remove_login() { perl -0pi -e 's/      - name: Log in to ghcr\.io\n        uses: docker\/login-action\@[^\n]+\n//' "$1/.github/workflows/build-images.yml"; }
+move_login_after_verification() {
+    perl -0pi -e 's/      - name: Log in to ghcr\.io\n        uses: docker\/login-action\@[^\n]+\n//; s/(      - name: Validate policy-copied secure artifact\n)/$1      - name: Log in to ghcr.io\n        uses: docker\/login-action\@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3\n/' "$1/.github/workflows/build-images.yml"
+}
+remove_promotion_src_authfile() { perl -0pi -e 's/ --src-authfile "\$AUTH_FILE"//' "$1/shared/bootc-secure/ci/promote-published-image.sh"; }
+remove_promotion_dest_authfile() { perl -0pi -e 's/ --dest-authfile "\$AUTH_FILE"//' "$1/shared/bootc-secure/ci/promote-published-image.sh"; }
+remove_promotion_inspect_authfile() { perl -0pi -e 's/skopeo inspect --authfile "\$AUTH_FILE"/skopeo inspect/' "$1/shared/bootc-secure/ci/promote-published-image.sh"; }
+old_inline_promotion_copy() {
+    perl -0pi -e 's{           \./shared/bootc-secure/ci/promote-published-image\.sh \\\n             "\$IMAGE" "\$DIGEST" "\$AUTH_FILE"}{           skopeo copy --all "docker://$IMAGE@$DIGEST" "docker://$IMAGE:latest"}' "$1/.github/workflows/build-images.yml"
+}
+inline_promotion_copy() {
+    perl -0pi -e 's|\./shared/bootc-secure/ci/promote-published-image\.sh|skopeo copy --all|' "$1/.github/workflows/build-images.yml"
+}
 
 assert_guard 'baseline secure publication fixture passes' 0 unchanged
 assert_guard 'missing bootc secure include fails' 1 remove_secure_include
@@ -205,6 +236,12 @@ assert_guard 'missing verifier digest inspect auth fails' 1 remove_digest_inspec
 assert_guard 'missing Cosign Docker config fails' 1 remove_cosign_docker_config
 assert_guard 'missing version tag binding fails' 1 remove_tag_binding
 assert_guard 'early latest promotion fails' 1 move_promotion_early
+assert_guard 'missing registry login fails' 1 remove_login
+assert_guard 'login after verification fails' 1 move_login_after_verification
+assert_guard 'missing promotion source auth fails' 1 remove_promotion_src_authfile
+assert_guard 'missing promotion destination auth fails' 1 remove_promotion_dest_authfile
+assert_guard 'missing promotion inspect auth fails' 1 remove_promotion_inspect_authfile
+assert_guard 'inline promotion copy fails' 1 inline_promotion_copy
 
 printf '%d passing assertions, %d failures\n' "$pass" "$fail"
 ((fail == 0))

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -195,9 +195,6 @@ move_login_after_verification() {
 remove_promotion_src_authfile() { perl -0pi -e 's/ --src-authfile "\$AUTH_FILE"//' "$1/shared/bootc-secure/ci/promote-published-image.sh"; }
 remove_promotion_dest_authfile() { perl -0pi -e 's/ --dest-authfile "\$AUTH_FILE"//' "$1/shared/bootc-secure/ci/promote-published-image.sh"; }
 remove_promotion_inspect_authfile() { perl -0pi -e 's/skopeo inspect --authfile "\$AUTH_FILE"/skopeo inspect/' "$1/shared/bootc-secure/ci/promote-published-image.sh"; }
-old_inline_promotion_copy() {
-    perl -0pi -e 's{           \./shared/bootc-secure/ci/promote-published-image\.sh \\\n             "\$IMAGE" "\$DIGEST" "\$AUTH_FILE"}{           skopeo copy --all "docker://$IMAGE@$DIGEST" "docker://$IMAGE:latest"}' "$1/.github/workflows/build-images.yml"
-}
 inline_promotion_copy() {
     perl -0pi -e 's|\./shared/bootc-secure/ci/promote-published-image\.sh|skopeo copy --all|' "$1/.github/workflows/build-images.yml"
 }

--- a/test/bootc-secure-docs-test.sh
+++ b/test/bootc-secure-docs-test.sh
@@ -46,6 +46,8 @@ required_strings=(
     'Remove the old MOK only after every old-signed rollback deployment is retired.'
     'Loss of both TPM authorization and the external recovery passphrase is unrecoverable.'
     'Root Skopeo receives the Docker login auth file explicitly through --src-authfile.'
+    'Every GHCR read and write in secure verification and promotion receives the Docker login config explicitly.'
+    'Pinned Cosign v2.6.1 receives registry auth through command-scoped DOCKER_CONFIG.'
 )
 
 for heading in "${required_headings[@]}"; do

--- a/test/bootc-secure-promotion-test.sh
+++ b/test/bootc-secure-promotion-test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Fixture coverage for authenticated immutable-digest promotion.
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+HELPER="$ROOT_DIR/shared/bootc-secure/ci/promote-published-image.sh"
+DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+IMAGE="ghcr.io/frostyard/cayo"
+WORK=""
+AUTH_FILE=""
+PASS=0
+FAIL=0
+
+pass() { printf 'ok - %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf 'not ok - %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+
+cleanup() { [[ -z "$WORK" ]] || rm -rf "$WORK"; }
+trap cleanup EXIT
+
+run_helper() { # image expected-digest auth-file
+    local output status
+    set +e
+    output=$(PATH="$WORK/bin:$PATH" COMMAND_LOG="$WORK/commands" \
+        EXPECTED_AUTH_FILE="$3" EXPECTED_DIGEST="$2" \
+        "$HELPER" "$@" 2>&1)
+    status=$?
+    set -e
+    printf '%s\n%s\n' "$status" "$output"
+}
+
+run_case() { # description expected-status image expected-digest auth-file
+    local result status output
+    : >"$WORK/commands"
+    result=$(run_helper "$3" "$4" "$5")
+    status=${result%%$'\n'*}
+    output=${result#*$'\n'}
+    if [[ $2 == success && $status -eq 0 ]] || [[ $2 == failure && $status -ne 0 ]]; then
+        pass "$1"
+    else
+        fail "$1 ($output)"
+    fi
+}
+
+WORK=$(mktemp -d)
+mkdir -p "$WORK/bin"
+AUTH_FILE="$WORK/config.json"
+printf '{"auths":{}}\n' >"$AUTH_FILE"
+
+cat >"$WORK/bin/skopeo" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf 'skopeo %s\n' "$*" >>"$COMMAND_LOG"
+case "$1" in
+    copy)
+        [[ " $* " == *" --all "* ]]
+        [[ " $* " == *" --src-authfile $EXPECTED_AUTH_FILE "* ]]
+        [[ " $* " == *" --dest-authfile $EXPECTED_AUTH_FILE "* ]]
+        [[ " $* " == *" docker://ghcr.io/frostyard/cayo@$EXPECTED_DIGEST docker://ghcr.io/frostyard/cayo:latest "* ]]
+        [[ ${SKOPEO_COPY_FAIL:-0} != 1 ]]
+        ;;
+    inspect)
+        [[ " $* " == *" --authfile $EXPECTED_AUTH_FILE "* ]]
+        [[ " $* " == *" --format {{.Digest}} "* ]]
+        [[ " $* " == *" docker://ghcr.io/frostyard/cayo:latest "* ]]
+        [[ ${SKOPEO_INSPECT_FAIL:-0} != 1 ]]
+        printf '%s\n' "${LATEST_DIGEST:-$EXPECTED_DIGEST}"
+        ;;
+    *) exit 64 ;;
+esac
+EOF
+chmod +x "$WORK/bin/skopeo"
+
+run_case "authenticated immutable promotion succeeds" success "$IMAGE" "$DIGEST" "$AUTH_FILE"
+grep -Fqx "skopeo copy --all --src-authfile $AUTH_FILE --dest-authfile $AUTH_FILE docker://$IMAGE@$DIGEST docker://$IMAGE:latest" "$WORK/commands" &&
+    pass "copy has explicit source and destination auth" ||
+    fail "copy has explicit source and destination auth"
+grep -Fqx "skopeo inspect --authfile $AUTH_FILE --format {{.Digest}} docker://$IMAGE:latest" "$WORK/commands" &&
+    pass "inspect has explicit auth and digest format" ||
+    fail "inspect has explicit auth and digest format"
+
+run_case "malformed repository is rejected" failure "ghcr.io/frostyard/untrusted" "$DIGEST" "$AUTH_FILE"
+run_case "tagged repository is rejected" failure "$IMAGE:version" "$DIGEST" "$AUTH_FILE"
+run_case "malformed digest is rejected" failure "$IMAGE" "sha256:not-a-digest" "$AUTH_FILE"
+run_case "missing auth file is rejected" failure "$IMAGE" "$DIGEST" "$WORK/missing/config.json"
+mkdir "$WORK/directory-auth"
+run_case "directory auth path is rejected" failure "$IMAGE" "$DIGEST" "$WORK/directory-auth"
+cp "$AUTH_FILE" "$WORK/auth.json"
+run_case "non-config.json auth file is rejected" failure "$IMAGE" "$DIGEST" "$WORK/auth.json"
+SKOPEO_COPY_FAIL=1 run_case "copy failure is propagated" failure "$IMAGE" "$DIGEST" "$AUTH_FILE"
+SKOPEO_INSPECT_FAIL=1 run_case "inspect failure is propagated" failure "$IMAGE" "$DIGEST" "$AUTH_FILE"
+LATEST_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+    run_case "latest digest mismatch is rejected" failure "$IMAGE" "$DIGEST" "$AUTH_FILE"
+
+printf '# Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+exit "$FAIL"

--- a/test/bootc-secure-publication-test.sh
+++ b/test/bootc-secure-publication-test.sh
@@ -39,7 +39,7 @@ assert_failure() { # description command output
 run_helper() { # image version digest local-ref auth-file
     local output status
     set +e
-    output=$(PATH="$WORK/bin:$PATH" COMMAND_LOG="$WORK/commands" COPIED_POLICY="$WORK/copied-policy.json" "$HELPER" "$@" 2>&1)
+    output=$(PATH="$WORK/bin:$PATH" COMMAND_LOG="$WORK/commands" COPIED_POLICY="$WORK/copied-policy.json" EXPECTED_AUTH_FILE="$5" EXPECTED_DIGEST="$3" "$HELPER" "$@" 2>&1)
     status=$?
     set -e
     printf '%s\n%s\n' "$status" "$output"
@@ -60,14 +60,21 @@ run_case() { # description expected-status image version digest local-ref auth-f
 
 WORK=$(mktemp -d)
 mkdir -p "$WORK/bin"
-AUTH_FILE="$WORK/auth.json"
+AUTH_FILE="$WORK/config.json"
 printf '{"auths":{}}\n' >"$AUTH_FILE"
 cat >"$WORK/bin/skopeo" <<'EOF'
 #!/bin/bash
 set -euo pipefail
 printf 'skopeo %s\n' "$*" >>"$COMMAND_LOG"
 case "$1" in
-    inspect) printf '%s\n' "$INSPECTION" ;;
+    inspect)
+        [[ " $* " == *" --authfile $EXPECTED_AUTH_FILE "* ]]
+        if [[ " $* " == *" --format {{.Digest}} "* ]]; then
+            printf '%s\n' "${TAG_DIGEST:-$EXPECTED_DIGEST}"
+        else
+            printf '%s\n' "$INSPECTION"
+        fi
+        ;;
     copy)
         while (($# > 0)); do
             case "$1" in
@@ -83,7 +90,9 @@ EOF
 cat >"$WORK/bin/cosign" <<'EOF'
 #!/bin/bash
 set -euo pipefail
-printf 'cosign %s\n' "$*" >>"$COMMAND_LOG"
+expected_dir=$(dirname -- "$EXPECTED_AUTH_FILE")
+printf 'DOCKER_CONFIG=%s cosign %s\n' "${DOCKER_CONFIG:-}" "$*" >>"$COMMAND_LOG"
+[[ ${DOCKER_CONFIG:-} == "$expected_dir" ]]
 [[ ${COSIGN_VERIFY_FAIL:-0} != 1 ]]
 EOF
 cat >"$WORK/bin/sudo" <<'EOF'
@@ -98,7 +107,9 @@ export INSPECTION
 INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
 
 run_case "accepted immutable secure image is copied" success "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
-grep -Fqx "cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" "$WORK/commands" && pass "Cosign verifies the immutable image with the committed key" || fail "Cosign verifies the immutable image with the committed key"
+grep -Fqx "skopeo inspect --authfile $AUTH_FILE docker://$IMAGE@$DIGEST" "$WORK/commands" && pass "Skopeo inspects immutable metadata with explicit auth" || fail "Skopeo inspects immutable metadata with explicit auth"
+grep -Fqx "skopeo inspect --authfile $AUTH_FILE --format {{.Digest}} docker://$IMAGE:$VERSION" "$WORK/commands" && pass "Skopeo resolves the version tag with explicit auth" || fail "Skopeo resolves the version tag with explicit auth"
+grep -Fqx "DOCKER_CONFIG=$(dirname -- "$AUTH_FILE") cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" "$WORK/commands" && pass "Cosign verifies the immutable image with the command-scoped auth config" || fail "Cosign verifies the immutable image with the command-scoped auth config"
 grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" && grep -Fq -- "--registries.d " "$WORK/commands" && grep -Fq "docker://$IMAGE@$DIGEST containers-storage:$LOCAL_REF" "$WORK/commands" && pass "policy copy uses immutable source and root containers storage" || fail "policy copy uses immutable source and root containers storage"
 if jq -e '.default == [{"type":"reject"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains global reject"; else fail "copied policy retains global reject"; fi
 if jq -e --arg key "$ROOT_DIR/cosign.pub" '
@@ -110,7 +121,7 @@ if jq -e --arg key "$ROOT_DIR/cosign.pub" '
     ]
 ' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains exactly the three scoped Cosign rules"; else fail "copied policy retains exactly the three scoped Cosign rules"; fi
 if jq -e '.transports["containers-storage"][""] == [{"type":"insecureAcceptAnything"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains the containers-storage exception"; else fail "copied policy retains the containers-storage exception"; fi
-if [[ $(sed -n '1p' "$WORK/commands") == "skopeo inspect docker://$IMAGE@$DIGEST" ]] && [[ $(sed -n '2p' "$WORK/commands") == "cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" ]] && [[ $(sed -n '4p' "$WORK/commands") == "skopeo copy --src-authfile $AUTH_FILE "* ]]; then pass "verification orders inspect before Cosign before policy copy"; else fail "verification orders inspect before Cosign before policy copy"; fi
+if [[ $(sed -n '1p' "$WORK/commands") == "skopeo inspect --authfile $AUTH_FILE docker://$IMAGE@$DIGEST" ]] && [[ $(sed -n '2p' "$WORK/commands") == "skopeo inspect --authfile $AUTH_FILE --format {{.Digest}} docker://$IMAGE:$VERSION" ]] && [[ $(sed -n '3p' "$WORK/commands") == "DOCKER_CONFIG=$(dirname -- "$AUTH_FILE") cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" ]] && [[ $(sed -n '5p' "$WORK/commands") == "skopeo copy --src-authfile $AUTH_FILE "* ]]; then pass "verification orders explicit metadata reads before Cosign before policy copy"; else fail "verification orders explicit metadata reads before Cosign before policy copy"; fi
 grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" &&
         pass "root policy copy receives the explicit source auth file" ||
         fail "root policy copy receives the explicit source auth file"
@@ -123,12 +134,18 @@ run_case "missing source auth file is rejected" failure \
     "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$WORK/missing-auth.json"
 run_case "non-regular source auth path is rejected" failure \
     "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$WORK"
+cp "$AUTH_FILE" "$WORK/auth.json"
+run_case "non-config.json auth file is rejected" failure \
+    "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$WORK/auth.json"
 
 run_case "tagged image reference is rejected" failure "$IMAGE:$VERSION" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 run_case "wrong image repository is rejected" failure "ghcr.io/frostyard/untrusted" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 run_case "malformed digest is rejected" failure "$IMAGE" "$VERSION" "sha256:not-a-digest" "$LOCAL_REF" "$AUTH_FILE"
 run_case "mismatched local reference is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "localhost/snosi-verified-snow:$VERSION" "$AUTH_FILE"
 run_case "malformed version tag is rejected" failure "$IMAGE" "latest" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
+TAG_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+    run_case "version tag digest mismatch is rejected" failure \
+    "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
 INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "false", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
 run_case "false secure capability is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
@@ -143,7 +160,7 @@ INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi
 COSIGN_VERIFY_FAIL=1 run_case "failed Cosign verification is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 SKOPEO_COPY_FAIL=1 run_case "failed policy copy is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
-if [[ -f "$HELPER" ]] && ! grep -Eiq '(skopeo|docker)[^#]*(push|tag)|latest' "$HELPER"; then
+if [[ -f "$HELPER" ]] && ! grep -Eiq "(skopeo|docker)[^#]*push|docker://[^[:space:]\"']+:latest" "$HELPER"; then
     pass "helper has no publication or mutable-tag operation"
 else
     fail "helper has no publication or mutable-tag operation"

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -208,15 +208,21 @@ after local validation and before registry publication.
 
 Protected bootc publication pushes a version tag, validates its immutable
 digest and secure labels/signature/policy-copied artifact, then moves `latest`;
-failed immutable candidates never move `latest`.
-The workflow's `docker/login-action` credentials serve user-context Cosign and
-are passed by path to the verifier. The Docker auth file must be directly
-consumable by root Skopeo without user-scoped credential-helper state; otherwise
-the policy-copy verification fails closed and the next protected run remains the
-live proof. Root Skopeo receives that file only through `--src-authfile` for the
-immutable registry source; its local `containers-storage:` destination receives
-no registry credentials. Do not infer this handoff from `XDG_RUNTIME_DIR` or
-root Buildah login state.
+failed immutable candidates never move `latest`. Every GHCR read and write in
+secure verification and promotion receives the Docker login config explicitly:
+Skopeo inspections use `--authfile`, root policy copy uses source-only
+`--src-authfile`, and promotion uses source and destination auth files. Pinned
+Cosign v2.6.1 receives registry auth through command-scoped `DOCKER_CONFIG`; it
+has no registry-config flag. Version-tag resolution must equal the pushed digest
+before policy copy. The Docker auth file must be directly consumable by root
+Skopeo without user-scoped credential-helper state; otherwise the policy-copy
+verification fails closed and the next protected run remains the live proof. Do
+not infer this handoff from `XDG_RUNTIME_DIR` or root Buildah login state.
+
+Deferred publication follow-ups: bind SBOM signing to the exact uploaded
+referrer digest, gate Snow release creation on complete metadata publication,
+decide whether `latest` moves only after metadata completion, and make general
+output cleanup unconditional where retained runners require it.
 `test-bootc-secure.yml` supplies PR/push fixture contracts,
 `bootc-secure-nightly.yml` supplies fixture coverage plus a self-hosted live
 full-window attempt, and `test-install.yml` remains explicitly insecure legacy


### PR DESCRIPTION
## Summary
- pass the Docker login config explicitly to both verifier Skopeo reads and pinned Cosign verification
- bind the pushed version tag to the expected immutable digest before policy copy
- move `latest` promotion into a fixture-tested helper with explicit source, destination, and confirming-inspect auth
- enforce login and publication ordering with 40 fail-closed guard mutations
- record deferred SBOM identity, metadata ordering, release gating, and cleanup findings without broadening this repair

## Failure evidence
Protected run 30594624886 passed secure assembly, local validation, protected-key deletion, immutable push, Docker login, and Cosign signing for Cayo, Snow, and Snowfield. All three then failed the verifier's first ambient `skopeo inspect` while trying `/run/user/1001/containers/auth.json`; policy-copy validation and `latest` promotion did not run.

## Validation
- `test/bootc-secure-publication-test.sh`: 27 passed, 0 failed
- `test/bootc-secure-promotion-test.sh`: 12 passed, 0 failed
- `test/bootc-publication-guard-test.sh`: 40 passing assertions, 0 failures
- documentation contract and static publication guard: passed
- actionlint across all modified workflows: clean
- ShellCheck across all modified scripts/tests: clean
- `git diff --check`: clean
- independent per-task and whole-branch reviews: approved

## Remaining gates
The next protected run remains the live proof that the hosted runner Docker config is readable by both user-context and root Skopeo and by Cosign v2.6.1. A successful publication is one candidate set only; Task 9 install/update/rollback/recovery evidence and Snowfield hardware proof remain blocked.