### PR TITLE
fix(task9): re-arm swtpm before the pre-MOK boot

### DIFF
--- a/test/bootc-secure-install-test.sh
+++ b/test/bootc-secure-install-test.sh
@@ -445,6 +445,13 @@ run_live() {
     SNOSI_SECURE_TPM_SOCKET="$SECURE_VM_TPM_SOCK" \
     run_marked_runner "$BOOTC_SECURE_INSTALLER" 'BOOTC_SECURE_INSTALLER: installed' \
         --non-interactive --iso "$DAKOTA_ISO" --recipe "$WORK/recipe.json"
+    # swtpm exits when its QEMU client does, and the installer runner's QEMU has
+    # just exited -- so without re-arming, this boot dies at
+    #   -chardev socket,id=tpmchr,path=.../swtpm-ctrl.sock: Failed to connect
+    # Same state directory, never reinitialised: the sealed TPM state lives
+    # there and a fresh one would silently invalidate the enrollment. This
+    # mirrors what the post-enrollment boot below already does.
+    secure_vm_start_swtpm_paths "$WORK/tpm" "$WORK/tpm/swtpm-ctrl.sock" "$WORK/tpm/swtpm.pid"
     start_vm
     pre_mok_rejection
     stop_vm


### PR DESCRIPTION
Reached for the first time because the secure install now completes — the previous run reported `{"message":"Installation complete!"}`, and the harness then failed on its own first boot:

```
qemu-system-x86_64: -chardev socket,id=tpmchr,path=.../swtpm-ctrl.sock: Failed to connect
```

swtpm exits when its QEMU client does, and the installer runner's QEMU has just exited by this point. The post-enrollment boot further down **already** re-arms swtpm before starting; the pre-MOK boot did not — and had never been reached, because nothing had ever got a secure install to complete.

Restarts against the **same state directory**. It must never be reinitialised: the sealed TPM state lives there, and a fresh one would silently invalidate the enrollment rather than fail loudly — which is the failure mode worth avoiding, since a silently-unenrolled TPM would make a later "unattended unlock" result meaningless.

`test/bootc-secure-install-test.sh --fixtures`: 44 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)