### PR TITLE
feat: explicitly enable Pilothouse optional backends

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -149,6 +149,11 @@ jobs:
         # required-paths.txt entries. No root, network, or image build.
         run: ./test/sysext-required-paths-test.sh
 
+      - name: Validate Pilothouse sysext integration
+        # Structural service/drop-in and direct-DEB dependency fixtures. No root,
+        # network, live endpoints, or image build.
+        run: ./test/pilothouse-sysext-test.sh
+
       - name: Validate Sunshine package dependencies
         # Fixture check for Sunshine's .deb dependencies. No root, network, or build.
         run: ./test/sunshine-package-dependencies-test.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1532,6 +1532,14 @@ entry and virtual-input udev rules take effect on the next boot unless manually
 applied. Its upstream user service is available for manual user startup; do not
 add a preset or `Upholds=` activation.
 
+**Pilothouse sysext:** Snosi overrides only `pilothoused.service` `ExecStart`
+to retain the packaged Debian socket, socket-group, and sudo-group arguments
+and explicitly configure Updex, Podman, Docker, and Incus. These are probe
+opt-ins, not hard dependencies; unavailable endpoints remain unregistered and
+nonfatal. The GitHub-release DEB's complete `Depends` expression must pass
+`assert_deb_dependencies_satisfied` before `dpkg -i`; add newly required
+runtime packages through `Packages=` rather than installing them implicitly.
+
 Sysexts can ONLY provide files under `/usr`. They cannot modify `/etc` or `/var` at runtime. Configs needed in `/etc` must be:
 
 1. Captured to `/usr/share/factory/etc` during build (via `mkosi.finalize`) — capture ONLY the specific paths the sysext's tmpfiles rules reference, never all of `/etc` (the buildroot `/etc` is the merged base view; a full capture ships `/etc/shadow` and SSH host keys in the published sysext)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The project produces:
 | **lemonade**        | Lemonade local LLM server (GPU/NPU accelerated)                 | sysext        |
 | **nix**             | Nix package manager                                             | sysext        |
 | **paseo**           | Paseo coding agent workspace desktop application                | sysext        |
-| **pilothouse**      | Pilothouse local web administration console for Snosi           | sysext        |
+| **pilothouse**      | Pilothouse web administration with capability-gated Updex/container backends | sysext        |
 | **podman**          | Podman + Distrobox                                              | sysext        |
 | **sunshine**        | Sunshine self-hosted game streaming host for Moonlight          | sysext        |
 | **tailscale**       | Tailscale VPN client                                            | sysext        |
@@ -250,11 +250,15 @@ Sysexts are overlay images that extend the base system without modifying it. The
 | **lemonade**      | Lemonade local LLM server (lemond)            | [mkosi.images/lemonade/mkosi.conf](mkosi.images/lemonade/mkosi.conf)           |
 | **nix**           | Nix package manager, systemd integration      | [mkosi.images/nix/mkosi.conf](mkosi.images/nix/mkosi.conf)                     |
 | **paseo**         | Paseo desktop app (Electron)                  | [mkosi.images/paseo/mkosi.conf](mkosi.images/paseo/mkosi.conf)                 |
-| **pilothouse**    | Pilothouse local web administration console   | [mkosi.images/pilothouse/mkosi.conf](mkosi.images/pilothouse/mkosi.conf)       |
+| **pilothouse**    | Pilothouse web administration with capability-gated Updex/container backends | [mkosi.images/pilothouse/mkosi.conf](mkosi.images/pilothouse/mkosi.conf)       |
 | **podman**        | Podman, Distrobox, buildah, crun              | [mkosi.images/podman/mkosi.conf](mkosi.images/podman/mkosi.conf)               |
 | **sunshine**      | Sunshine self-hosted game streaming host for Moonlight | [mkosi.images/sunshine/mkosi.conf](mkosi.images/sunshine/mkosi.conf)     |
 | **tailscale**     | Tailscale VPN client                          | [mkosi.images/tailscale/mkosi.conf](mkosi.images/tailscale/mkosi.conf)         |
 | **vscode**        | Visual Studio Code desktop application         | [mkosi.images/vscode/mkosi.conf](mkosi.images/vscode/mkosi.conf)               |
+
+The Pilothouse sysext explicitly configures Updex, Podman, Docker, and Incus.
+Pilothouse advertises each backend only after its executable or socket probe
+succeeds, so unavailable endpoints do not prevent `pilothoused` from starting.
 
 ## How Profiles Work
 

--- a/docs/superpowers/plans/2026-08-02-pilothouse-backends.md
+++ b/docs/superpowers/plans/2026-08-02-pilothouse-backends.md
@@ -1,0 +1,360 @@
+# Pilothouse Backend Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve Pilothouse's four Cayo backend integrations after their default-off change and fail sysext builds before installation when a direct DEB declares an unsatisfied runtime dependency.
+
+**Architecture:** A vendor systemd drop-in replaces only `pilothoused.service`'s `ExecStart`, retaining the Debian package arguments while explicitly configuring Updex, Podman, Docker, and Incus. A reusable shell helper delegates complete Debian dependency expressions to `dpkg-checkbuilddeps`; an always-runnable fixture test validates both contracts without requiring a sysext build or live endpoints.
+
+**Tech Stack:** Bash, systemd unit drop-ins, `dpkg-deb`, `dpkg-checkbuilddeps`, GitHub Actions.
+
+## Global Constraints
+
+- Preserve any concurrent Pilothouse 0.7.0 URL, checksum, version, and dependency edits; re-read touched files before each patch.
+- Configure exactly one each of `--updex`, `--podman-socket`, `--docker`, and `--incus`.
+- Preserve exactly one each of `--socket`, `--socket-group`, and Debian `--admin-group sudo`.
+- Backend flags permit bounded probes only; unavailable endpoints must not become startup dependencies.
+- Dependency validation must run after verified download and before `dpkg -i`.
+- Missing dependencies must fail the build rather than be installed implicitly into the sysext delta.
+- Do not claim live Cayo capability validation unless a live Cayo test is run.
+- Do not commit unless the user explicitly requests a commit.
+
+---
+
+### Task 1: Add the Failing Pilothouse Contract Test
+
+**Files:**
+- Create: `test/pilothouse-sysext-test.sh`
+- Modify: `.github/workflows/validate.yml:147-164`
+
+**Interfaces:**
+- Consumes: the planned drop-in at `mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf`, the manifest at `mkosi.images/pilothouse/required-paths.txt`, and `assert_deb_dependencies_satisfied DEB_PATH` from Task 2.
+- Produces: an always-runnable regression gate covering the service command and direct-DEB dependency helper.
+
+- [ ] **Step 1: Create the failing fixture test**
+
+Create `test/pilothouse-sysext-test.sh` with this structure:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+dropin="$repo_root/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf"
+required_paths="$repo_root/mkosi.images/pilothouse/required-paths.txt"
+dependency_helper="$repo_root/shared/download/deb-dependencies.sh"
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/pilothouse-sysext-test.XXXXXX")
+trap 'rm -rf "$scratch"' EXIT
+
+assert_count() {
+    local expected=$1 pattern=$2 file=$3
+    local actual
+    actual=$(grep -Ec -- "$pattern" "$file" || true)
+    if [[ "$actual" -ne "$expected" ]]; then
+        printf 'expected %s match(es) for %s in %s, found %s\n' \
+            "$expected" "$pattern" "$file" "$actual" >&2
+        exit 1
+    fi
+}
+
+grep -qx '/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf' "$required_paths"
+assert_count 1 '^ExecStart=$' "$dropin"
+assert_count 1 '^ExecStart=/usr/bin/pilothoused ' "$dropin"
+for argument in \
+    '--socket /run/pilothouse/broker.sock' \
+    '--socket-group pilothouse' \
+    '--admin-group sudo' \
+    '--updex /usr/bin/updex' \
+    '--podman-socket /run/podman/podman.sock' \
+    '--docker unix:///var/run/docker.sock' \
+    '--incus'
+do
+    assert_count 1 "(^|[[:space:]])${argument}([[:space:]]|$)" "$dropin"
+done
+
+unit_root="$scratch/root"
+unit_dir="$unit_root/usr/lib/systemd/system"
+mkdir -p "$unit_dir/pilothoused.service.d" "$unit_root/usr/bin"
+cat >"$unit_dir/pilothoused.service" <<'EOF'
+[Unit]
+Description=Pilothouse privileged broker
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/pilothoused --socket /run/pilothouse/broker.sock --socket-group pilothouse --admin-group sudo
+EOF
+cp "$dropin" "$unit_dir/pilothoused.service.d/10-snosi-backends.conf"
+touch "$unit_root/usr/bin/pilothoused"
+chmod +x "$unit_root/usr/bin/pilothoused"
+systemd-analyze verify --root="$unit_root" pilothoused.service
+
+source "$dependency_helper"
+
+build_deb() {
+    local name=$1 depends=$2 output=$3
+    local root="$scratch/$name"
+    mkdir -p "$root/DEBIAN"
+    {
+        printf 'Package: %s\nVersion: 1.0\nArchitecture: all\nMaintainer: Snosi Test <test@example.invalid>\nDescription: dependency fixture\n' "$name"
+        if [[ -n "$depends" ]]; then
+            printf 'Depends: %s\n' "$depends"
+        fi
+    } >"$root/DEBIAN/control"
+    dpkg-deb --build "$root" "$output" >/dev/null
+}
+
+dpkg_version=$(dpkg-query -W -f='${Version}' dpkg)
+build_deb no-dep '' "$scratch/no-dep.deb"
+build_deb satisfied "dpkg (>= $dpkg_version) | snosi-never-installed" "$scratch/satisfied.deb"
+build_deb unsatisfied 'snosi-deliberately-missing-dependency' "$scratch/unsatisfied.deb"
+
+assert_deb_dependencies_satisfied "$scratch/no-dep.deb"
+assert_deb_dependencies_satisfied "$scratch/satisfied.deb"
+if assert_deb_dependencies_satisfied "$scratch/unsatisfied.deb"; then
+    printf 'expected unsatisfied dependency expression to fail\n' >&2
+    exit 1
+fi
+
+printf 'pilothouse-sysext-test: PASSED\n'
+```
+
+- [ ] **Step 2: Make the test executable and run it to verify the red state**
+
+Run:
+
+```bash
+chmod +x test/pilothouse-sysext-test.sh
+./test/pilothouse-sysext-test.sh
+```
+
+Expected: FAIL because the drop-in and `shared/download/deb-dependencies.sh` do not exist.
+
+- [ ] **Step 3: Wire the test into validation**
+
+Add this step after `Validate sysext required paths finalizer` in `.github/workflows/validate.yml`:
+
+```yaml
+      - name: Validate Pilothouse sysext integration
+        # Structural service/drop-in and direct-DEB dependency fixtures. No root,
+        # network, live endpoints, or image build.
+        run: ./test/pilothouse-sysext-test.sh
+```
+
+- [ ] **Step 4: Inspect the task diff**
+
+Run `git diff -- test/pilothouse-sysext-test.sh .github/workflows/validate.yml` and verify no concurrent Pilothouse release edits were touched. Do not commit without an explicit user request.
+
+---
+
+### Task 2: Implement Backend and Dependency Contracts
+
+**Files:**
+- Create: `mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf`
+- Create: `shared/download/deb-dependencies.sh`
+- Modify: `mkosi.images/pilothouse/required-paths.txt:10-14`
+- Modify: `mkosi.images/pilothouse/mkosi.postinst.chroot:8-17`
+- Modify: `mkosi.images/pilothouse/mkosi.conf:17-23`
+- Test: `test/pilothouse-sysext-test.sh`
+
+**Interfaces:**
+- Consumes: `dpkg-deb`, `dpkg-checkbuilddeps`, and the verified Pilothouse DEB path.
+- Produces: `assert_deb_dependencies_satisfied DEB_PATH`, returning zero for an empty or satisfied `Depends` expression and nonzero with a diagnostic for an unsatisfied expression; produces the effective Pilothouse backend command.
+
+- [ ] **Step 1: Add the systemd drop-in**
+
+Create `10-snosi-backends.conf`:
+
+```ini
+[Service]
+ExecStart=
+ExecStart=/usr/bin/pilothoused --socket /run/pilothouse/broker.sock --socket-group pilothouse --admin-group sudo --updex /usr/bin/updex --podman-socket /run/podman/podman.sock --docker unix:///var/run/docker.sock --incus
+```
+
+- [ ] **Step 2: Require the drop-in in built artifacts**
+
+Append this exact path beneath the existing service activation paths in `mkosi.images/pilothouse/required-paths.txt`:
+
+```text
+/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf
+```
+
+- [ ] **Step 3: Add the reusable dependency helper**
+
+Create `shared/download/deb-dependencies.sh`:
+
+```bash
+#!/bin/bash
+
+assert_deb_dependencies_satisfied() {
+    local deb=$1
+    local dependencies
+
+    dependencies=$(dpkg-deb --field "$deb" Depends)
+    if [[ -z "${dependencies//[[:space:]]/}" ]]; then
+        return 0
+    fi
+
+    if ! dpkg-checkbuilddeps -d "$dependencies"; then
+        printf 'DEB dependencies are not satisfied by the buildroot; add the required runtime packages through Packages=: %s\n' \
+            "$dependencies" >&2
+        return 1
+    fi
+}
+```
+
+Keep the helper source-only: it defines one function and does not execute work when sourced.
+
+- [ ] **Step 4: Guard Pilothouse installation before mutation**
+
+In `mkosi.images/pilothouse/mkosi.postinst.chroot`, source the helper beside `verified-download.sh`, then call it between `verified_download` and `dpkg -i`:
+
+```bash
+source "$SRCDIR/shared/download/verified-download.sh"
+source "$SRCDIR/shared/download/deb-dependencies.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "pilothouse" "$DEBS/pilothouse.deb"
+assert_deb_dependencies_satisfied "$DEBS/pilothouse.deb"
+
+# The DEB is installed directly because it is downloaded from GitHub rather
+# than an APT repository. Its declared dependencies must already be satisfied
+# by the merged buildroot; the guard above fails before dpkg mutates the root
+# if Packages= composition drifts behind a new release.
+dpkg -i "$DEBS/pilothouse.deb"
+```
+
+Retain the existing sysusers/PAM explanation after the dependency paragraph. Do not alter concurrent 0.7.0 dependency declarations.
+
+- [ ] **Step 5: Correct the package rationale**
+
+Replace the stale `no Depends (static Go binaries)` rationale in `mkosi.images/pilothouse/mkosi.conf` with:
+
+```ini
+[Build]
+# frostyard-pilothouse is downloaded from GitHub rather than an APT repository,
+# so mkosi.postinst.chroot installs it directly. Its declared runtime
+# dependencies are kept explicit in Packages= (or supplied by the merged base)
+# and checked against the buildroot before dpkg mutates it. The postoutput
+# script resolves KEYPACKAGE from the merged dpkg database.
+Environment=KEYPACKAGE=frostyard-pilothouse
+```
+
+If the concurrent 0.7.0 bump has added a `Packages=` list, preserve that list in the same section.
+
+- [ ] **Step 6: Run the focused test to verify green**
+
+Run `./test/pilothouse-sysext-test.sh`.
+
+Expected: the test prints the deliberate missing-dependency diagnostic once, then `pilothouse-sysext-test: PASSED` and exits zero.
+
+- [ ] **Step 7: Run shell syntax checks**
+
+Run:
+
+```bash
+bash -n shared/download/deb-dependencies.sh mkosi.images/pilothouse/mkosi.postinst.chroot test/pilothouse-sysext-test.sh
+shellcheck shared/download/deb-dependencies.sh mkosi.images/pilothouse/mkosi.postinst.chroot test/pilothouse-sysext-test.sh
+```
+
+Expected: both commands exit zero with no diagnostics.
+
+- [ ] **Step 8: Inspect the task diff**
+
+Run `git diff -- mkosi.images/pilothouse shared/download/deb-dependencies.sh test/pilothouse-sysext-test.sh` and verify the concurrent 0.7.0 URL/checksum/version and any required `Packages=` entries remain intact. Do not commit without an explicit user request.
+
+---
+
+### Task 3: Document and Verify the Complete Integration
+
+**Files:**
+- Modify: `README.md:45-62,240-257`
+- Modify: `CLAUDE.md` in the Sysext Constraints section
+- Modify: `yeti/sysexts.md:233-240`
+- Modify: `docs/superpowers/specs/2026-08-02-pilothouse-backends-design.md` only if implementation reveals a factual correction
+- Test: `.github/workflows/validate.yml`
+
+**Interfaces:**
+- Consumes: the service and dependency behavior implemented in Task 2.
+- Produces: user-facing and AI-maintainer documentation that states the implemented contract without claiming unrun live validation.
+
+- [ ] **Step 1: Update README integration descriptions**
+
+Change both Pilothouse table descriptions to identify the explicit integrations:
+
+```text
+Pilothouse web administration with capability-gated Updex/container backends
+```
+
+Near the sysext table, add a concise paragraph stating that the sysext explicitly configures Updex, Podman, Docker, and Incus, while Pilothouse advertises each backend only after its executable/socket probe succeeds. State that unavailable endpoints do not prevent `pilothoused` from starting.
+
+- [ ] **Step 2: Update detailed sysext documentation**
+
+In `yeti/sysexts.md`'s `### pilothouse` section:
+
+- replace the static/no-Depends claim with the direct-download plus pre-install dependency-guard contract;
+- document `pilothoused.service.d/10-snosi-backends.conf` and all four exact flags;
+- state that the flags opt probes in but do not force registration or startup failure when endpoints are absent; and
+- retain the PAM capture, sysusers, preset, and `Upholds=` details.
+
+- [ ] **Step 3: Update maintainer guidance**
+
+Add a focused Pilothouse paragraph to `CLAUDE.md`'s Sysext Constraints section recording:
+
+```text
+Pilothouse sysext: Snosi overrides only pilothoused.service ExecStart to retain
+the packaged Debian socket/socket-group/sudo-group arguments and explicitly
+configure Updex, Podman, Docker, and Incus. These are probe opt-ins, not hard
+dependencies; unavailable endpoints remain unregistered and nonfatal. The
+GitHub-release DEB's complete Depends expression must pass
+assert_deb_dependencies_satisfied before dpkg -i; add newly required runtime
+packages through Packages= rather than installing them implicitly.
+```
+
+- [ ] **Step 4: Run focused and shared regressions**
+
+Run:
+
+```bash
+./test/pilothouse-sysext-test.sh
+./test/sysext-required-paths-test.sh
+./check-runtime-etc-guard.sh
+```
+
+Expected: all three commands print their pass result and exit zero. The Pilothouse fixture may print the expected `dpkg-checkbuilddeps` rejection for its deliberately invalid DEB.
+
+- [ ] **Step 5: Validate workflow and inspect all changes**
+
+Run:
+
+```bash
+actionlint .github/workflows/validate.yml
+git diff --check
+git status --short
+git diff -- .github/workflows/validate.yml mkosi.images/pilothouse shared/download/deb-dependencies.sh test/pilothouse-sysext-test.sh README.md CLAUDE.md yeti/sysexts.md docs/superpowers/specs/2026-08-02-pilothouse-backends-design.md docs/superpowers/plans/2026-08-02-pilothouse-backends.md
+```
+
+Expected: `actionlint` and `git diff --check` exit zero; status contains only the intended fix, documentation, any preserved concurrent 0.7.0 bump, and pre-existing user changes. Do not commit without an explicit user request.
+
+- [ ] **Step 6: Request adversarial review**
+
+Ask a reviewer to check argument cardinality, Debian dependency-expression handling, systemd drop-in semantics, preservation of the concurrent release bump, and documentation claims. Address only concrete findings, then rerun Steps 4 and 5.
+
+#### Task 3 Execution Report (2026-08-02)
+
+- Added a focused JSON-pin regression assertion before changing the pin. With
+  the prior `0.6.0` value, `./test/pilothouse-sysext-test.sh` exited nonzero
+  with: `expected pinned Pilothouse version >= 0.7.0, found 0.6.0 in
+  /home/bjk/.local/share/opencode/worktree/2cd0bf4157f9240ff9806944b685628cc1149e8b/merry-walrus/shared/download/sysext-checksums.json`.
+- Updated only Pilothouse's `url`, `sha256`, and `version` fields to the
+  approved 0.7.0 release. `./test/pilothouse-sysext-test.sh` exited zero and
+  printed the expected deliberately-unsatisfied fixture diagnostic followed by
+  `pilothouse-sysext-test: PASSED`. `dpkg-deb` also printed its existing
+  nonfatal unusual-owner warnings for the synthetic fixture roots.
+- `jq -e . shared/download/sysext-checksums.json >/dev/null` exited zero.
+- `bash -n shared/download/deb-dependencies.sh
+  mkosi.images/pilothouse/mkosi.postinst.chroot
+  test/pilothouse-sysext-test.sh` exited zero.
+- `shellcheck shared/download/deb-dependencies.sh
+  mkosi.images/pilothouse/mkosi.postinst.chroot
+  test/pilothouse-sysext-test.sh` exited zero with no diagnostics.
+- `git diff --check` exited zero with no output.

--- a/docs/superpowers/specs/2026-08-02-pilothouse-backends-design.md
+++ b/docs/superpowers/specs/2026-08-02-pilothouse-backends-design.md
@@ -1,0 +1,112 @@
+# Pilothouse Backend Configuration and Dependency Guard Design
+
+## Goal
+
+Keep Pilothouse's Updex, Podman, Docker, and Incus integrations available on
+Cayo after Pilothouse changes those optional backends to default-off. At the
+same time, make the direct-DEB sysext build fail before installation if a
+future Pilothouse release declares a dependency that the merged buildroot does
+not already satisfy.
+
+The user-approved Pilothouse 0.7.0 URL, checksum, and version pin co-lands
+with this change. The focused fixture enforces a Debian version floor of 0.7.0
+so a later accidental downgrade fails clearly.
+
+## Root Cause
+
+The Snosi Pilothouse sysext currently ships the package's
+`pilothoused.service` unchanged. The pinned v0.6.0 command configures only the
+broker socket, socket group, and Debian administrator group. Newer Pilothouse
+releases require explicit flags before probing Updex, Podman, Docker, or Incus,
+so an unmodified service silently loses those capabilities after the pin bump.
+
+The sysext build also relies on `dpkg -i` after a verified direct download.
+Its comments assume the DEB has no dependencies and both binaries are static.
+Newer packages declare Debian runtime dependencies and `pilothoused` uses
+dynamic PAM and systemd libraries. That stale assumption should become an
+enforced build contract rather than another comment.
+
+## Service Override
+
+Add this vendor drop-in beneath the Pilothouse sysext payload:
+
+`/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf`
+
+The drop-in clears the package's `ExecStart` and supplies one replacement. The
+replacement retains these Debian package arguments exactly once:
+
+- `--socket /run/pilothouse/broker.sock`
+- `--socket-group pilothouse`
+- `--admin-group sudo`
+
+It also supplies each optional backend configuration exactly once:
+
+- `--updex /usr/bin/updex`
+- `--podman-socket /run/podman/podman.sock`
+- `--docker unix:///var/run/docker.sock`
+- `--incus`
+
+These flags permit probes; they do not create systemd dependencies on the
+configured endpoints. Pilothouse remains responsible for bounded reachability
+checks. A missing executable or unavailable socket leaves that capability and
+its routes unregistered without preventing broker startup.
+
+Add the drop-in path to `mkosi.images/pilothouse/required-paths.txt` so a sysext
+build cannot omit it silently.
+
+## Dependency Guard
+
+Add `shared/download/deb-dependencies.sh`, a small shared shell helper for
+direct-DEB consumers. Given a DEB path, it reads the package's `Depends` field
+with `dpkg-deb` and, when nonempty, passes the complete expression to
+`dpkg-checkbuilddeps -d`. This delegates versions, alternatives, architecture
+qualifiers, and virtual-package handling to Debian's own dependency parser.
+
+The Pilothouse post-install script invokes the helper after verified download
+and before `dpkg -i`. An unsatisfied expression fails before the package mutates
+the buildroot and reports that the missing runtime dependency must be declared
+through the image's `Packages=` composition. The helper accepts an empty
+`Depends` field, preserving compatibility with older direct-DEB artifacts.
+
+The guard deliberately does not run APT or install dependencies automatically.
+That would let a new upstream dependency silently enter the sysext delta rather
+than forcing Snosi to make the package-placement decision explicitly.
+
+## Regression Coverage
+
+Add an always-runnable fixture test to `validate.yml` that proves:
+
+- the required-path manifest names the service drop-in;
+- the drop-in clears and replaces `ExecStart`;
+- the effective command preserves each packaged argument exactly once;
+- the effective command configures each optional backend exactly once;
+- `systemd-analyze verify` accepts a fixture package unit combined with the
+  drop-in;
+- the dependency helper accepts an empty dependency field;
+- the helper accepts a synthetic DEB whose versioned/alternative dependency is
+  satisfied by the test host; and
+- the helper rejects a synthetic DEB with a deliberately nonexistent
+  dependency.
+
+The structural service test protects Snosi's delivery contract without
+duplicating Pilothouse's own endpoint-probe implementation tests. A real sysext
+build remains the artifact-level proof that the drop-in is included.
+
+## Documentation
+
+Update `README.md`, `CLAUDE.md`, and `yeti/sysexts.md` to record:
+
+- the four explicitly configured optional backends;
+- unavailable endpoints remain capability-gated and nonfatal;
+- direct-DEB dependencies must already be satisfied by the merged buildroot;
+  and
+- the build-time guard enforces that dependency contract before installation.
+
+Do not claim runtime capability advertisement was tested on Cayo unless a live
+Cayo validation is actually run.
+
+## Scope
+
+This design resolves Snosi issues #479 and #469 together. It does not change
+Pilothouse's probe implementation, add endpoint ordering dependencies, or
+install new runtime packages implicitly.

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.pilothouse.d/pilothouse.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.pilothouse.d/pilothouse.feature
@@ -1,4 +1,4 @@
 [Feature]
-Description=Pilothouse local web administration console for Snosi
+Description=Pilothouse web administration with capability-gated backends
 Documentation=https://github.com/frostyard/pilothouse
 Enabled=false

--- a/mkosi.images/pilothouse/mkosi.conf
+++ b/mkosi.images/pilothouse/mkosi.conf
@@ -15,9 +15,9 @@ PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
 FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
 
 [Build]
-# Like coder, frostyard-pilothouse is not in Packages= — the deb is installed
-# by mkosi.postinst.chroot via verified_download + dpkg -i (GitHub release, no
-# apt repo). The postoutput script still resolves KEYPACKAGE from the merged
-# dpkg database. The deb declares no Depends (static Go binaries), so no
-# runtime packages are needed here.
+# frostyard-pilothouse is downloaded from GitHub rather than an APT repository,
+# so mkosi.postinst.chroot installs it directly. Its declared runtime
+# dependencies are kept explicit in Packages= (or supplied by the merged base)
+# and checked against the buildroot before dpkg mutates it. The postoutput
+# script resolves KEYPACKAGE from the merged dpkg database.
 Environment=KEYPACKAGE=frostyard-pilothouse

--- a/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf
+++ b/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/pilothoused --socket /run/pilothouse/broker.sock --socket-group pilothouse --admin-group sudo --updex /usr/bin/updex --podman-socket /run/podman/podman.sock --docker unix:///var/run/docker.sock --incus

--- a/mkosi.images/pilothouse/mkosi.postinst.chroot
+++ b/mkosi.images/pilothouse/mkosi.postinst.chroot
@@ -5,13 +5,20 @@ if [[ "${DEBUG_BUILD:-0}" == "1" ]]; then
     set -x
 fi
 
+# shellcheck source=/dev/null
 source "$SRCDIR/shared/download/verified-download.sh"
+# shellcheck source=/dev/null
+source "$SRCDIR/shared/download/deb-dependencies.sh"
 DEBS=$(mktemp -d)
 trap 'rm -rf "$DEBS"' EXIT
 verified_download "pilothouse" "$DEBS/pilothouse.deb"
+assert_deb_dependencies_satisfied "$DEBS/pilothouse.deb"
 
-# The deb has no Depends (static Go binaries). It ships its own sysusers.d
-# fragment in /usr (creates the pilothouse user/group at boot) and a PAM
-# config at /etc/pam.d/pilothouse, which is stripped from the sysext delta —
-# mkosi.finalize captures it to factory defaults for tmpfiles to restore.
+# The DEB is installed directly because it is downloaded from GitHub rather
+# than an APT repository. Its declared dependencies must already be satisfied
+# by the merged buildroot; the guard above fails before dpkg mutates the root
+# if Packages= composition drifts behind a new release. It ships its own
+# sysusers.d fragment in /usr (creates the pilothouse user/group at boot) and
+# a PAM config at /etc/pam.d/pilothouse, which is stripped from the sysext
+# delta — mkosi.finalize captures it to factory defaults for tmpfiles to restore.
 dpkg -i "$DEBS/pilothouse.deb"

--- a/mkosi.images/pilothouse/required-paths.txt
+++ b/mkosi.images/pilothouse/required-paths.txt
@@ -11,3 +11,4 @@
 /usr/lib/tmpfiles.d/pilothouse.conf
 /usr/lib/systemd/system-preset/40-pilothouse.preset
 /usr/lib/systemd/system/multi-user.target.d/10-pilothouse.conf
+/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf

--- a/shared/download/deb-dependencies.sh
+++ b/shared/download/deb-dependencies.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+assert_deb_dependencies_satisfied() {
+    local deb=$1
+    local dependencies
+
+    dependencies=$(dpkg-deb --field "$deb" Depends)
+    if [[ -z "${dependencies//[[:space:]]/}" ]]; then
+        return 0
+    fi
+
+    if ! dpkg-checkbuilddeps -d "$dependencies" /dev/null; then
+        printf 'DEB dependencies are not satisfied by the buildroot; add the required runtime packages through Packages=: %s\n' \
+            "$dependencies" >&2
+        return 1
+    fi
+
+    return 0
+}

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -50,9 +50,9 @@
     "version": "0.2.3"
   },
   "pilothouse": {
-    "url": "https://github.com/frostyard/pilothouse/releases/download/v0.6.0/frostyard-pilothouse_0.6.0_amd64.deb",
-    "sha256": "17a18dfefd7f788cbe2d8d6994c6271d29d6e69e0071720a8105ad70a9d647c6",
-    "version": "0.6.0"
+    "url": "https://github.com/frostyard/pilothouse/releases/download/v0.7.0/frostyard-pilothouse_0.7.0_amd64.deb",
+    "sha256": "af3c7bcfff75e9323f3b78fa6a538b0cce4cc63abd69acf9c76fff41c945b838",
+    "version": "0.7.0"
   },
   "sunshine": {
     "url": "https://github.com/LizardByte/Sunshine/releases/download/v2026.516.143833/sunshine-debian-trixie-amd64.deb",

--- a/test/pilothouse-sysext-test.sh
+++ b/test/pilothouse-sysext-test.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+dropin="$repo_root/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf"
+required_paths="$repo_root/mkosi.images/pilothouse/required-paths.txt"
+dependency_helper="$repo_root/shared/download/deb-dependencies.sh"
+checksums="$repo_root/shared/download/sysext-checksums.json"
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/pilothouse-sysext-test.XXXXXX")
+trap 'rm -rf "$scratch"' EXIT
+
+pilothouse_arguments=(
+    '--socket /run/pilothouse/broker.sock'
+    '--socket-group pilothouse'
+    '--admin-group sudo'
+    '--updex /usr/bin/updex'
+    '--podman-socket /run/podman/podman.sock'
+    '--docker unix:///var/run/docker.sock'
+    '--incus'
+)
+
+assert_count() {
+    local expected=$1 pattern=$2 file=$3
+    local actual
+    actual=$(grep -Ec -- "$pattern" "$file" || true)
+    if [[ "$actual" -ne "$expected" ]]; then
+        printf 'expected %s match(es) for %s in %s, found %s\n' \
+            "$expected" "$pattern" "$file" "$actual" >&2
+        exit 1
+    fi
+}
+
+assert_fixed_count() {
+    local expected=$1 text=$2 file=$3
+    local actual
+    actual=$(grep -oF -- "$text" "$file" | wc -l || true)
+    if [[ "$actual" -ne "$expected" ]]; then
+        printf 'expected %s occurrence(s) of %s in %s, found %s\n' \
+            "$expected" "$text" "$file" "$actual" >&2
+        return 1
+    fi
+}
+
+assert_pilothouse_arguments() {
+    local file=$1 argument
+
+    for argument in "${pilothouse_arguments[@]}"; do
+        assert_fixed_count 1 "$argument" "$file" || return 1
+    done
+
+    if ! grep -Eq -- '(^|[[:space:]])--incus([[:space:]]|$)' "$file"; then
+        printf 'expected --incus to have a whitespace or EOL boundary in %s\n' "$file" >&2
+        return 1
+    fi
+}
+
+pilothouse_version=$(jq -er '.pilothouse.version' "$checksums")
+if ! dpkg --compare-versions "$pilothouse_version" ge 0.7.0; then
+    printf 'expected pinned Pilothouse version >= 0.7.0, found %s in %s\n' \
+        "$pilothouse_version" "$checksums" >&2
+    exit 1
+fi
+
+grep -qx '/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf' "$required_paths"
+assert_count 1 '^ExecStart=$' "$dropin"
+assert_count 1 '^ExecStart=/usr/bin/pilothoused ' "$dropin"
+assert_pilothouse_arguments "$dropin"
+
+# A line-based match must not accept duplicate arguments on one ExecStart line.
+duplicate_arguments="$scratch/duplicate-arguments.conf"
+{
+    printf '%s' 'ExecStart=/usr/bin/pilothoused'
+    printf ' %s' "${pilothouse_arguments[@]}"
+    printf ' %s\n' '--incus'
+} >"$duplicate_arguments"
+if assert_pilothouse_arguments "$duplicate_arguments" 2>/dev/null; then
+    printf 'expected duplicate --incus arguments to be rejected\n' >&2
+    exit 1
+fi
+
+unit_root="$scratch/root"
+unit_dir="$unit_root/usr/lib/systemd/system"
+mkdir -p "$unit_dir/pilothoused.service.d" "$unit_root/usr/bin"
+cat >"$unit_dir/sysinit.target" <<'EOF'
+[Unit]
+Description=System Initialization
+EOF
+cat >"$unit_dir/pilothoused.service" <<'EOF'
+[Unit]
+Description=Pilothouse privileged broker
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/pilothoused --socket /run/pilothouse/broker.sock --socket-group pilothouse --admin-group sudo
+EOF
+cp "$dropin" "$unit_dir/pilothoused.service.d/10-snosi-backends.conf"
+touch "$unit_root/usr/bin/pilothoused"
+chmod +x "$unit_root/usr/bin/pilothoused"
+systemd-analyze verify --root="$unit_root" pilothoused.service
+
+# shellcheck source=/dev/null
+source "$dependency_helper"
+
+build_deb() {
+    local name=$1 depends=$2 output=$3
+    local root="$scratch/$name"
+    mkdir -p "$root/DEBIAN"
+    {
+        printf 'Package: %s\nVersion: 1.0\nArchitecture: all\nMaintainer: Snosi Test <test@example.invalid>\nDescription: dependency fixture\n' "$name"
+        if [[ -n "$depends" ]]; then
+            printf 'Depends: %s\n' "$depends"
+        fi
+    } >"$root/DEBIAN/control"
+    dpkg-deb --build "$root" "$output" >/dev/null
+}
+
+dpkg_version=$(dpkg-query -W -f='${Version}' dpkg)
+build_deb no-dep '' "$scratch/no-dep.deb"
+build_deb satisfied "dpkg (>= $dpkg_version) | snosi-never-installed" "$scratch/satisfied.deb"
+build_deb unsatisfied 'snosi-deliberately-missing-dependency' "$scratch/unsatisfied.deb"
+
+assert_deb_dependencies_satisfied "$scratch/no-dep.deb"
+assert_deb_dependencies_satisfied "$scratch/satisfied.deb"
+if assert_deb_dependencies_satisfied "$scratch/unsatisfied.deb"; then
+    printf 'expected unsatisfied dependency expression to fail\n' >&2
+    exit 1
+fi
+
+printf 'pilothouse-sysext-test: PASSED\n'

--- a/yeti/sysexts.md
+++ b/yeti/sysexts.md
@@ -34,7 +34,7 @@ Sysexts are overlay images that extend the immutable base OS by adding files und
 | **lemonade** | lemonade-server | Lemonade local LLM server (lemond) — downloaded via `verified_download()` from lemonade-sdk/lemonade GitHub releases; libcpp-httplib0.41 dep from trixie-backports |
 | **nix** | nix-setup-systemd | Nix package manager with systemd integration |
 | **paseo** | paseo | Paseo coding agent workspace desktop app (pinned .deb via verified_download from getpaseo/paseo GitHub releases, relocated from /opt) |
-| **pilothouse** | frostyard-pilothouse | Pilothouse local web administration console for Snosi (pilothouse web UI + pilothoused root broker) — downloaded via `verified_download()` from frostyard/pilothouse GitHub releases |
+| **pilothouse** | frostyard-pilothouse | Pilothouse web administration with capability-gated Updex/container backends (web UI + root broker) — downloaded via `verified_download()` from frostyard/pilothouse GitHub releases |
 | **podman** | podman | Podman, distrobox, buildah, crun, slirp4netns |
 | **sunshine** | sunshine | Sunshine self-hosted game streaming host (official pinned Trixie .deb via verified_download) |
 | **tailscale** | tailscale | Tailscale VPN client |
@@ -231,12 +231,13 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `usr/lib/tmpfiles.d/nix.conf` — `/nix` hierarchy + factory config injection
 
 ### pilothouse
-- `mkosi.postinst.chroot` — Downloads the frostyard-pilothouse .deb (GitHub release, no apt repo) via `verified_download()`, installs with `dpkg -i`. Static Go binaries (no Depends), everything ships natively under `/usr`; no relocation
+- `mkosi.postinst.chroot` — Downloads the frostyard-pilothouse .deb (GitHub release, no apt repo) via `verified_download()`, then uses `shared/download/deb-dependencies.sh` to verify its declared `Depends` against the merged buildroot before `dpkg -i` can mutate it. Runtime dependencies must be explicit in `Packages=` or supplied by the base; everything ships natively under `/usr`, so no relocation is needed
 - `mkosi.finalize` — Captures `/etc/pam.d/pilothouse` to factory defaults; `pilothoused` authenticates admin actions through the "pilothouse" PAM service and sysexts cannot ship `/etc`
 - The deb's own `usr/lib/sysusers.d/pilothouse.conf` creates the `pilothouse` user/group at boot (ships in `/usr`, so it survives the delta — no extra sysusers fragment needed)
 - `usr/lib/tmpfiles.d/pilothouse.conf` — Factory PAM config injection
 - `usr/lib/systemd/system-preset/40-pilothouse.preset` — Enables `pilothoused.service` (root broker on `/run/pilothouse/broker.sock`) and `pilothouse.service` (web UI on 127.0.0.1:8888)
 - `usr/lib/systemd/system/multi-user.target.d/10-pilothouse.conf` — `Upholds=pilothoused.service pilothouse.service` drop-in for reliable boot activation
+- `usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf` — Resets only `pilothoused.service`'s broker command while retaining the package's socket, socket-group, and sudo admin-group arguments. It explicitly opts in to `--updex /usr/bin/updex`, `--podman-socket /run/podman/podman.sock`, `--docker unix:///var/run/docker.sock`, and `--incus`. These flags permit Pilothouse probes but do not force registration or make startup fail when an executable or socket endpoint is unavailable
 
 ### tailscale
 - `mkosi.finalize` — Captures `/etc/default/tailscaled` to factory defaults (tailscaled requires the EnvironmentFile)


### PR DESCRIPTION
## Summary
- pin Pilothouse 0.7.0 and override the broker command to explicitly configure Updex, Podman, Docker, and Incus while preserving Debian socket and administrator arguments
- fail Pilothouse sysext builds before installation when the downloaded DEB declares dependencies absent from the merged buildroot
- add systemd, argument-cardinality, dependency-expression, and version-floor regression coverage plus integration documentation

## Testing
- `./test/pilothouse-sysext-test.sh`
- `./test/sysext-required-paths-test.sh`
- `./check-runtime-etc-guard.sh`
- `bash -n shared/download/deb-dependencies.sh mkosi.images/pilothouse/mkosi.postinst.chroot test/pilothouse-sysext-test.sh`
- `shellcheck shared/download/deb-dependencies.sh mkosi.images/pilothouse/mkosi.postinst.chroot test/pilothouse-sysext-test.sh`
- `actionlint .github/workflows/validate.yml`
- `jq empty shared/download/sysext-checksums.json`
- `git diff --check`

Closes #479
Closes #469