### PR TITLE
fix(images): remove frostyard-igloo

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,6 @@ The Frostyard repository provides custom packages for Snow Linux:
 - **nbc** (Not BootC): CLI tool for installing, updating bootc-compatible container based Operating Systems
 - **chairlift**: System extension manager with GUI integration
 - **updex**: Update executor service for applying staged updates
-- **igloo**: System configuration tool
 - **intuneme**: Intune management agent
 - **snow-first-setup**: First-boot setup wizard
 

--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -30,9 +30,8 @@ Frostyard workspace root (the parent of `snosi/`).
 | nbc | `frostyard-nbc` | `snosi/mkosi.images/base/mkosi.conf:44` | all images (legacy updater) |
 | updex | `frostyard-updex` | `snosi/mkosi.images/base/mkosi.conf:45` | all images (sysext feature/update manager) |
 | chairlift | `frostyard-chairlift` | `snosi/shared/packages/snow/mkosi.conf:6` | snow, snowfield (+ `-ab`) |
-| igloo | `frostyard-igloo` | `snosi/shared/packages/snow/mkosi.conf:7` | snow, snowfield (+ `-ab`) |
-| snow-first-setup | `snow-first-setup` | `snosi/shared/packages/snow/mkosi.conf:8` | snow, snowfield (+ `-ab`) |
-| intuneme | `frostyard-intuneme` | `snosi/shared/packages/snow/mkosi.conf:67` | snow, snowfield (+ `-ab`) |
+| snow-first-setup | `snow-first-setup` | `snosi/shared/packages/snow/mkosi.conf:7` | snow, snowfield (+ `-ab`) |
+| intuneme | `frostyard-intuneme` | `snosi/shared/packages/snow/mkosi.conf:66` | snow, snowfield (+ `-ab`) |
 | bootc | `bootc` | `snosi/shared/packages/bootc/mkosi.conf:4` | bootc profiles (cayo, snow, snowfield) |
 | ostree | `libostree-1-1` | `snosi/shared/packages/bootc/mkosi.conf:5` | bootc profiles |
 | pilothouse | `frostyard-pilothouse` | `snosi/mkosi.images/pilothouse/mkosi.conf:23` (sysext) | opt-in sysext, all products |
@@ -55,9 +54,9 @@ wrap third-party tools). It is a pinned GitHub-release `.deb`
 | `repogen` | APT repo layout + sysext repo layout at `repository.frostyard.org` | snosi APT sources + `.transfer` files |
 | `snosi` | native OS + installer-ISO layout at `repository.frostyard.org` | snosi `.transfer` files, installer redirect Worker |
 
-`igloo` and `intuneme` have **no** update/sysext/native-OS integration
-(confirmed exhaustively) — they are Incus-container tools. They are listed for
-completeness and excluded from the contract catalog below.
+`intuneme` has **no** update/sysext/native-OS integration (confirmed
+exhaustively) — it is an Incus-container tool. It is listed for completeness
+and excluded from the contract catalog below.
 
 ---
 

--- a/docs/plans/2026-07-20-update-api-daemon-design.md
+++ b/docs/plans/2026-07-20-update-api-daemon-design.md
@@ -105,7 +105,7 @@ thin snosi service that composes updex's schema with transport detection.
   instead of reducing it.
 - **Forcing chairlift off its type-safe Go SDK.** That is a regression from 🟢
   to 🟡 for no benefit.
-- **Pulling igloo / intuneme / first-setup / repogen "under" the daemon.** The
+- **Pulling intuneme / first-setup / repogen "under" the daemon.** The
   map confirms these have zero update/sysext coupling. "& friends" is exactly
   where this idea over-reaches.
 

--- a/shared/packages/snow/mkosi.conf
+++ b/shared/packages/snow/mkosi.conf
@@ -4,7 +4,6 @@ BaseTrees=%O/base
 # Sysext base requirements
 # Keep package metadata so sysexts can properly extend
 Packages=frostyard-chairlift
-         frostyard-igloo
          snow-first-setup
 
 # Plymouth

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1345,7 +1345,7 @@ Target-image APT repositories are configured in `mkosi.sandbox/etc/apt/` with GP
 - Debian Backports — Newer kernel + firmware + mesa
 - Debian Griffo.io (debian.griffo.io) — Additional Debian packages
 - Docker (docker.com) — Docker CE packages
-- Frostyard (repository.frostyard.org) — Custom packages: bootc, libostree-1-1 (built by frostyard/bootc-debian), nbc, chairlift, updex, igloo, intuneme, snow-first-setup.
+- Frostyard (repository.frostyard.org) — Custom packages: bootc, libostree-1-1 (built by frostyard/bootc-debian), nbc, chairlift, updex, intuneme, snow-first-setup.
 - Linux Surface (pkg.surfacelinux.com) — Surface kernel + tools
 - Microsoft Edge (packages.microsoft.com) — Edge browser
 - Microsoft VSCode (packages.microsoft.com) — VS Code editor


### PR DESCRIPTION
## Summary

- remove `frostyard-igloo` from the shared Snow package composition
- remove stale Igloo references from package inventories and documentation

## Validation

- `./check-duplicate-packages.sh`
- `git diff --check`
- confirmed no `frostyard-igloo` or `igloo` references remain

Closes #513