### PR TITLE
test(download): cover update-checksums.sh split-file key selection

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -149,6 +149,15 @@ jobs:
         # hooks. No root, no bind mount, no image build.
         run: ./test/snosi-etc-diff-test.sh
 
+      - name: Validate update-checksums split-file selection
+        # shared/download/update-checksums.sh resolves an existing key by
+        # searching sysext-checksums.json then image-checksums.json relative to
+        # its own directory, with CHECKSUMS_FILE as an explicit single-file
+        # override. Fixture test against a throwaway copy of that layout and
+        # file:// payloads: asserts the update lands in the right file and the
+        # siblings stay byte-identical. No root, no network, no image build.
+        run: ./test/update-checksums-split-test.sh
+
       - name: Validate sysext required paths finalizer
         # Fixture regression test for whitespace-preserving parsing of sysext
         # required-paths.txt entries. No root, network, or image build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1569,6 +1569,7 @@ The shared sysext postoutput script (`shared/sysext/postoutput/sysext-postoutput
 - External direct downloads must go through `verified_download()` with entries in `sysext-checksums.json` for sysext consumers or `image-checksums.json` for OCI profile consumers
 - Pin external URLs to specific versions/commits, never `latest` or branch names
 - When adding a new verified download, also add a corresponding update check to `.github/workflows/check-dependencies.yml`; sysext APT package sentinels go in `.github/workflows/check-packages.yml`
+- Both halves of the split checksum metadata (`sysext-checksums.json`, `image-checksums.json`) are covered by fixture tests: `test/verified-download-split-checksums-test.sh` for the read side (`verified_download`) and `test/update-checksums-split-test.sh` for the write side (`update-checksums.sh`'s ordered file selection, `CHECKSUMS_FILE` override, missing-file/absent-key hard-fails, and the no-partial-write guarantee). See `yeti/build-pipeline.md` "Verified Download System" for the exact rules those tests pin.
 
 ## User Service Enablement in Chroot
 

--- a/test/update-checksums-split-test.sh
+++ b/test/update-checksums-split-test.sh
@@ -1,0 +1,282 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Focused regression test for shared/download/update-checksums.sh's split
+# checksum metadata selection (issue #389, companion to
+# test/verified-download-split-checksums-test.sh, which covers the read side).
+#
+# The script resolves an existing key by searching sysext-checksums.json and
+# then image-checksums.json relative to its OWN directory, with CHECKSUMS_FILE
+# as an explicit single-file override. Every case below runs the real script
+# from a throwaway copy of that directory layout, against file:// payloads, and
+# asserts BOTH that the intended file changed and that the sibling files are
+# untouched byte for byte.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_SCRIPT="$PROJECT_ROOT/shared/download/update-checksums.sh"
+WORK_DIR=""
+PASS=0
+FAIL=0
+
+cleanup() {
+    if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+record_pass() {
+    echo "ok - $1"
+    (( PASS++ )) || true
+}
+
+record_fail() {
+    echo "not ok - $1"
+    if [[ $# -gt 1 ]]; then
+        echo "  $2" >&2
+    fi
+    (( FAIL++ )) || true
+}
+
+assert_equals() {
+    local desc="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [[ "$actual" == "$expected" ]]; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "expected '$expected', got '$actual'"
+    fi
+}
+
+assert_json() {
+    local desc="$1"
+    local file="$2"
+    local filter="$3"
+    local expected="$4"
+
+    if [[ ! -f "$file" ]]; then
+        record_fail "$desc" "missing file: $file"
+        return
+    fi
+
+    assert_equals "$desc" "$expected" "$(jq -r "$filter" "$file")"
+}
+
+# Every case snapshots its metadata files before running the script; this
+# asserts a file the script must not have touched is still byte-identical.
+assert_unchanged() {
+    local desc="$1"
+    local dir="$2"
+    local name="$3"
+
+    if [[ ! -f "$dir/$name" ]]; then
+        record_fail "$desc" "missing file: $dir/$name"
+        return
+    fi
+
+    if cmp -s "$dir/before/$name" "$dir/$name"; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "$name was modified: $(diff "$dir/before/$name" "$dir/$name" | tr '\n' ' ')"
+    fi
+}
+
+assert_stderr_contains() {
+    local desc="$1"
+    local dir="$2"
+    local needle="$3"
+
+    if grep -qF -- "$needle" "$dir/stderr.log"; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "stderr lacked '$needle': $(cat "$dir/stderr.log")"
+    fi
+}
+
+sha256_of() {
+    sha256sum "$1" | cut -d' ' -f1
+}
+
+write_entry_json() {
+    local path="$1"
+    local key="$2"
+    local version="$3"
+
+    cat >"$path" <<JSON
+{
+  "$key": {
+    "url": "file://$WORK_DIR/payloads/stale.txt",
+    "sha256": "$STALE_SHA",
+    "version": "$version"
+  }
+}
+JSON
+}
+
+# Builds an isolated copy of shared/download/ for one case. Extra arguments
+# name metadata files to omit, so the "a default file is missing" branches can
+# be exercised without mutating a shared fixture.
+new_case() {
+    local name="$1"; shift
+    local dir="$WORK_DIR/cases/$name"
+    local omit=" $* "
+
+    mkdir -p "$dir/before"
+    cp "$SOURCE_SCRIPT" "$dir/update-checksums.sh"
+    chmod +x "$dir/update-checksums.sh"
+
+    [[ "$omit" == *" sysext-checksums.json "* ]] || \
+        write_entry_json "$dir/sysext-checksums.json" "sysext-fixture" "sysext-old"
+    [[ "$omit" == *" image-checksums.json "* ]] || \
+        write_entry_json "$dir/image-checksums.json" "image-fixture" "image-old"
+    [[ "$omit" == *" override-checksums.json "* ]] || \
+        write_entry_json "$dir/override-checksums.json" "sysext-fixture" "override-old"
+
+    cp "$dir"/*-checksums.json "$dir/before/"
+    echo "$dir"
+}
+
+# Runs the real script inside a case directory (its $0 dirname is what selects
+# the metadata files) and records the exit status in RUN_STATUS.
+run_update() {
+    local dir="$1"; shift
+
+    RUN_STATUS=0
+    ( cd "$dir" && ./update-checksums.sh "$@" ) \
+        >"$dir/stdout.log" 2>"$dir/stderr.log" || RUN_STATUS=$?
+}
+
+[[ -f "$SOURCE_SCRIPT" ]] || { echo "Error: script not found: $SOURCE_SCRIPT" >&2; exit 1; }
+command -v jq >/dev/null || { echo "Error: jq is required" >&2; exit 1; }
+
+WORK_DIR="$(mktemp -d)"
+mkdir -p "$WORK_DIR/payloads" "$WORK_DIR/cases"
+
+printf 'stale payload fixture' >"$WORK_DIR/payloads/stale.txt"
+printf 'fresh payload fixture' >"$WORK_DIR/payloads/fresh.txt"
+STALE_SHA="$(sha256_of "$WORK_DIR/payloads/stale.txt")"
+FRESH_SHA="$(sha256_of "$WORK_DIR/payloads/fresh.txt")"
+FRESH_URL="file://$WORK_DIR/payloads/fresh.txt"
+
+echo "# update-checksums.sh split checksum metadata selection"
+
+# --- Key present only in sysext-checksums.json --------------------------------
+CASE_DIR="$(new_case sysext-key)"
+run_update "$CASE_DIR" sysext-fixture "$FRESH_URL" sysext-new
+assert_equals "sysext-only key: script succeeds" 0 "$RUN_STATUS"
+assert_json "sysext-only key: url updated in sysext-checksums.json" \
+    "$CASE_DIR/sysext-checksums.json" '."sysext-fixture".url' "$FRESH_URL"
+assert_json "sysext-only key: sha256 updated in sysext-checksums.json" \
+    "$CASE_DIR/sysext-checksums.json" '."sysext-fixture".sha256' "$FRESH_SHA"
+assert_json "sysext-only key: version updated in sysext-checksums.json" \
+    "$CASE_DIR/sysext-checksums.json" '."sysext-fixture".version' "sysext-new"
+assert_unchanged "sysext-only key: image-checksums.json untouched" \
+    "$CASE_DIR" image-checksums.json
+assert_unchanged "sysext-only key: override-checksums.json untouched" \
+    "$CASE_DIR" override-checksums.json
+
+# --- Key present only in image-checksums.json ---------------------------------
+CASE_DIR="$(new_case image-key)"
+run_update "$CASE_DIR" image-fixture "$FRESH_URL" image-new
+assert_equals "image-only key: script succeeds" 0 "$RUN_STATUS"
+assert_json "image-only key: url updated in image-checksums.json" \
+    "$CASE_DIR/image-checksums.json" '."image-fixture".url' "$FRESH_URL"
+assert_json "image-only key: sha256 updated in image-checksums.json" \
+    "$CASE_DIR/image-checksums.json" '."image-fixture".sha256' "$FRESH_SHA"
+assert_json "image-only key: version updated in image-checksums.json" \
+    "$CASE_DIR/image-checksums.json" '."image-fixture".version' "image-new"
+assert_unchanged "image-only key: sysext-checksums.json untouched" \
+    "$CASE_DIR" sysext-checksums.json
+
+# --- Optional version argument ------------------------------------------------
+CASE_DIR="$(new_case omitted-version)"
+run_update "$CASE_DIR" sysext-fixture "$FRESH_URL"
+assert_equals "omitted version: script succeeds" 0 "$RUN_STATUS"
+assert_json "omitted version: sha256 still updated" \
+    "$CASE_DIR/sysext-checksums.json" '."sysext-fixture".sha256' "$FRESH_SHA"
+assert_json "omitted version: existing version preserved" \
+    "$CASE_DIR/sysext-checksums.json" '."sysext-fixture".version' "sysext-old"
+
+# --- Key absent from both split files -----------------------------------------
+CASE_DIR="$(new_case missing-key)"
+run_update "$CASE_DIR" absent-fixture "$FRESH_URL" absent-new
+assert_equals "absent key: script fails" 1 "$RUN_STATUS"
+assert_stderr_contains "absent key: reports split metadata lookup failure" \
+    "$CASE_DIR" "Key 'absent-fixture' not found in split checksum metadata"
+assert_unchanged "absent key: sysext-checksums.json untouched" \
+    "$CASE_DIR" sysext-checksums.json
+assert_unchanged "absent key: image-checksums.json untouched" \
+    "$CASE_DIR" image-checksums.json
+
+# --- CHECKSUMS_FILE override --------------------------------------------------
+# The key also exists in sysext-checksums.json, so this proves the override
+# short-circuits the search rather than merely agreeing with it.
+CASE_DIR="$(new_case override)"
+CHECKSUMS_FILE="$CASE_DIR/override-checksums.json" \
+    run_update "$CASE_DIR" sysext-fixture "$FRESH_URL" override-new
+assert_equals "CHECKSUMS_FILE override: script succeeds" 0 "$RUN_STATUS"
+assert_json "CHECKSUMS_FILE override: sha256 updated in the named file" \
+    "$CASE_DIR/override-checksums.json" '."sysext-fixture".sha256' "$FRESH_SHA"
+assert_json "CHECKSUMS_FILE override: version updated in the named file" \
+    "$CASE_DIR/override-checksums.json" '."sysext-fixture".version' "override-new"
+assert_unchanged "CHECKSUMS_FILE override: sysext-checksums.json untouched" \
+    "$CASE_DIR" sysext-checksums.json
+assert_unchanged "CHECKSUMS_FILE override: image-checksums.json untouched" \
+    "$CASE_DIR" image-checksums.json
+
+# --- CHECKSUMS_FILE override reaches a file outside the split pair -------------
+CASE_DIR="$(new_case override-missing-defaults)"
+rm -f "$CASE_DIR/sysext-checksums.json" "$CASE_DIR/image-checksums.json"
+CHECKSUMS_FILE="$CASE_DIR/override-checksums.json" \
+    run_update "$CASE_DIR" sysext-fixture "$FRESH_URL" override-new
+assert_equals "CHECKSUMS_FILE override: does not require the default files" \
+    0 "$RUN_STATUS"
+assert_json "CHECKSUMS_FILE override: named file updated without defaults" \
+    "$CASE_DIR/override-checksums.json" '."sysext-fixture".sha256' "$FRESH_SHA"
+
+# --- A default metadata file is missing ---------------------------------------
+# Current behavior, locked in deliberately: the search hard-fails on the first
+# missing candidate, so a key that only image-checksums.json carries is
+# unreachable when sysext-checksums.json is absent.
+CASE_DIR="$(new_case missing-sysext-file sysext-checksums.json)"
+run_update "$CASE_DIR" image-fixture "$FRESH_URL" image-new
+assert_equals "missing sysext-checksums.json: hard-fails before image lookup" \
+    1 "$RUN_STATUS"
+assert_stderr_contains "missing sysext-checksums.json: reports the missing file" \
+    "$CASE_DIR" "Error: Checksums file not found:"
+assert_unchanged "missing sysext-checksums.json: image-checksums.json untouched" \
+    "$CASE_DIR" image-checksums.json
+
+# The search stops at the first matching candidate, so a missing
+# image-checksums.json is never noticed for a sysext key.
+CASE_DIR="$(new_case missing-image-file image-checksums.json)"
+run_update "$CASE_DIR" sysext-fixture "$FRESH_URL" sysext-new
+assert_equals "missing image-checksums.json: sysext key still resolves" \
+    0 "$RUN_STATUS"
+assert_json "missing image-checksums.json: sysext-checksums.json updated" \
+    "$CASE_DIR/sysext-checksums.json" '."sysext-fixture".sha256' "$FRESH_SHA"
+
+# A missing image-checksums.json IS fatal once the search has to look at it.
+CASE_DIR="$(new_case missing-image-file-absent-key image-checksums.json)"
+run_update "$CASE_DIR" absent-fixture "$FRESH_URL" absent-new
+assert_equals "missing image-checksums.json: absent key hard-fails" 1 "$RUN_STATUS"
+assert_stderr_contains "missing image-checksums.json: reports the missing file" \
+    "$CASE_DIR" "Error: Checksums file not found:"
+
+# --- Download failure leaves metadata untouched -------------------------------
+CASE_DIR="$(new_case download-failure)"
+run_update "$CASE_DIR" sysext-fixture "file://$WORK_DIR/payloads/does-not-exist.txt" \
+    sysext-new
+if [[ "$RUN_STATUS" -eq 0 ]]; then
+    record_fail "unfetchable URL: script fails" "script unexpectedly succeeded"
+else
+    record_pass "unfetchable URL: script fails"
+fi
+assert_unchanged "unfetchable URL: sysext-checksums.json untouched" \
+    "$CASE_DIR" sysext-checksums.json
+
+echo ""
+echo "# Results: $PASS passed, $FAIL failed, $(( PASS + FAIL )) total"
+exit "$FAIL"

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -474,6 +474,26 @@ checksum file already contains the key:
 ./update-checksums.sh <key> <url> [version]
 ```
 
+Selection rules, locked in by `test/update-checksums-split-test.sh` (fixture
+test, wired into `validate.yml`; the read side is covered by
+`test/verified-download-split-checksums-test.sh`):
+
+- The search is ordered — `sysext-checksums.json` first, then
+  `image-checksums.json` — and stops at the first file that `has()` the key,
+  so exactly one file is ever rewritten and the siblings stay byte-identical.
+- A key present in neither file is an error (`Key '...' not found in split
+  checksum metadata`); the script never creates a key through the search path.
+- `CHECKSUMS_FILE` short-circuits the search entirely: it rewrites that one
+  file (creating the key if absent) and does not require either default file to
+  exist.
+- A *missing* default file is a hard error, not a skip — but only if the search
+  actually reaches it. A sysext key still resolves when `image-checksums.json`
+  is absent (the loop breaks first), while an image key is unreachable when
+  `sysext-checksums.json` is absent. This asymmetry is current behavior; the
+  test pins it so a deliberate change to it is visible rather than accidental.
+- Any failure before the `jq` rewrite (unfetchable URL, missing file, unknown
+  key) leaves every metadata file untouched.
+
 ## Tree Overlays
 
 Each profile has filesystem overlays (ExtraTrees) that are merged into the image:


### PR DESCRIPTION
Closes #389.

## Problem

PR #387 taught `shared/download/update-checksums.sh` to locate an existing key by searching the split checksum files (`sysext-checksums.json`, then `image-checksums.json`), with `CHECKSUMS_FILE` as an explicit override. `test/verified-download-split-checksums-test.sh` (same PR) covers the **read** side thoroughly; the **write** side had no coverage at all.

## What this adds

`test/update-checksums-split-test.sh` — a fixture test that runs the real script from a throwaway copy of the `shared/download/` layout against `file://` payloads. Every case snapshots all metadata files first, so it asserts both that the intended file changed **and** that the siblings are still byte-identical:

| Case | Asserted behavior |
| --- | --- |
| key only in `sysext-checksums.json` | that file's url/sha256/version updated, others untouched |
| key only in `image-checksums.json` | that file updated, `sysext-checksums.json` untouched |
| version argument omitted | url/sha256 updated, existing `version` preserved |
| key in neither file | fails with `Key '...' not found in split checksum metadata`, no writes |
| `CHECKSUMS_FILE` set | rewrites only that file — proven with a key that *also* exists in `sysext-checksums.json`, so it shows the override short-circuits the search rather than merely agreeing with it; also works with neither default file present |
| a default file missing | hard-fails, but **only when the ordered search reaches it**: a sysext key still resolves with `image-checksums.json` absent (the loop breaks first), while an image key is unreachable with `sysext-checksums.json` absent |
| unfetchable URL | fails before the `jq` rewrite, metadata untouched |

34 assertions, all green.

The missing-file asymmetry is the issue's "worth locking in or reconsidering" item. This PR **locks in current behavior** rather than changing it — the test documents the asymmetry explicitly, so altering it later becomes a deliberate, visible decision instead of an accidental one.

## Regression-detection check

The test was validated against three mutations of `update-checksums.sh`, each caught:

| Mutation | Result |
| --- | --- |
| candidate search order reversed | 5 failures |
| `CHECKSUMS_FILE` override ignored | 5 failures |
| absent-key guard removed (falls back to first file) | 3 failures |

`update-checksums.sh` itself is unchanged (`git diff` clean after each mutation was reverted).

## CI + docs

Wired into `validate.yml` (no root, no network, no image build; `shellcheck -S warning -x` clean, `actionlint` clean). Rules pinned by the test are documented in `yeti/build-pipeline.md` "Verified Download System", with a pointer from CLAUDE.md's Shell Script Conventions.

Wiring the *sibling* `verified-download-split-checksums-test.sh` into CI is separate issue #388 and is deliberately not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)