### PR TITLE
fix: chunk bootc images before digest sealing

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -160,13 +160,17 @@ jobs:
       - name: Package image
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
+          MAX_LAYERS: 128
           SNOSI_BOOTC_SECURE: "1"
           SNOSI_BOOTC_MOK_KEY: /var/tmp/bootc-secure-credentials/mok.key
           SNOSI_BOOTC_MOK_CERT: /var/tmp/bootc-secure-credentials/mok.crt
           SNOSI_BOOTC_PCR_KEY: /var/tmp/bootc-secure-credentials/pcr.key
           SNOSI_BOOTC_PCR_CERT: /var/tmp/bootc-secure-credentials/pcr.pub
         run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
           sudo TMPDIR="$TMPDIR" \
+            SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
+            MAX_LAYERS="$MAX_LAYERS" \
             SNOSI_BOOTC_SECURE="$SNOSI_BOOTC_SECURE" \
             SNOSI_BOOTC_MOK_KEY="$SNOSI_BOOTC_MOK_KEY" \
             SNOSI_BOOTC_MOK_CERT="$SNOSI_BOOTC_MOK_CERT" \
@@ -196,19 +200,6 @@ jobs:
       - name: Remove protected bootc signing credentials
         if: always()
         run: sudo rm -rf /var/tmp/bootc-secure-credentials
-
-      - name: Chunk image
-        env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
-          MAX_LAYERS: 128
-        run: |
-          # head_commit.timestamp is empty on workflow_dispatch/repository_dispatch
-          # and GNU 'date -d ""' silently yields today-midnight; derive the epoch
-          # from the checked-out commit instead (correct for every trigger).
-          SOURCE_EPOCH=$(git log -1 --format=%ct)
-          sudo TMPDIR="$TMPDIR" ./shared/outformat/image/chunkah-package.sh \
-          "$IMAGE:${{ steps.version.outputs.tag }}" \
-          "$SOURCE_EPOCH"
 
       - name: Smoke test - verify SUID bit and bcvk requirements
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,17 +67,20 @@ Frostyard debs or the selected systemd family changes.
 hidden storage-digest plus direct two-pass ukify behavior as a maintained,
 fail-closed compatibility contract. This is NOT upstream-stable. Secure builds
 must set `SNOSI_BOOTC_SECURE=1` and caller-owned MOK/PCR credentials; Buildah
-packages a pristine first pass, obtains its storage composefs ID from the image
-binary, first places the MOK-signed systemd-boot source at
-`/usr/lib/snosi/bootc/systemd-bootx64.efi`, constructs the UKI and ESP copy
-below `/boot`, and requires a final OCI probe to retain the ID. It emits the explicit
+packages and chunks a pristine first pass, then obtains its storage composefs
+ID from that chunked candidate image. It first places the MOK-signed
+systemd-boot source at `/usr/lib/snosi/bootc/systemd-bootx64.efi`, constructs
+the UKI and ESP copy below `/boot`, and derives the final image from the
+chunked candidate with that `/boot` tree as its only filesystem overlay. The
+final candidate's bootc performs the second of exactly two digest probes and
+must retain the ID; protected builds never chunk after assembly. It emits the explicit
 `io.snosi.bootc.secureboot-capable=true` label; non-secure builds emit `false`.
 Before first-pass packaging, the root packager temporarily bind-mounts only host
 `/proc` into the complete mkosi rootfs and runs the exact bootc version probe
 through chroot, so target libraries rather than the CI host ABI resolve. It
 refuses pre-mounted/missing rootfs proc paths and unmounts before any image
 mutation. Storage-digest authority remains bootc inside the candidate OCI image.
-Direct ukify executes as `/usr/bin/ukify` inside the pristine first-pass
+Direct ukify executes as `/usr/bin/ukify` inside the chunked first-pass
 candidate with network disabled, individual read-only credential mounts, and a
 public-only writable work mount. Protected run 30579247524 reached this point
 but cayo job 90995134482 failed because the unprivileged candidate could not
@@ -104,8 +107,9 @@ state. Task 5 derives fingerprints only from those exact caller-owned private
 keys and rejects matches in the rootfs, mounted OCI filesystem/config, sanitized
 ukify log, and scan state; it deliberately permits unrelated package/example
 keys and does not use documentation/MIME exclusions. Re-run Tasks 1-3 and Task 5 artifact/negative validation before changing
-bootc/libostree, ukify/systemd, Buildah packaging, or any observed command/output
-shape. See `docs/bootc-secure-assembly-compatibility.md`.
+bootc/libostree, ukify/systemd, chunkah, Buildah derivation, the `/boot`
+exclusion, or any observed command/output shape. See
+`docs/bootc-secure-assembly-compatibility.md`.
 
 **Bootc shim second-stage reconciliation (Task 7, 2026-07-28):** secure OCI
 assembly retains the MOK-signed systemd-boot at
@@ -1546,7 +1550,7 @@ The shared sysext postoutput script (`shared/sysext/postoutput/sysext-postoutput
 - `shared/download/` - Verified download system: `sysext-checksums.json` pins direct downloads consumed by sysexts, `image-checksums.json` pins direct downloads consumed by OCI profile builds, `package-versions.json` tracks external APT package version sentinels for sysexts, and `verified-download.sh` provides the `verified_download()` helper
 - `shared/kernel/` - Kernel configs (backports, surface, stock) and dracut scripts
 - `shared/packages/` - Package set definitions, some with postinstall scripts for relocation
-- `shared/outformat/image/` - Image output format config (directory), finalize scripts, `buildah-package.sh` (OCI packaging), and `chunkah-package.sh` (CI re-chunks the OCI image for efficient delta updates)
+- `shared/outformat/image/` - Image output format config (directory), finalize scripts, `buildah-package.sh` (OCI packaging), and `chunkah-package.sh` (chunks non-secure OCI images and the pristine protected candidate before digest sealing; protected images are never re-chunked after assembly)
 - `shared/sysext/postoutput/` - Shared sysext postoutput logic
 - `mkosi.sandbox/etc/apt/` - External APT repo configs (Docker, Incus, linux-surface, Frostyard)
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ version drift at that compatibility boundary.
 The protected packager passes its secure assembly flag and credential paths
 explicitly through sudo. The private bytes stay in mode-0600 runner files;
 only their paths cross the privilege boundary.
+For protected secure images, it chunks the pristine candidate before the
+candidate's pinned bootc obtains the authoritative storage digest. The final
+image inherits those chunked layers and overlays only `/boot`; its bootc must
+return the same digest in the second of exactly two digest probes. Protected
+assembly never runs a post-assembly chunk pass.
 
 ## Architecture
 
@@ -290,7 +295,7 @@ shared/
 │       ├── mkosi.conf         ← Sets Format=directory
 │       ├── finalize/          ← Image finalization scripts
 │       ├── buildah-package.sh ← Packages rootfs dir into an OCI image
-│       └── chunkah-package.sh ← Re-chunks the OCI image for efficient updates
+│       └── chunkah-package.sh ← Chunks OCI candidates for efficient updates
 ├── packages/
 │   ├── cayo/mkosi.conf        ← Server packages + podman
 │   ├── snow/mkosi.conf        ← GNOME desktop packages
@@ -429,10 +434,13 @@ Native A/B profiles intentionally do not inherit this OCI-only bcvk dependency.
 
 **Secure Boot status:** OCI bootc profiles include a bootc-only secure
 composition and a Task 5 two-pass UKI assembly adapter. Protected builds set
-`SNOSI_BOOTC_SECURE=1`; Buildah computes the pre-injection OCI composefs digest,
-constructs a MOK-signed Type #2 UKI plus MOK-signed systemd-boot, retains the
-signed second stage under `/usr/lib/snosi/bootc/` for installed-ESP
-reconciliation, then refuses the final image if its digest changes. The static
+`SNOSI_BOOTC_SECURE=1`; Buildah chunks the pristine candidate before that
+candidate's bootc computes the authoritative OCI composefs digest, constructs a
+MOK-signed Type #2 UKI plus MOK-signed systemd-boot, retains the signed second
+stage under `/usr/lib/snosi/bootc/` for installed-ESP reconciliation, then
+derives the final image from the chunked candidate with only `/boot` overlaid.
+The final candidate's bootc is the second of exactly two digest probes and must
+return the same digest; protected assembly never chunks after that overlay. The static
 reconciler activates after local filesystems without writing `/etc`, verifies
 the MOK signer before atomically replacing only shim's `grubx64.efi`, and allows
 valid rollback deployments to restore their own stage. It never remounts an

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -119,6 +119,8 @@ else
             capture { print }
         ' <<<"$secure_job")
         forwarded_variables=(
+            SOURCE_DATE_EPOCH
+            MAX_LAYERS
             SNOSI_BOOTC_SECURE
             SNOSI_BOOTC_MOK_KEY
             SNOSI_BOOTC_MOK_CERT
@@ -131,9 +133,18 @@ else
             require_text "$workflow protected package sudo environment" \
                 "$package_step" "$forwarded_line"
         done
+        require_text "$workflow protected package environment" \
+            "$package_step" '          MAX_LAYERS: 128'
+        # shellcheck disable=SC2016 # This is a literal workflow marker.
+        require_text "$workflow protected package epoch derivation" \
+            "$package_step" '          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)'
         sudo_tmpdir_line=$(printf '%s%s' "          sudo TMPDIR=\"\$TMPDIR\" " "\\")
         require_text "$workflow protected package sudo environment" \
             "$package_step" "$sudo_tmpdir_line"
+
+        if grep -Eq '(^|[[:space:]])\./shared/outformat/image/chunkah-package\.sh([[:space:]]|$)' <<<"$secure_job"; then
+            fail_check "$workflow secure-build: must not invoke chunkah-package.sh directly"
+        fi
 
         cleanup_step=$(awk '
             /^      - name: Remove protected bootc signing credentials$/ { capture=1 }
@@ -176,8 +187,10 @@ else
         if ! grep -Fq './shared/bootc-secure/ci/verify-published-image.sh' <<<"$verifier_step"; then
             fail_check "$workflow secure-build: missing secure image verifier call"
         fi
+        # shellcheck disable=SC2016 # Match the literal workflow shell source.
         require_text "$workflow secure verifier auth path" \
             "$verifier_step" '          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"'
+        # shellcheck disable=SC2016 # Match the literal workflow shell source.
         require_text "$workflow secure verifier auth argument" \
             "$verifier_step" '            "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"'
 
@@ -197,8 +210,10 @@ else
         if ! grep -Fq './shared/bootc-secure/ci/promote-published-image.sh' <<<"$promotion_step"; then
             fail_check "$workflow secure-build: missing authenticated promotion helper call"
         fi
+        # shellcheck disable=SC2016 # Match the literal workflow shell source.
         require_text "$workflow secure promotion auth path" \
             "$promotion_step" '          AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"'
+        # shellcheck disable=SC2016 # Match the literal workflow shell source.
         require_text "$workflow secure promotion auth argument" \
             "$promotion_step" '            "$IMAGE" "${{ steps.push.outputs.digest }}" "$AUTH_FILE"'
     fi
@@ -228,6 +243,7 @@ else
     verifier_text=$(<"$verifier")
     require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-capable"] == "true" and'
     require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.3-storage-digest-v1"'
+    # shellcheck disable=SC1003,SC2016 # Match the literal verifier shell source.
     require_text "$verifier" "$verifier_text" \
         'inspection=$(skopeo inspect --authfile "$AUTH_FILE" \'
     tag_inspect_line=$(cat <<'EOF'
@@ -235,10 +251,13 @@ tag_digest=$(skopeo inspect --authfile "$AUTH_FILE" --format '{{.Digest}}' \
 EOF
 )
     require_text "$verifier tag inspect auth" "$verifier_text" "$tag_inspect_line"
+    # shellcheck disable=SC2016 # Match the literal verifier shell source.
     require_text "$verifier" "$verifier_text" \
         'if [[ $tag_digest != "$EXPECTED_DIGEST" ]]; then'
+    # shellcheck disable=SC1003,SC2016 # Match the literal verifier shell source.
     require_text "$verifier" "$verifier_text" \
         'DOCKER_CONFIG=$auth_dir cosign verify --key "$ROOT_DIR/cosign.pub" \'
+    # shellcheck disable=SC1003,SC2016 # Match the literal verifier shell source.
     require_text "$verifier" "$verifier_text" \
         'sudo skopeo copy --src-authfile "$AUTH_FILE" \'
 fi
@@ -248,8 +267,10 @@ if [[ ! -f $promotion_helper ]]; then
     fail_check "missing secure image promotion helper: shared/bootc-secure/ci/promote-published-image.sh"
 else
     promotion_text=$(<"$promotion_helper")
+    # shellcheck disable=SC1003 # Match the literal promotion shell source.
     require_text "$promotion_helper" "$promotion_text" \
         'skopeo copy --all \'
+    # shellcheck disable=SC1003,SC2016 # Match the literal promotion shell source.
     require_text "$promotion_helper promotion source auth" "$promotion_text" \
         '    --src-authfile "$AUTH_FILE" --dest-authfile "$AUTH_FILE" \'
     promotion_inspect_line=$(cat <<'EOF'

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -8,10 +8,12 @@ upstream-stable bootc interface.
 
 The adapter relies on all of the following observed behavior:
 
-1. A pristine OCI image can run the hidden command
+1. A pristine OCI image can be chunked with the pinned chunkah operation before
+   it runs the hidden command
    `bootc container compute-composefs-digest-from-storage IMAGE` and return one
    128-hex-character composefs ID.
-2. Adding files only below `/boot` does not change that OCI-derived ID.
+2. Adding files only below `/boot` to an image derived from that chunked
+   candidate does not change that OCI-derived ID.
 3. Direct `ukify build` can produce a MOK-signed UKI with `rw` and exactly one
    `composefs=?<ID>` argument, one kernel/initramfs pair, an RSA-2048 PCR public
    key, and four PCR policies per signer.
@@ -19,8 +21,8 @@ The adapter relies on all of the following observed behavior:
    deployment without raw `linux` or `initrd` BLS fallback.
 5. Forky `systemd-ukify 261.1-3` ships executable `/usr/bin/ukify` (package
    SHA-256 `817b8ea0a8953f9fb4b42d91f04ed1511bbb1e76cee466497dfb955cb246aa34`).
-6. Direct ukify runs inside the first-pass candidate; candidate bootc remains
-   storage-digest authority.
+6. Direct ukify runs inside the chunked first-pass candidate; that candidate's
+   bootc remains storage-digest authority.
 7. Final host byte comparisons depend on first-pass `cp -a` identity.
 8. Candidate ukify runs with network disabled and all Linux capabilities dropped.
    It runs as the common numeric owner of its mode-0600 credentials; mismatches
@@ -42,12 +44,16 @@ The adapter relies on all of the following observed behavior:
 The cited protected run failed before validation, push, signing, or promotion;
 this fixture-covered behavior is not live secure-publication evidence.
 
-`buildah-package.sh` makes a first, unsigned-label OCI image, computes that
-storage digest through the image's own bootc binary, invokes the assembler,
-packages a second probe image, and refuses publication unless the digest is
-unchanged. The final image is labelled
-`io.snosi.bootc.secureboot-capable=true` only after that sequence. Non-secure
-builds explicitly carry `false`; key presence is never a capability signal.
+`buildah-package.sh` makes a first, unsigned-label OCI image, chunks it with
+the pinned chunkah operation, and obtains the authoritative storage digest
+through that chunked candidate's own bootc binary. It invokes the assembler,
+then derives the final image from the chunked candidate and overlays only the
+assembled `/boot` tree. The final candidate's own bootc performs the second and
+only other digest probe, which must return the authoritative digest exactly.
+There is no protected post-assembly chunk pass. The final image is labelled
+`io.snosi.bootc.secureboot-capable=true` only after that comparison and the
+credential scan pass. Non-secure builds explicitly carry `false`; key presence
+is never a capability signal.
 
 ## Credentials and rotation
 
@@ -67,9 +73,9 @@ output. Temporary files are private and removed on exit.
 ## Mandatory revalidation
 
 Before changing the Frostyard bootc/libostree package, bootc upstream version,
-the selected systemd/ukify family, or Buildah packaging behavior, run the full
-Task 1-3 rootfs proof and Task 5 artifact/negative tests against a newly built
-rootfs. Treat any change to the hidden command, digest equality, UKI sections,
-PCR signature shape, Type #2 BLS layout, or signed systemd-boot output as a
-hard stop. Update this compatibility contract only with replacement evidence;
-do not silently normalize the changed shape.
+the selected systemd/ukify family, chunkah, Buildah derivation, or the `/boot`
+exclusion, run the full Task 1-3 rootfs proof and Task 5 artifact/negative
+tests against a newly built rootfs. Treat any change to the hidden command,
+digest equality, UKI sections, PCR signature shape, Type #2 BLS layout, or
+signed systemd-boot output as a hard stop. Update this compatibility contract
+only with replacement evidence; do not silently normalize the changed shape.

--- a/docs/superpowers/plans/2026-07-31-bootc-chunk-before-seal.md
+++ b/docs/superpowers/plans/2026-07-31-bootc-chunk-before-seal.md
@@ -1,0 +1,336 @@
+# Bootc Chunk-Before-Seal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish chunkah-optimized secure bootc images whose final bootc storage digest exactly matches the digest sealed into the UKI.
+
+**Architecture:** Refactor the pinned chunkah command into a sourceable `chunk_image` function. In secure mode, `buildah-package.sh` packages and chunks the pristine candidate first, computes the authoritative digest from that chunked image, assembles the UKI, and derives the final image from the chunked candidate with only `/boot` copied into a final layer. The final image's own bootc must return the same digest before the image can survive cleanup or reach publication.
+
+**Tech Stack:** Bash, Buildah, Podman, chunkah, bootc 1.16.3, ukify 261.1-3, GitHub Actions, ShellCheck, actionlint.
+
+## Global Constraints
+
+- Preserve `quay.io/coreos/chunkah@sha256:fdff3175bfb41e111089392ef8a41b46a10766c7b2ec454ba1272a0c39ce3bf3`.
+- Preserve `chunkah build --prune /sysroot/ --max-layers "$MAX_LAYERS"` and the default `MAX_LAYERS=128`.
+- Secure mode requires `SOURCE_DATE_EPOCH`, derived from `git log -1 --format=%ct` and explicitly forwarded through sudo.
+- Candidate bootc 1.16.3 remains the sole storage-digest authority.
+- The only post-digest filesystem mutation is a final overlay copied from `$ROOTFS_DIR/boot/` to the derived candidate's `/boot/`.
+- The final image inherits the chunked candidate layers; it is never repackaged from scratch and never passed through chunkah a second time.
+- Private MOK/PCR credentials must not enter chunkah mounts, environment, image layers, labels, logs, or retained state.
+- Preserve existing candidate-ukify confinement, byte comparisons, credential scans, secure labels, and failure cleanup.
+- Do not modify or revert unrelated worktree changes.
+- Do not create git commits unless the user explicitly requests them.
+
+---
+
+### Task 1: Chunked Secure Packaging
+
+**Files:**
+- Modify: `shared/outformat/image/chunkah-package.sh:1-40`
+- Test: `test/bootc-secure-package-cleanup-test.sh`
+
+**Interfaces:**
+- Produces: `chunk_image IMAGE_REF SOURCE_DATE_EPOCH [MAX_LAYERS]`, which replaces the named local image with chunkah's loaded output and returns nonzero on malformed load output.
+- Preserves: direct CLI `chunkah-package.sh IMAGE_REF SOURCE_DATE_EPOCH` with `MAX_LAYERS` read from the environment and defaulting to 128.
+
+- [ ] **Step 1: Add failing fixture assertions for the reusable chunker**
+
+Extend the package fixture's fake Podman to distinguish `inspect`, the pinned chunkah `run`, `load`, and bootc digest probes. Record chunk arguments in `$BUILD_FIXTURE_STATE/chunk-args`, and assert:
+
+```bash
+grep -Fxq -- '--prune' "$state/chunk-args" || fail "chunkah lost --prune"
+grep -Fxq -- '/sysroot/' "$state/chunk-args" || fail "chunkah lost /sysroot/"
+grep -Fxq -- '--max-layers' "$state/chunk-args" || fail "chunkah lost --max-layers"
+grep -Fxq -- '128' "$state/chunk-args" || fail "chunkah lost the default layer limit"
+[[ $(<"$state/chunk-source-epoch") == 1722384000 ]] || fail "chunkah received the wrong source epoch"
+```
+
+Invoke every secure fixture with `SOURCE_DATE_EPOCH=1722384000`. Add a missing-epoch case that expects `SOURCE_DATE_EPOCH is required for secure chunking` and proves chunkah, assembler, and final commit were not reached.
+
+- [ ] **Step 2: Run the fixture and verify the new expectations fail**
+
+Run:
+
+```bash
+./test/bootc-secure-package-cleanup-test.sh
+```
+
+Expected: nonzero, with at least one failure showing that secure packaging never invoked chunkah or accepted the source epoch.
+
+- [ ] **Step 3: Refactor the chunker without changing its CLI**
+
+Replace top-level execution in `chunkah-package.sh` with:
+
+```bash
+CHUNKAH_IMAGE='quay.io/coreos/chunkah@sha256:fdff3175bfb41e111089392ef8a41b46a10766c7b2ec454ba1272a0c39ce3bf3'
+
+chunk_image() { # image-ref source-date-epoch [max-layers]
+    local image_ref=$1 source_date_epoch=$2 max_layers=${3:-128}
+    local config loaded new_ref
+    [[ $source_date_epoch =~ ^[0-9]+$ ]] || {
+        echo "Error: SOURCE_DATE_EPOCH must be a non-negative integer" >&2
+        return 1
+    }
+    [[ $max_layers =~ ^[1-9][0-9]*$ ]] || {
+        echo "Error: MAX_LAYERS must be a positive integer" >&2
+        return 1
+    }
+
+    config=$(podman inspect "$image_ref")
+    loaded=$(podman run --rm \
+        --security-opt label=type:unconfined_t \
+        --mount=type=image,src="$image_ref",dst=/chunkah \
+        -e "CHUNKAH_CONFIG_STR=$config" \
+        -e "SOURCE_DATE_EPOCH=$source_date_epoch" \
+        "$CHUNKAH_IMAGE" \
+        build --prune /sysroot/ --max-layers "$max_layers" \
+        --label ostree.commit- --label ostree.final-diffid- | podman load)
+    printf '%s\n' "$loaded"
+    new_ref=$(grep -oP '(?<=Loaded image: ).*' <<<"$loaded" ||
+        grep -oP '(?<=Loaded image\(s\): ).*' <<<"$loaded" || true)
+    [[ -n $new_ref ]] || {
+        echo "ERROR: could not parse loaded image ref from podman output above" >&2
+        return 1
+    }
+    [[ $new_ref == "$image_ref" ]] || podman tag "$new_ref" "$image_ref"
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    [[ $# -eq 2 ]] || {
+        echo "Usage: $0 IMAGE_REF SOURCE_DATE_EPOCH" >&2
+        exit 1
+    }
+    chunk_image "$1" "$2" "${MAX_LAYERS:-128}"
+fi
+```
+
+- [ ] **Step 4: Verify direct and sourced behavior**
+
+Run:
+
+```bash
+bash -n shared/outformat/image/chunkah-package.sh
+shellcheck shared/outformat/image/chunkah-package.sh
+./test/bootc-secure-package-cleanup-test.sh
+```
+
+Expected: syntax and ShellCheck pass before continuing to Part B; the package
+fixture remains red until Part B completes the same atomic task.
+
+---
+
+#### Part B: Chunk Before Digest Sealing
+
+**Files:**
+- Modify: `shared/outformat/image/buildah-package.sh:68-177`
+- Test: `test/bootc-secure-package-cleanup-test.sh`
+
+**Interfaces:**
+- Consumes: `chunk_image IMAGE_REF SOURCE_DATE_EPOCH [MAX_LAYERS]` from Part A.
+- Produces: a secure `$IMAGE_REF` derived from the chunked first candidate, with one final `/boot` filesystem overlay and trusted secure labels.
+
+- [ ] **Step 1: Add failing ordering and digest-equality fixtures**
+
+Update the fake Buildah implementation to log every invocation and make `from IMAGE` distinguish scratch packaging from final derivation. Add assertions equivalent to:
+
+```bash
+first=$(<"$state/chunk-image")
+grep -Fxq "from $first" "$state/buildah-commands" ||
+    fail "final image was not derived from the chunked candidate"
+grep -Fxq -- "-a $root/boot/. " "$state/cp-final-prefix" ||
+    fail "final image did not copy only the rootfs boot tree"
+[[ $(<"$state/digest-probe-count") == 2 ]] ||
+    fail "secure packaging did not perform exactly two digest probes"
+[[ $(<"$state/first-digest-image") == "$first" ]] ||
+    fail "chunked candidate was not digest authority"
+[[ $(<"$state/final-digest-image") == "$published" ]] ||
+    fail "published image was not the final digest authority"
+```
+
+Change the mismatch fixture so the second digest probe returns a different 128-hex digest. Keep the success rerun to prove cleanup does not wedge another secure package.
+
+- [ ] **Step 2: Run the focused fixture and verify it fails**
+
+Run:
+
+```bash
+./test/bootc-secure-package-cleanup-test.sh
+```
+
+Expected: nonzero because the current packager computes its first digest before chunking and builds the final image from scratch.
+
+- [ ] **Step 3: Implement chunk-before-seal secure packaging**
+
+In secure mode, source the helper and require the epoch before mutating the rootfs:
+
+```bash
+CHUNKER="$(dirname "${BASH_SOURCE[0]}")/chunkah-package.sh"
+[[ -r $CHUNKER ]] || { echo "Error: chunkah packager is unavailable" >&2; exit 1; }
+# shellcheck source=shared/outformat/image/chunkah-package.sh
+source "$CHUNKER"
+: "${SOURCE_DATE_EPOCH:?SOURCE_DATE_EPOCH is required for secure chunking}"
+```
+
+After preparing the immutable systemd-boot source, recursively package the pristine candidate with caller labels, then chunk it before the first digest probe:
+
+```bash
+first_image="localhost/snosi-bootc-secure-first-$$"
+SNOSI_BOOTC_SECURE=0 "$0" "$ROOTFS_DIR" "$first_image" "$@"
+chunk_image "$first_image" "$SOURCE_DATE_EPOCH" "${MAX_LAYERS:-128}"
+digest=$(podman run --rm --privileged --pid=host \
+    -v /var/lib/containers:/var/lib/containers \
+    --security-opt label=type:unconfined_t "$first_image" \
+    bootc container compute-composefs-digest-from-storage "$first_image" | tr -d '\n')
+```
+
+After assembly, replace the scratch second/final packaging passes with a container derived from the chunked candidate:
+
+```bash
+container=$(buildah from "$first_image")
+mountpoint=$(buildah mount "$container")
+mkdir -p "$mountpoint/boot"
+cp -a "$ROOTFS_DIR/boot/". "$mountpoint/boot/"
+buildah umount "$container"
+buildah config --label "io.snosi.bootc.secureboot-capable=true" "$container"
+buildah config --label \
+    "io.snosi.bootc.secureboot-assembly=bootc-1.16.3-storage-digest-v1" "$container"
+buildah commit "$container" "$IMAGE_REF"
+buildah rm "$container"
+final_image_committed=1
+```
+
+Probe `$IMAGE_REF` exactly once, reject inequality with `Error: /boot overlay changed OCI composefs digest`, scan the final image, set `secure_complete=1`, print completion, and exit before the non-secure scratch packager. Remove `final_probe` and its cleanup branch.
+
+- [ ] **Step 4: Verify digest equality and cleanup behavior**
+
+Run:
+
+```bash
+./test/bootc-secure-package-cleanup-test.sh
+./test/bootc-secure-artifact-test.sh --fixtures
+./test/bootc-secure-artifact-negative-test.sh --fixtures
+```
+
+Expected: all three pass. The cleanup fixture proves equal digests succeed and a changed final digest removes the incomplete final image and injected boot artifacts.
+
+---
+
+### Task 2: Protected Workflow Ordering Guard
+
+**Files:**
+- Modify: `.github/workflows/build-images.yml:160-212`
+- Modify: `check-bootc-publication-guard.sh:105-137`
+- Modify: `test/bootc-publication-guard-test.sh:75-244`
+
+**Interfaces:**
+- Consumes: secure packager requirement `SOURCE_DATE_EPOCH=<commit epoch>`.
+- Produces: a protected build with no post-package chunk step and a static guard rejecting either missing epoch forwarding or reintroduced post-assembly chunking.
+
+- [ ] **Step 1: Add failing publication-guard mutations**
+
+Add `SOURCE_DATE_EPOCH` and `MAX_LAYERS` to the fixture package environment and sudo forwarding. Keep a fixture `Chunk image` step initially, then add mutations/assertions:
+
+```bash
+remove_source_epoch_forwarding() {
+    perl -0pi -e 's/^            SOURCE_DATE_EPOCH="\$SOURCE_DATE_EPOCH" \\\n//m' \
+        "$1/.github/workflows/build-images.yml"
+}
+add_post_package_chunk() {
+    perl -0pi -e 's/(      - name: Validate locally assembled secure artifact)/      - name: Chunk image\n        run: .\/shared\/outformat\/image\/chunkah-package.sh image epoch\n$1/' \
+        "$1/.github/workflows/build-images.yml"
+}
+
+assert_guard 'missing sudo SOURCE_DATE_EPOCH forwarding fails' 1 remove_source_epoch_forwarding
+assert_guard 'post-package secure chunking fails' 1 add_post_package_chunk
+```
+
+- [ ] **Step 2: Run the guard fixture and verify the new mutations fail to be detected**
+
+Run:
+
+```bash
+./test/bootc-publication-guard-test.sh
+```
+
+Expected: nonzero because the guard does not yet require source-epoch forwarding or prohibit a secure-build `Chunk image` step.
+
+- [ ] **Step 3: Move epoch derivation into protected packaging**
+
+In `Package image`, set:
+
+```yaml
+          MAX_LAYERS: 128
+```
+
+Then derive and forward the epoch in the run block:
+
+```bash
+SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+sudo TMPDIR="$TMPDIR" \
+  SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
+  MAX_LAYERS="$MAX_LAYERS" \
+```
+
+Delete the protected secure-build `Chunk image` step entirely. Do not alter mechanics-build chunking.
+
+- [ ] **Step 4: Enforce the workflow invariant statically**
+
+Extend `check-bootc-publication-guard.sh` to require the exact epoch derivation and sudo forwarding in `package_step`, require `MAX_LAYERS`, and fail if `secure_job` contains `- name: Chunk image`.
+
+- [ ] **Step 5: Verify workflow and guard behavior**
+
+Run:
+
+```bash
+./check-bootc-publication-guard.sh
+./test/bootc-publication-guard-test.sh
+actionlint .github/workflows/build-images.yml
+```
+
+Expected: all pass, with the guard fixture count increased by two assertions.
+
+---
+
+### Task 3: Documentation and Full Verification
+
+**Files:**
+- Modify: `docs/bootc-secure-assembly-compatibility.md:7-50`
+- Modify: `yeti/build-pipeline.md:57-73,395-409`
+- Modify: `CLAUDE.md:68-110,1549`
+- Modify: `README.md:28-36`
+- Verify: `docs/superpowers/specs/2026-07-31-bootc-chunk-before-seal-design.md`
+
+**Interfaces:**
+- Documents: chunked candidate authority, final `/boot` overlay, exact two digest probes, and absence of post-assembly chunking.
+
+- [ ] **Step 1: Update maintained contracts**
+
+State consistently that protected secure packaging chunks the pristine candidate before calculating the storage digest; the final image inherits those layers and adds only `/boot`; the final candidate's bootc must return the same digest; and changing chunkah, Buildah derivation, or `/boot` exclusion requires full compatibility revalidation.
+
+- [ ] **Step 2: Run static and fixture verification**
+
+Run:
+
+```bash
+bash -n shared/outformat/image/buildah-package.sh shared/outformat/image/chunkah-package.sh \
+  test/bootc-secure-package-cleanup-test.sh check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh
+shellcheck shared/outformat/image/buildah-package.sh shared/outformat/image/chunkah-package.sh \
+  test/bootc-secure-package-cleanup-test.sh check-bootc-publication-guard.sh \
+  test/bootc-publication-guard-test.sh
+./test/bootc-secure-package-cleanup-test.sh
+./test/bootc-secure-artifact-test.sh --fixtures
+./test/bootc-secure-artifact-negative-test.sh --fixtures
+./check-bootc-publication-guard.sh
+./test/bootc-publication-guard-test.sh
+./test/bootc-secure-publication-test.sh
+./test/bootc-secure-promotion-test.sh
+actionlint .github/workflows/build-images.yml
+git diff --check
+```
+
+Expected: every command exits 0. Record fixture assertion totals in the final report.
+
+- [ ] **Step 3: Request adversarial review**
+
+Ask a reviewer to check specifically for digest authority before chunking, any filesystem mutation outside `/boot`, a second chunk pass, missing credential cleanup, labels surviving failed validation, or workflow paths that bypass source-epoch forwarding. Resolve all correctness findings and rerun Step 2.

--- a/docs/superpowers/specs/2026-07-31-bootc-chunk-before-seal-design.md
+++ b/docs/superpowers/specs/2026-07-31-bootc-chunk-before-seal-design.md
@@ -1,0 +1,111 @@
+# Bootc Chunk-Before-Seal Design
+
+## Problem
+
+The protected bootc build currently assembles and validates a UKI before CI
+runs `chunkah-package.sh`. The UKI binds its `composefs=` command-line argument
+to the storage digest of the pre-chunk OCI image. Chunkah then rewrites the OCI
+layer layout, changing the candidate's bootc storage digest. Local validation
+passes before chunking, but validation of the policy-copied registry artifact
+correctly rejects the published image because its UKI still names the old
+digest.
+
+Secure publication must retain the current chunkah optimization while ensuring
+that the final published image has the same storage digest sealed into its UKI.
+
+## Selected Flow
+
+Secure packaging owns chunking and performs these operations in order:
+
+1. Place the MOK-signed systemd-boot reconciliation source under
+   `/usr/lib/snosi/bootc/` before any candidate packaging.
+2. Package the pristine rootfs as a temporary non-capable OCI candidate with
+   the final caller-supplied image metadata.
+3. Run the existing pinned chunkah operation against that temporary candidate,
+   preserving `--prune /sysroot/`, the configured maximum layer count, and the
+   caller-supplied source epoch.
+4. Run the chunked candidate's pinned bootc 1.16.3 to obtain the authoritative
+   storage digest.
+5. Run the candidate's ukify to build a UKI whose command line is exactly
+   `rw composefs=?<digest>`, then add the UKI and signed ESP second stage to the
+   source rootfs below `/boot`.
+6. Create the final image by deriving it from the chunked candidate, copying
+   only the assembled `/boot` tree into a final overlay layer, and replacing
+   the non-capable label with the secure capability and assembly labels.
+7. Run the final image's bootc storage-digest command and require byte-for-byte
+   equality with the digest from step 4.
+8. Scan the final OCI image for protected credential bytes before allowing the
+   packager to succeed.
+
+The workflow no longer invokes chunkah after secure packaging. Non-secure and
+secretless mechanics packaging retain their existing flow unless they already
+delegate chunking separately.
+
+## Security Boundary
+
+The chunked candidate, not the unchunked rootfs package, is storage-digest
+authority. The final image inherits that candidate's optimized layers. Its only
+filesystem delta is the `/boot` overlay permitted by the maintained bootc
+compatibility contract; image configuration changes are limited to trusted
+secure labels.
+
+Private credentials remain caller-owned files. Chunkah receives no credential
+mounts or credential environment values. Candidate ukify retains its existing
+network, capability, ownership, read-only mount, redaction, byte-comparison,
+and scan restrictions.
+
+The packager must fail closed if:
+
+- the source epoch needed by chunkah is absent or invalid;
+- chunkah fails or does not produce the expected candidate reference;
+- either storage-digest probe is malformed;
+- final assembly changes any path outside `/boot`;
+- the final digest differs from the chunked candidate digest;
+- a private credential is found in the rootfs, image, logs, or retained state;
+- cleanup cannot remove an incomplete final image or injected `/boot` output.
+
+No image carrying `io.snosi.bootc.secureboot-capable=true` is retained or made
+available for publication unless the final digest comparison and credential
+scan pass.
+
+## Interfaces
+
+`buildah-package.sh` remains the protected build entry point. Secure mode
+requires `SOURCE_DATE_EPOCH` for its internal chunkah call and continues to
+honor `MAX_LAYERS`, defaulting to 128 as the standalone chunker does. The
+workflow derives `SOURCE_DATE_EPOCH` from the checked-out commit and passes it
+explicitly through the `sudo` boundary.
+
+The chunking implementation should expose a reusable operation rather than
+duplicating the pinned image reference and chunkah arguments. The standalone
+`chunkah-package.sh` interface remains available for non-secure callers.
+
+## Tests
+
+Fixture tests must prove:
+
+- chunking occurs after pristine packaging and before the authoritative digest;
+- the existing pinned chunkah image and arguments are retained;
+- the authoritative digest is read from the chunked candidate;
+- the final image derives from that chunked candidate rather than from scratch;
+- only `/boot` content is copied into the final filesystem layer;
+- secure labels are applied only to the final candidate;
+- equal pre-overlay and final digests succeed;
+- a changed final digest fails and removes the incomplete final image;
+- chunk failure, malformed digest output, and missing source epoch fail before
+  publication;
+- the protected workflow has no second post-assembly chunk step and explicitly
+  forwards the source epoch through sudo;
+- existing credential, UKI-section, local artifact, policy-copy, and
+  publication guards remain green.
+
+The real protected build remains the final evidence: local validation and the
+policy-copied registry validation must both accept the same chunked-and-sealed
+artifact before `latest` can move.
+
+## Documentation
+
+Update `CLAUDE.md`, `docs/bootc-secure-assembly-compatibility.md`,
+`yeti/build-pipeline.md`, and relevant CI documentation to state that secure
+chunking precedes digest sealing and that the final `/boot` overlay is the sole
+post-digest filesystem mutation.

--- a/shared/outformat/image/buildah-package.sh
+++ b/shared/outformat/image/buildah-package.sh
@@ -65,17 +65,20 @@ probe_rootfs_bootc_version() ( # rootfs
     }
 )
 
-secure_label="io.snosi.bootc.secureboot-capable=false"
-secure_assembly_label=""
+readonly SECURE_CAPABLE_LABEL="io.snosi.bootc.secureboot-capable=true"
+readonly SECURE_INCAPABLE_LABEL="io.snosi.bootc.secureboot-capable=false"
+readonly SECURE_ASSEMBLY_LABEL="io.snosi.bootc.secureboot-assembly=bootc-1.16.3-storage-digest-v1"
 first_image=""
-final_probe=""
+final_container=""
+final_mount=""
 final_image_committed=0
 secure_complete=0
 cleanup_secure() {
     local status=$?
     set +e
+    [[ -z "$final_mount" ]] || buildah umount "$final_container" >/dev/null 2>&1
+    [[ -z "$final_container" ]] || buildah rm "$final_container" >/dev/null 2>&1
     [[ -z "$first_image" ]] || buildah rmi "$first_image" >/dev/null 2>&1
-    [[ -z "$final_probe" ]] || buildah rmi "$final_probe" >/dev/null 2>&1
     [[ $secure_complete -eq 1 || $final_image_committed -eq 0 ]] || buildah rmi "$IMAGE_REF" >/dev/null 2>&1
     [[ $secure_complete -eq 1 ]] || "$ASSEMBLER" --remove-injected "$ROOTFS_DIR" >/dev/null 2>&1
     return "$status"
@@ -103,6 +106,11 @@ if [[ ${SNOSI_BOOTC_SECURE:-0} == 1 ]]; then
     [[ -x "$ASSEMBLER" ]] || {
         echo "Error: bootc secure assembler is unavailable" >&2; exit 1;
     }
+    CHUNKER="$(dirname "${BASH_SOURCE[0]}")/chunkah-package.sh"
+    [[ -r $CHUNKER ]] || { echo "Error: chunkah packager is unavailable" >&2; exit 1; }
+    # shellcheck source=shared/outformat/image/chunkah-package.sh
+    source "$CHUNKER"
+    : "${SOURCE_DATE_EPOCH:?SOURCE_DATE_EPOCH is required for secure chunking}"
     probe_rootfs_bootc_version "$ROOTFS_DIR"
     trap cleanup_secure EXIT
     # The reconciler's signed source must be in the pristine first OCI pass:
@@ -110,7 +118,11 @@ if [[ ${SNOSI_BOOTC_SECURE:-0} == 1 ]]; then
     "$ASSEMBLER" --prepare-systemd-boot-source "$ROOTFS_DIR" \
         "$SNOSI_BOOTC_MOK_KEY" "$SNOSI_BOOTC_MOK_CERT"
     first_image="localhost/snosi-bootc-secure-first-$$"
-    SNOSI_BOOTC_SECURE=0 "$0" "$ROOTFS_DIR" "$first_image" "io.snosi.bootc.secureboot-capable=false"
+    SNOSI_BOOTC_SECURE=0 "$0" "$ROOTFS_DIR" "$first_image" "$@"
+    chunk_image "$first_image" "$SOURCE_DATE_EPOCH" "${MAX_LAYERS:-128}" || {
+        echo "Error: secure chunkah packaging failed" >&2
+        exit 1
+    }
     digest=$(podman run --rm --privileged --pid=host -v /var/lib/containers:/var/lib/containers \
         --security-opt label=type:unconfined_t "$first_image" \
         bootc container compute-composefs-digest-from-storage "$first_image" | tr -d '\n')
@@ -121,16 +133,28 @@ if [[ ${SNOSI_BOOTC_SECURE:-0} == 1 ]]; then
         "$ASSEMBLER" "$ROOTFS_DIR" \
         "$SNOSI_BOOTC_MOK_KEY" "$SNOSI_BOOTC_MOK_CERT" "$SNOSI_BOOTC_PCR_KEY" "$SNOSI_BOOTC_PCR_CERT" \
         "${SNOSI_BOOTC_PREVIOUS_PCR_CERT:-}"
-    final_probe="localhost/snosi-bootc-secure-final-$$"
-    SNOSI_BOOTC_SECURE=0 "$0" "$ROOTFS_DIR" "$final_probe" "io.snosi.bootc.secureboot-capable=false"
-    final_digest=$(podman run --rm --privileged --pid=host -v /var/lib/containers:/var/lib/containers \
-        --security-opt label=type:unconfined_t "$final_probe" \
-        bootc container compute-composefs-digest-from-storage "$final_probe" | tr -d '\n')
-    [[ "$digest" == "$final_digest" ]] || { echo "Error: secure injection changed OCI composefs digest" >&2; exit 1; }
-    "$ASSEMBLER" --scan-image "$final_probe" "$SNOSI_BOOTC_MOK_KEY" "$SNOSI_BOOTC_PCR_KEY" \
+    final_container=$(buildah from "$first_image")
+    final_mount=$(buildah mount "$final_container")
+    mkdir -p "$final_mount/boot"
+    cp -a "$ROOTFS_DIR/boot/." "$final_mount/boot/"
+    buildah umount "$final_container"
+    final_mount=""
+    buildah config --label "$SECURE_CAPABLE_LABEL" "$final_container"
+    buildah config --label "$SECURE_ASSEMBLY_LABEL" "$final_container"
+    buildah commit "$final_container" "$IMAGE_REF"
+    buildah rm "$final_container"
+    final_container=""
+    final_image_committed=1
+    published_digest=$(podman run --rm --privileged --pid=host -v /var/lib/containers:/var/lib/containers \
+        --security-opt label=type:unconfined_t "$IMAGE_REF" \
+        bootc container compute-composefs-digest-from-storage "$IMAGE_REF" | tr -d '\n')
+    [[ $published_digest =~ ^[[:xdigit:]]{128}$ ]] || { echo "Error: unsupported bootc storage-digest interface" >&2; exit 1; }
+    [[ "$digest" == "$published_digest" ]] || { echo "Error: /boot overlay changed OCI composefs digest" >&2; exit 1; }
+    "$ASSEMBLER" --scan-image "$IMAGE_REF" "$SNOSI_BOOTC_MOK_KEY" "$SNOSI_BOOTC_PCR_KEY" \
         "${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-}"
-    secure_label="io.snosi.bootc.secureboot-capable=true"
-    secure_assembly_label="io.snosi.bootc.secureboot-assembly=bootc-1.16.3-storage-digest-v1"
+    secure_complete=1
+    echo "=== Image packaged: $IMAGE_REF ==="
+    exit 0
 fi
 
 echo "=== Packaging rootfs into OCI image ==="
@@ -157,21 +181,12 @@ for label in "$@"; do
 done
 
 # Trusted labels are applied last so caller labels cannot downgrade or forge them.
-buildah config --label "$secure_label" "$container"
-[[ -z "$secure_assembly_label" ]] || buildah config --label "$secure_assembly_label" "$container"
+buildah config --label "$SECURE_INCAPABLE_LABEL" "$container"
 
 # Commit to image
 buildah commit "$container" "$IMAGE_REF"
 buildah rm "$container"
 final_image_committed=1
-if [[ ${SNOSI_BOOTC_SECURE:-0} == 1 ]]; then
-    published_digest=$(podman run --rm --privileged --pid=host -v /var/lib/containers:/var/lib/containers \
-        --security-opt label=type:unconfined_t "$IMAGE_REF" \
-        bootc container compute-composefs-digest-from-storage "$IMAGE_REF" | tr -d '\n')
-    [[ "$digest" == "$published_digest" ]] || { echo "Error: committed secure OCI image changed composefs digest" >&2; exit 1; }
-    "$ASSEMBLER" --scan-image "$IMAGE_REF" "$SNOSI_BOOTC_MOK_KEY" "$SNOSI_BOOTC_PCR_KEY" \
-        "${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-}"
-fi
 secure_complete=1
 
 echo "=== Image packaged: $IMAGE_REF ==="

--- a/shared/outformat/image/chunkah-package.sh
+++ b/shared/outformat/image/chunkah-package.sh
@@ -1,40 +1,46 @@
 #!/bin/bash
 set -euo pipefail
 
-IMAGE_REF="$1"
-SOURCE_DATE_EPOCH="$2"
-MAX_LAYERS="${MAX_LAYERS:-128}"
+CHUNKAH_IMAGE='quay.io/coreos/chunkah@sha256:fdff3175bfb41e111089392ef8a41b46a10766c7b2ec454ba1272a0c39ce3bf3'
 
-echo "==> Chunkifying $IMAGE_REF (Max Layers: $MAX_LAYERS) - Date: $SOURCE_DATE_EPOCH"
+chunk_image() { # image-ref source-date-epoch [max-layers]
+    local image_ref=$1 source_date_epoch=$2 max_layers=${3:-128}
+    local config loaded new_ref
+    [[ $source_date_epoch =~ ^[0-9]+$ ]] || {
+        echo "Error: SOURCE_DATE_EPOCH must be a non-negative integer" >&2
+        return 1
+    }
+    [[ $max_layers =~ ^[1-9][0-9]*$ ]] || {
+        echo "Error: MAX_LAYERS must be a positive integer" >&2
+        return 1
+    }
 
-# Get config from existing image
-CONFIG=$(podman inspect "$IMAGE_REF")
+    config=$(podman inspect "$image_ref")
+    if ! loaded=$(podman run --rm \
+        --security-opt label=type:unconfined_t \
+        --mount=type=image,src="$image_ref",dst=/chunkah \
+        -e "CHUNKAH_CONFIG_STR=$config" \
+        -e "SOURCE_DATE_EPOCH=$source_date_epoch" \
+        "$CHUNKAH_IMAGE" \
+        build --prune /sysroot/ --max-layers "$max_layers" \
+        --label ostree.commit- --label ostree.final-diffid- | podman load); then
+        echo "ERROR: chunkah or podman load failed" >&2
+        return 1
+    fi
+    printf '%s\n' "$loaded"
+    new_ref=$(grep -oP '(?<=Loaded image: ).*' <<<"$loaded" ||
+        grep -oP '(?<=Loaded image\(s\): ).*' <<<"$loaded" || true)
+    [[ -n $new_ref ]] || {
+        echo "ERROR: could not parse loaded image ref from podman output above" >&2
+        return 1
+    }
+    [[ $new_ref == "$image_ref" ]] || podman tag "$new_ref" "$image_ref"
+}
 
-# Run chunkah (default 64 layers) and pipe to podman load
-# Uses --mount=type=image to expose the source image content to chunkah
-# Note: We need --privileged for some podman-in-podman/mount scenarios or just standard access
-LOADED=$(podman run --rm \
-    --security-opt label=type:unconfined_t \
-    --mount=type=image,src="$IMAGE_REF",dst=/chunkah \
-    -e "CHUNKAH_CONFIG_STR=$CONFIG" \
-    -e "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" \
-    quay.io/coreos/chunkah@sha256:fdff3175bfb41e111089392ef8a41b46a10766c7b2ec454ba1272a0c39ce3bf3 \
-    build --prune /sysroot/ --max-layers "$MAX_LAYERS" \
-    --label ostree.commit- --label ostree.final-diffid- | podman load)
-
-echo "$LOADED"
-
-# Parse the loaded image reference. The image is already loaded at this
-# point, so a wording change in podman's output must not abort the script —
-# fail loudly instead so the message format can be fixed.
-NEW_REF=$(echo "$LOADED" | grep -oP '(?<=Loaded image: ).*' || \
-          echo "$LOADED" | grep -oP '(?<=Loaded image\(s\): ).*' || true)
-if [ -z "$NEW_REF" ]; then
-    echo "ERROR: could not parse loaded image ref from podman output above" >&2
-    exit 1
-fi
-
-if [ "$NEW_REF" != "$IMAGE_REF" ]; then
-    echo "==> Retagging chunked image to $IMAGE_REF..."
-    podman tag "$NEW_REF" "$IMAGE_REF"
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    [[ $# -eq 2 ]] || {
+        echo "Usage: $0 IMAGE_REF SOURCE_DATE_EPOCH" >&2
+        exit 1
+    }
+    chunk_image "$1" "$2" "${MAX_LAYERS:-128}"
 fi

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -88,13 +88,17 @@ jobs:
           NATIVE_PCR_SIGNING_CERTIFICATE: ${{ secrets.NATIVE_PCR_SIGNING_CERTIFICATE }}
       - name: Package image
         env:
+          MAX_LAYERS: 128
           SNOSI_BOOTC_SECURE: "1"
           SNOSI_BOOTC_MOK_KEY: /var/tmp/bootc-secure-credentials/mok.key
           SNOSI_BOOTC_MOK_CERT: /var/tmp/bootc-secure-credentials/mok.crt
           SNOSI_BOOTC_PCR_KEY: /var/tmp/bootc-secure-credentials/pcr.key
           SNOSI_BOOTC_PCR_CERT: /var/tmp/bootc-secure-credentials/pcr.pub
         run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
           sudo TMPDIR="$TMPDIR" \
+            SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
+            MAX_LAYERS="$MAX_LAYERS" \
             SNOSI_BOOTC_SECURE="$SNOSI_BOOTC_SECURE" \
             SNOSI_BOOTC_MOK_KEY="$SNOSI_BOOTC_MOK_KEY" \
             SNOSI_BOOTC_MOK_CERT="$SNOSI_BOOTC_MOK_CERT" \
@@ -162,6 +166,23 @@ remove_forwarded_package_variable() {
         "$2/.github/workflows/build-images.yml"
 }
 remove_sudo_tmpdir() { perl -0pi -e 's/^          sudo TMPDIR="\$TMPDIR" \\\n//m' "$1/.github/workflows/build-images.yml"; }
+remove_source_epoch_forwarding() {
+    perl -0pi -e 's/^            SOURCE_DATE_EPOCH="\$SOURCE_DATE_EPOCH" \\\n//m' \
+        "$1/.github/workflows/build-images.yml"
+}
+remove_max_layers_environment() { perl -0pi -e 's/^\s+MAX_LAYERS: 128\n//m' "$1/.github/workflows/build-images.yml"; }
+remove_source_epoch_derivation() { perl -0pi -e 's/^\s+SOURCE_DATE_EPOCH=\$\(git log -1 --format=%ct\)\n//m' "$1/.github/workflows/build-images.yml"; }
+remove_max_layers_forwarding() {
+    perl -0pi -e 's/^            MAX_LAYERS="\$MAX_LAYERS" \\\n//m' "$1/.github/workflows/build-images.yml"
+}
+add_post_package_chunk() {
+    perl -0pi -e 's/(      - name: Validate locally assembled secure artifact)/      - name: Chunk image\n        run: .\/shared\/outformat\/image\/chunkah-package.sh image epoch\n$1/' \
+        "$1/.github/workflows/build-images.yml"
+}
+add_direct_secure_chunk() {
+    perl -0pi -e 's/(      - name: Validate locally assembled secure artifact)/      - name: Arbitrary name\n        run: .\/shared\/outformat\/image\/chunkah-package.sh image epoch\n$1/' \
+        "$1/.github/workflows/build-images.yml"
+}
 remove_cleanup_condition() { perl -0pi -e 's/        if: always\(\)\n//' "$1/.github/workflows/build-images.yml"; }
 break_label_check() { perl -0pi -e 's/== "true"/== "false"/' "$1/shared/bootc-secure/ci/verify-published-image.sh"; }
 remove_label_check() { perl -0pi -e 's/    \.Labels\["io\.snosi\.bootc\.secureboot-capable"\].*\n//' "$1/shared/bootc-secure/ci/verify-published-image.sh"; }
@@ -224,6 +245,12 @@ for variable in SNOSI_BOOTC_SECURE SNOSI_BOOTC_MOK_KEY SNOSI_BOOTC_MOK_CERT SNOS
         remove_forwarded_package_variable "$variable"
 done
 assert_guard 'missing sudo TMPDIR forwarding fails' 1 remove_sudo_tmpdir
+assert_guard 'missing sudo SOURCE_DATE_EPOCH forwarding fails' 1 remove_source_epoch_forwarding
+assert_guard 'missing MAX_LAYERS environment fails' 1 remove_max_layers_environment
+assert_guard 'missing SOURCE_DATE_EPOCH derivation fails' 1 remove_source_epoch_derivation
+assert_guard 'missing sudo MAX_LAYERS forwarding fails' 1 remove_max_layers_forwarding
+assert_guard 'post-package secure chunking fails' 1 add_post_package_chunk
+assert_guard 'direct secure chunking under any step name fails' 1 add_direct_secure_chunk
 assert_guard 'missing unconditional cleanup fails' 1 remove_cleanup_condition
 assert_guard 'false secure label check fails' 1 break_label_check
 assert_guard 'missing secure label check fails' 1 remove_label_check

--- a/test/bootc-secure-package-cleanup-test.sh
+++ b/test/bootc-secure-package-cleanup-test.sh
@@ -18,7 +18,7 @@ image_path() {
 
 write_fixtures() { # state root
     local state=$1 root=$2
-    mkdir -p "$state/bin" "$state/images" "$root/proc" "$root/usr/bin" "$root/usr/lib/modules/test-kernel" \
+    mkdir -p "$state/bin" "$state/images" "$state/containers" "$state/mounts" "$root/proc" "$root/usr/bin" "$root/usr/lib/modules/test-kernel" \
         "$root/boot/EFI/Linux" "$root/boot/EFI/BOOT"
     : >"$root/usr/lib/modules/test-kernel/vmlinuz"
     : >"$root/usr/lib/modules/test-kernel/initramfs.img"
@@ -61,33 +61,121 @@ EOF
 #!/bin/bash
 set -euo pipefail
 touch "$BUILD_FIXTURE_STATE/buildah-invoked"
+printf '%s\n' "$*" >>"$BUILD_FIXTURE_STATE/buildah-commands"
 hash() { printf '%s' "$1" | sha256sum | cut -d' ' -f1; }
 case $1 in
-    from) printf 'container-%s\n' "${RANDOM}" ;;
-    mount) mount="$BUILD_FIXTURE_STATE/mount-$2"; mkdir -p "$mount"; printf '%s\n' "$mount" ;;
-    umount|config|rm) : ;;
-    commit) touch "$BUILD_FIXTURE_STATE/images/$(hash "$3")" ;;
-    rmi) rm -f "$BUILD_FIXTURE_STATE/images/$(hash "$2")" ;;
+    from)
+        count=0
+        [[ ! -f "$BUILD_FIXTURE_STATE/container-count" ]] || count=$(<"$BUILD_FIXTURE_STATE/container-count")
+        count=$((count + 1))
+        printf '%s' "$count" >"$BUILD_FIXTURE_STATE/container-count"
+        container="container-$count"
+        mkdir -p "$BUILD_FIXTURE_STATE/containers/$container/fs"
+        printf '%s\n' "$2" >"$BUILD_FIXTURE_STATE/$container-source"
+        image="$BUILD_FIXTURE_STATE/images/$(hash "$2").fs"
+        [[ ! -d $image ]] || /bin/cp -a "$image/." "$BUILD_FIXTURE_STATE/containers/$container/fs/"
+        printf '%s\n' "$container"
+        ;;
+    mount)
+        mount="$BUILD_FIXTURE_STATE/mounts/$2"
+        ln -s "../containers/$2/fs" "$mount"
+        printf '%s\n' "$mount"
+        ;;
+    umount) rm -f -- "$BUILD_FIXTURE_STATE/mounts/$2" ;;
+    config)
+        container=${!#}
+        for ((i = 2; i < $#; i++)); do
+            [[ ${!i} != --label ]] || {
+                i=$((i + 1))
+                printf '%s\n' "${!i}" >>"$BUILD_FIXTURE_STATE/$container-labels"
+            }
+        done
+        ;;
+    rm) rm -rf -- "$BUILD_FIXTURE_STATE/containers/$2" ;;
+    commit)
+        if [[ ${BUILD_FIXTURE_FINAL_NONBOOT_MUTATION:-0} == 1 && $3 == "$BUILD_FIXTURE_PUBLISHED" ]]; then
+            printf 'forbidden non-boot mutation\n' >"$BUILD_FIXTURE_STATE/containers/$2/fs/usr/nonboot-mutation"
+        fi
+        /bin/cp -a "$BUILD_FIXTURE_STATE/containers/$2/fs" "$BUILD_FIXTURE_STATE/images/$(hash "$3").fs"
+        touch "$BUILD_FIXTURE_STATE/images/$(hash "$3")"
+        ;;
+    rmi) rm -rf -- "$BUILD_FIXTURE_STATE/images/$(hash "$2")" "$BUILD_FIXTURE_STATE/images/$(hash "$2").fs" ;;
     *) echo "unexpected buildah invocation: $*" >&2; exit 99 ;;
 esac
+EOF
+    cat >"$state/bin/cp" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [[ ${2:-} == "$BUILD_FIXTURE_ROOT/boot/." ]]; then
+    printf '%s\n' "$1" >"$BUILD_FIXTURE_STATE/cp-final-option"
+    printf '%s\n' "$2" >"$BUILD_FIXTURE_STATE/cp-final-source"
+    printf '%s\n' "${!#}" >"$BUILD_FIXTURE_STATE/cp-final-destination"
+    [[ ${BUILD_FIXTURE_FINAL_CP_FAIL:-0} != 1 ]] || exit 89
+fi
+/bin/cp "$@"
 EOF
     cat >"$state/bin/podman" <<'EOF'
 #!/bin/bash
 set -euo pipefail
-count_file="$BUILD_FIXTURE_STATE/podman-count"
-count=0
-[[ ! -f "$count_file" ]] || count=$(<"$count_file")
-count=$((count + 1))
-printf '%s' "$count" >"$count_file"
-printf '%s\n' "$@" >"$BUILD_FIXTURE_STATE/podman-$count-args"
-if [[ ${BUILD_FIXTURE_FINAL_PROBE_FAIL:-0} == 1 && $count -eq 2 ]]; then
-    exit 86
-fi
-if [[ ${BUILD_FIXTURE_PUBLISHED_DIGEST_MISMATCH:-0} == 1 && $count -eq 3 ]]; then
-    printf '%0128d\n' 1
-    exit 0
-fi
-printf '%0128d\n' 0
+case $1 in
+    inspect)
+        printf '{}\n'
+        ;;
+    load)
+        cat >/dev/null
+        if [[ ${BUILD_FIXTURE_CHUNK_UNPARSEABLE_LOAD:-0} == 1 ]]; then
+            printf 'unparseable fixture output\n'
+        else
+            printf 'Loaded image: %s\n' "$(<"$BUILD_FIXTURE_STATE/chunk-image")"
+        fi
+        ;;
+    tag)
+        :
+        ;;
+    run)
+        if [[ " $* " == *' quay.io/coreos/chunkah@sha256:fdff3175bfb41e111089392ef8a41b46a10766c7b2ec454ba1272a0c39ce3bf3 '* ]]; then
+            printf '%s\n' "$@" >"$BUILD_FIXTURE_STATE/chunk-args"
+            for ((i = 1; i <= $#; i++)); do
+                if [[ ${!i} == SOURCE_DATE_EPOCH=* ]]; then
+                    printf '%s\n' "${!i#SOURCE_DATE_EPOCH=}" >"$BUILD_FIXTURE_STATE/chunk-source-epoch"
+                elif [[ ${!i} == --mount=type=image,* ]]; then
+                    image=${!i#*src=}
+                    printf '%s\n' "${image%%,*}" >"$BUILD_FIXTURE_STATE/chunk-image"
+                fi
+            done
+            [[ ${BUILD_FIXTURE_CHUNK_FAIL:-0} != 1 ]] || exit 88
+            exit 0
+        fi
+        previous=""
+        image=""
+        for argument in "$@"; do
+            [[ $argument != bootc ]] || { image=$previous; break; }
+            previous=$argument
+        done
+        count=0
+        [[ ! -f "$BUILD_FIXTURE_STATE/digest-probe-count" ]] || count=$(<"$BUILD_FIXTURE_STATE/digest-probe-count")
+        count=$((count + 1))
+        printf '%s' "$count" >"$BUILD_FIXTURE_STATE/digest-probe-count"
+        if [[ $count -eq 1 ]]; then
+            printf '%s\n' "$image" >"$BUILD_FIXTURE_STATE/first-digest-image"
+        else
+            printf '%s\n' "$image" >"$BUILD_FIXTURE_STATE/final-digest-image"
+        fi
+        snapshot="$BUILD_FIXTURE_STATE/images/$(printf '%s' "$image" | sha256sum | cut -d' ' -f1).fs"
+        if [[ ${BUILD_FIXTURE_MALFORMED_FIRST_DIGEST:-0} == 1 && $count -eq 1 ]] ||
+                [[ ${BUILD_FIXTURE_MALFORMED_FINAL_DIGEST:-0} == 1 && $count -eq 2 ]]; then
+            printf 'not-a-storage-digest\n'
+        elif [[ ${BUILD_FIXTURE_PUBLISHED_DIGEST_MISMATCH:-0} == 1 && $count -eq 2 ]]; then
+            printf '%0128d\n' 1
+        else
+            tar -C "$snapshot" --exclude=./boot --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner -cf - . | sha512sum | cut -d' ' -f1
+        fi
+        ;;
+    *)
+        echo "unexpected podman invocation: $*" >&2
+        exit 99
+        ;;
+esac
 EOF
     cat >"$state/assembler" <<'EOF'
 #!/bin/bash
@@ -98,6 +186,7 @@ if [[ $1 == --remove-injected ]]; then
     exit 0
 fi
 if [[ $1 == --scan-image ]]; then
+    touch "$BUILD_FIXTURE_STATE/scan-invoked"
     exit 0
 fi
 if [[ $1 == --prepare-systemd-boot-source ]]; then
@@ -113,30 +202,29 @@ printf 'injected-bootloader\n' >"$1/boot/EFI/BOOT/grubx64.efi"
 [[ ${BUILD_FIXTURE_ASSEMBLER_FAIL:-0} != 1 ]]
 EOF
     chmod +x "$state/bin/mountpoint" "$state/bin/mount" "$state/bin/chroot" \
-        "$state/bin/umount" "$state/bin/buildah" "$state/bin/podman" "$state/assembler"
+        "$state/bin/umount" "$state/bin/buildah" "$state/bin/cp" "$state/bin/podman" "$state/assembler"
 }
 
 assert_cleanup() { # state root published
-    local state=$1 root=$2 published=$3 ukify_image first final
+    local state=$1 root=$2 published=$3 ukify_image first
     [[ -f "$state/assembler-invoked" ]] || fail "controlled assembler was not invoked"
     [[ -f "$state/ukify-image" ]] || fail "assembler did not receive a ukify image"
-    ukify_image=$(<"$state/ukify-image")
+    ukify_image=""
+    [[ ! -f "$state/ukify-image" ]] || ukify_image=$(<"$state/ukify-image")
     [[ $ukify_image == localhost/snosi-bootc-secure-first-[0-9]* ]] ||
         fail "assembler did not receive the exact first-pass ukify image"
-    first=$(grep -m1 -E '^localhost/snosi-bootc-secure-first-[0-9]+$' "$state/podman-1-args" || true)
-    final=""
-    [[ ! -f "$state/podman-2-args" ]] || final=$(grep -m1 -E '^localhost/snosi-bootc-secure-final-[0-9]+$' "$state/podman-2-args" || true)
-    [[ -n $first ]] || fail "first probe image was not captured from Podman"
-    [[ ! -f "$state/podman-2-args" || -n $final ]] || fail "final probe image was not captured from Podman"
-    { [[ -f "$state/podman-1-args" ]] && grep -Fxq -- "$ukify_image" "$state/podman-1-args"; } ||
-        fail "assembler ukify image differs from the first digest candidate"
+    first=""
+    [[ ! -f "$state/chunk-image" ]] || first=$(<"$state/chunk-image")
+    [[ $first == localhost/snosi-bootc-secure-first-[0-9]* ]] || fail "chunker did not receive the first candidate"
+    [[ $ukify_image == "$first" ]] || fail "assembler ukify image differs from the chunked digest candidate"
     [[ -f "$state/mount-invoked" && $(<"$state/mount-invoked") == "--bind /proc $root/proc" ]] || fail "rootfs proc bind was not exact"
     [[ -f "$state/chroot-invoked" && $(<"$state/chroot-invoked") == "$root /usr/bin/bootc --version" ]] || fail "bootc version did not use rootfs chroot"
     [[ -f "$state/umount-invoked" && $(<"$state/umount-invoked") == "$root/proc" ]] || fail "rootfs proc unmount was not exact"
     [[ ! -e "$state/proc-mounted" ]] || fail "rootfs proc mount survived"
-    [[ ! -e "$state/images/$(image_path "$first")" ]] || fail "first probe image survived"
-    [[ -z $final || ! -e "$state/images/$(image_path "$final")" ]] || fail "final probe image survived"
+    [[ ! -e "$state/images/$(image_path "$first")" ]] || fail "first candidate image survived"
     [[ ! -e "$state/images/$(image_path "$published")" ]] || fail "published image survived"
+    [[ ! -d "$state/containers" || -z $(compgen -G "$state/containers/*") ]] || fail "Buildah working container survived"
+    [[ ! -d "$state/mounts" || -z $(compgen -G "$state/mounts/*") ]] || fail "Buildah working mount survived"
     [[ ! -e "$root/boot/EFI/Linux/test-kernel.efi" ]] || fail "Task 5 UKI residue survived"
     [[ ! -e "$root/boot/EFI/BOOT/grubx64.efi" ]] || fail "Task 5 bootloader residue survived"
     [[ ! -e "$root/usr/lib/snosi/bootc/systemd-bootx64.efi" ]] || fail "Task 7 immutable bootloader source residue survived"
@@ -144,7 +232,7 @@ assert_cleanup() { # state root published
     [[ $(<"$root/boot/EFI/BOOT/pre-existing.efi") == keep-boot ]] || fail "pre-existing boot file changed"
 }
 
-run_case() { # name assembler-fails|final-probe-fails|published-digest-mismatch
+run_case() { # name assembler-fails|final-cp-fails|published-digest-mismatch|nonboot-mutation
     local name=$1 work state root published status
     work=$(mktemp -d)
     trap 'rm -rf -- "$work"' RETURN
@@ -152,13 +240,14 @@ run_case() { # name assembler-fails|final-probe-fails|published-digest-mismatch
     published="localhost/task5-cleanup-$name:latest"
     write_fixtures "$state" "$root"
     set +e
-    BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
+    BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" BUILD_FIXTURE_PUBLISHED="$published" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
         SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture \
         SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
-        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" \
+        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" SOURCE_DATE_EPOCH=1722384000 \
         BUILD_FIXTURE_ASSEMBLER_FAIL=$([[ $name == assembler-fails ]] && printf 1 || printf 0) \
-        BUILD_FIXTURE_FINAL_PROBE_FAIL=$([[ $name == final-probe-fails ]] && printf 1 || printf 0) \
+        BUILD_FIXTURE_FINAL_CP_FAIL=$([[ $name == final-cp-fails ]] && printf 1 || printf 0) \
         BUILD_FIXTURE_PUBLISHED_DIGEST_MISMATCH=$([[ $name == published-digest-mismatch ]] && printf 1 || printf 0) \
+        BUILD_FIXTURE_FINAL_NONBOOT_MUTATION=$([[ $name == nonboot-mutation ]] && printf 1 || printf 0) \
         "$PACKAGER" "$root" "$published" >/dev/null 2>&1
     status=$?
     set -e
@@ -167,10 +256,10 @@ run_case() { # name assembler-fails|final-probe-fails|published-digest-mismatch
 
     # A fresh secure invocation must not be blocked by leftovers from the failure.
     set +e
-    BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
+    BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" BUILD_FIXTURE_PUBLISHED="localhost/task5-cleanup-rerun-$name:latest" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
         SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture \
         SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
-        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" \
+        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" SOURCE_DATE_EPOCH=1722384000 \
         "$PACKAGER" "$root" "localhost/task5-cleanup-rerun-$name:latest" >/dev/null
     status=$?
     set -e
@@ -190,7 +279,7 @@ run_probe_failure_case() { # name expected-text setup-command env-name env-value
     output=$(env BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" PATH="$state/bin:$PATH" \
         SNOSI_BOOTC_SECURE=1 SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture \
         SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
-        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" \
+        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" SOURCE_DATE_EPOCH=1722384000 \
         "$env_name=$env_value" "$PACKAGER" "$root" "$published" 2>&1)
     status=$?
     set -e
@@ -224,8 +313,135 @@ run_probe_failure_case wrong-version 'expected bootc 1.16.3, observed bootc 1.16
 run_probe_failure_case umount-fails 'failed to unmount rootfs proc' none BUILD_FIXTURE_UMOUNT_FAIL 1
 
 run_case assembler-fails
-run_case final-probe-fails
+run_case final-cp-fails
 run_case published-digest-mismatch
+run_case nonboot-mutation
+
+run_success_case() {
+    local work state root published
+    work=$(mktemp -d)
+    trap 'rm -rf -- "$work"' RETURN
+    state="$work/state"; root="$work/root"; published="localhost/task5-cleanup-success:latest"
+    write_fixtures "$state" "$root"
+    BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" BUILD_FIXTURE_PUBLISHED="$published" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
+        SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
+        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" SOURCE_DATE_EPOCH=1722384000 \
+        "$PACKAGER" "$root" "$published" org.opencontainers.image.version=fixture >/dev/null
+    first=""
+    [[ ! -f "$state/chunk-image" ]] || first=$(<"$state/chunk-image")
+    if [[ ! -f "$state/chunk-args" ]] || ! grep -Fxq -- '--prune' "$state/chunk-args"; then
+        fail "chunkah lost --prune"
+    fi
+    if [[ ! -f "$state/chunk-args" ]] || ! grep -Fxq -- '/sysroot/' "$state/chunk-args"; then
+        fail "chunkah lost /sysroot/"
+    fi
+    if [[ ! -f "$state/chunk-args" ]] || ! grep -Fxq -- '--max-layers' "$state/chunk-args"; then
+        fail "chunkah lost --max-layers"
+    fi
+    if [[ ! -f "$state/chunk-args" ]] || ! grep -Fxq -- '128' "$state/chunk-args"; then
+        fail "chunkah lost the default layer limit"
+    fi
+    [[ -f "$state/chunk-source-epoch" && $(<"$state/chunk-source-epoch") == 1722384000 ]] || fail "chunkah received the wrong source epoch"
+    grep -Fxq "from $first" "$state/buildah-commands" || fail "final image was not derived from the chunked candidate"
+    [[ $(<"$state/cp-final-option") == -a && $(<"$state/cp-final-source") == "$root/boot/." ]] ||
+        fail "final image did not copy only the rootfs boot tree"
+    [[ $(<"$state/cp-final-destination") == "$state/mounts/container-2/boot/" ]] ||
+        fail "final image did not copy the boot overlay into the derived container"
+    [[ -f "$state/digest-probe-count" && $(<"$state/digest-probe-count") == 2 ]] || fail "secure packaging did not perform exactly two digest probes"
+    [[ -f "$state/first-digest-image" && $(<"$state/first-digest-image") == "$first" ]] || fail "chunked candidate was not digest authority"
+    [[ -f "$state/final-digest-image" && $(<"$state/final-digest-image") == "$published" ]] || fail "published image was not the final digest authority"
+    grep -Fxq 'containers.bootc=1' "$state/container-1-labels" || fail "first candidate lost the bootc label"
+    grep -Fxq 'org.opencontainers.image.vendor=frostyard' "$state/container-1-labels" || fail "first candidate lost the vendor label"
+    grep -Fxq 'org.opencontainers.image.version=fixture' "$state/container-1-labels" || fail "first candidate lost the caller label"
+    ! grep -Fxq 'io.snosi.bootc.secureboot-capable=true' "$state/container-1-labels" || fail "first candidate gained the secure capability label"
+    ! grep -Fq 'io.snosi.bootc.secureboot-assembly=' "$state/container-1-labels" || fail "first candidate gained the assembly label"
+    grep -Fxq 'io.snosi.bootc.secureboot-capable=true' "$state/container-2-labels" || fail "final container lost the secure label"
+    grep -Fxq 'io.snosi.bootc.secureboot-assembly=bootc-1.16.3-storage-digest-v1' "$state/container-2-labels" || fail "final container lost the assembly label"
+    "$state/assembler" --remove-injected "$root"
+}
+
+run_chunk_failure_case() { # name env-name env-value expected-text
+    local name=$1 env_name=$2 env_value=$3 expected=$4 work state root published output status
+    work=$(mktemp -d)
+    trap 'rm -rf -- "$work"' RETURN
+    state="$work/state"; root="$work/root"; published="localhost/task5-chunk-$name:latest"
+    write_fixtures "$state" "$root"
+    set +e
+    output=$(env BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" BUILD_FIXTURE_PUBLISHED="$published" PATH="$state/bin:$PATH" \
+        SNOSI_BOOTC_SECURE=1 SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture \
+        SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture SNOSI_BOOTC_SECURE_TEST_HOOKS=1 \
+        SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" SOURCE_DATE_EPOCH=1722384000 \
+        "$env_name=$env_value" "$PACKAGER" "$root" "$published" 2>&1)
+    status=$?
+    set -e
+    [[ $status -ne 0 && $output == *"$expected"* ]] || fail "$name was not rejected with $expected"
+    [[ ! -e "$state/scan-invoked" ]] || fail "$name reached publication scanning"
+    if [[ $name != malformed-final-digest ]]; then
+        [[ ! -e "$state/assembler-invoked" ]] || fail "$name reached assembly"
+    fi
+    [[ ! -e "$state/images/$(image_path "$published")" ]] || fail "$name retained a final image"
+    [[ ! -e "$state/images/$(image_path localhost/snosi-bootc-secure-first-$$)" ]] || fail "$name retained the first candidate"
+    [[ ! -d "$state/containers" || -z $(compgen -G "$state/containers/*") ]] || fail "$name retained a container"
+    [[ ! -d "$state/mounts" || -z $(compgen -G "$state/mounts/*") ]] || fail "$name retained a mount"
+
+    # The failed candidate must not poison a later protected package attempt.
+    set +e
+    BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" \
+        BUILD_FIXTURE_PUBLISHED="localhost/task5-chunk-rerun-$name:latest" PATH="$state/bin:$PATH" \
+        SNOSI_BOOTC_SECURE=1 SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture \
+        SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture SNOSI_BOOTC_SECURE_TEST_HOOKS=1 \
+        SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" SOURCE_DATE_EPOCH=1722384000 \
+        "$PACKAGER" "$root" "localhost/task5-chunk-rerun-$name:latest" >/dev/null
+    status=$?
+    set -e
+    [[ $status -eq 0 ]] || fail "$name left the next secure packaging run wedged"
+    "$state/assembler" --remove-injected "$root"
+}
+
+run_chunk_failure_case chunk-failure BUILD_FIXTURE_CHUNK_FAIL 1 'chunkah'
+run_chunk_failure_case unparseable-load BUILD_FIXTURE_CHUNK_UNPARSEABLE_LOAD 1 'could not parse loaded image ref'
+run_chunk_failure_case malformed-first-digest BUILD_FIXTURE_MALFORMED_FIRST_DIGEST 1 'unsupported bootc storage-digest interface'
+run_chunk_failure_case malformed-final-digest BUILD_FIXTURE_MALFORMED_FINAL_DIGEST 1 'unsupported bootc storage-digest interface'
+
+run_missing_epoch_case() {
+    local work state root output status
+    work=$(mktemp -d)
+    trap 'rm -rf -- "$work"' RETURN
+    state="$work/state"; root="$work/root"
+    write_fixtures "$state" "$root"
+    set +e
+    output=$(env BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
+        SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
+        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" \
+        "$PACKAGER" "$root" localhost/task5-cleanup-missing-epoch:latest 2>&1)
+    status=$?
+    set -e
+    [[ $status -ne 0 && $output == *'SOURCE_DATE_EPOCH is required for secure chunking'* ]] || fail "missing source epoch was not rejected"
+    [[ ! -e "$state/chunk-args" && ! -e "$state/assembler-invoked" && ! -e "$state/buildah-invoked" ]] ||
+        fail "missing source epoch reached chunkah, assembler, or final commit"
+}
+
+run_invalid_epoch_case() {
+    local work state root output status
+    work=$(mktemp -d)
+    trap 'rm -rf -- "$work"' RETURN
+    state="$work/state"; root="$work/root"
+    write_fixtures "$state" "$root"
+    set +e
+    output=$(env BUILD_FIXTURE_STATE="$state" BUILD_FIXTURE_ROOT="$root" PATH="$state/bin:$PATH" SNOSI_BOOTC_SECURE=1 \
+        SNOSI_BOOTC_MOK_KEY=fixture SNOSI_BOOTC_MOK_CERT=fixture SNOSI_BOOTC_PCR_KEY=fixture SNOSI_BOOTC_PCR_CERT=fixture \
+        SNOSI_BOOTC_SECURE_TEST_HOOKS=1 SNOSI_BOOTC_SECURE_TEST_ASSEMBLER="$state/assembler" SOURCE_DATE_EPOCH=not-a-number \
+        "$PACKAGER" "$root" localhost/task5-cleanup-invalid-epoch:latest 2>&1)
+    status=$?
+    set -e
+    [[ $status -ne 0 && $output == *'SOURCE_DATE_EPOCH must be a non-negative integer'* ]] || fail "invalid source epoch was not rejected"
+    [[ ! -e "$state/assembler-invoked" ]] || fail "invalid source epoch reached assembly"
+    [[ ! -e "$state/images/$(image_path localhost/task5-cleanup-invalid-epoch:latest)" ]] || fail "invalid source epoch reached final commit"
+}
+
+run_success_case
+run_missing_epoch_case
+run_invalid_epoch_case
 
 [[ $failures -eq 0 ]] || exit 1
 echo "bootc secure package cleanup fixtures passed"

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -55,9 +55,10 @@ MOK/recovery/TPM/UKI tools and the public-only native MOK certificate plus
 RSA-2048 PCR signing public key. The image contract is
 `/usr/lib/snosi/bootc-secure.json` (schema 1). Task 5 adds
 `shared/bootc-secure/assemble-uki.sh`, called only through
-`buildah-package.sh` when `SNOSI_BOOTC_SECURE=1`: the first OCI package obtains
-bootc 1.16.3's hidden storage digest, and the adapter injects a MOK-signed UKI
-plus the ESP copy of systemd-boot under `/boot`. Before that first package, it
+`buildah-package.sh` when `SNOSI_BOOTC_SECURE=1`: the pristine first OCI package
+is chunked before its candidate bootc obtains bootc 1.16.3's hidden storage
+digest. That chunked candidate is digest authority; the adapter injects a
+MOK-signed UKI plus the ESP copy of systemd-boot under `/boot`. Before that first package, it
 places the same signed systemd-boot source at
 `/usr/lib/snosi/bootc/systemd-bootx64.efi`; this is required because an
 installed ESP mount shadows `/boot`, and it is deliberately present before the
@@ -66,9 +67,11 @@ digest is calculated. The preflight version gate uses bare-name
 `$ROOTFS_DIR/proc`, bind-mounts only host `/proc`, runs `/usr/bin/bootc
 --version` against target libraries, and always unmounts before
 `--prepare-systemd-boot-source`. Bare names are load-bearing for the non-root
-PATH fixtures. This gate is not digest authority; both storage digest probes
-still run bootc inside their candidate OCI images. A second OCI probe must
-retain the exact digest. This is a
+PATH fixtures. This gate is not digest authority; exactly two storage digest
+probes run bootc inside candidate OCI images: the chunked candidate before
+assembly and the final image after assembly. The final image inherits the
+chunked candidate's layers and receives only the `/boot` overlay; its probe must
+retain the exact digest. Protected builds never chunk after assembly. This is a
 fail-closed maintained compatibility contract, not
 an upstream interface; see `docs/bootc-secure-assembly-compatibility.md` for
 the mandatory revalidation triggers. Private keys remain caller-owned and must
@@ -396,7 +399,7 @@ Creates OCI container images from the directory output.
 buildah-package.sh <rootfs-dir> <image-ref> [label=value ...]
 ```
 
-Uses `buildah mount` + `cp -a` + `buildah commit` instead of `buildah COPY` to preserve all file metadata (SUID bits, xattrs, capabilities, ACLs, hardlinks). This works around buildah#4463 which drops SUID bits during COPY.
+Uses `buildah mount` + `cp -a` + `buildah commit` instead of `buildah COPY` to preserve all file metadata (SUID bits, xattrs, capabilities, ACLs, hardlinks). This works around buildah#4463 which drops SUID bits during COPY. In protected secure mode it first packages and chunks a pristine candidate, seals that chunked candidate's digest into the UKI, then derives the final image from it with only `/boot` overlaid. The final candidate must return the same digest in the second of exactly two digest probes; no protected post-assembly chunking is permitted.
 
 ### chunkah-package.sh
 
@@ -407,6 +410,11 @@ Optimizes OCI image layers using [chunkah](https://quay.io/jlebon/chunkah).
 - Runs `chunkah build --prune /sysroot/ --max-layers $MAX_LAYERS` (default 128)
 - Uses `user.component` xattrs (set during finalize) to group files into efficient layers
 - Removes ostree-specific labels from output
+
+For protected secure packaging, changing chunkah, the Buildah derivation, or
+the `/boot` exclusion requires the full bootc secure compatibility
+revalidation; these are digest-binding behavior, not independent optimization
+details.
 
 ## Verified Download System
 


### PR DESCRIPTION
## Summary
- move pinned Chunkah packaging inside the protected secure packager before the authoritative bootc storage-digest probe
- derive the final OCI image from the chunked candidate and add only the digest-excluded `/boot` overlay before requiring exact digest equality
- remove protected post-assembly chunking, forward the commit epoch/layer cap through sudo, and enforce the ordering with static guards
- add modeled image-state fixtures for `/boot` digest stability plus chunk, malformed-digest, cleanup, and workflow-negative coverage
- update the secure assembly compatibility contract and build documentation

## Verification
- `bash -n` and ShellCheck on changed shell scripts
- `test/bootc-secure-package-cleanup-test.sh`
- `test/bootc-secure-artifact-test.sh --fixtures`
- `test/bootc-secure-artifact-negative-test.sh --fixtures`
- `check-bootc-publication-guard.sh`
- `test/bootc-publication-guard-test.sh` (46 assertions)
- `test/bootc-secure-publication-test.sh` (27 assertions)
- `test/bootc-secure-promotion-test.sh` (12 assertions)
- `actionlint .github/workflows/build-images.yml`
- `git diff --check`

## Evidence Boundary
This change is fixture- and static-contract validated. The protected secure build must still prove real Chunkah config preservation and bootc 1.16.3 storage-digest stability on the chunked candidate through both local and policy-copied artifact validation before `latest` can move.