### PR TITLE
test: validate secure bootc root cryptsetup generation

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -187,15 +187,23 @@ jobs:
             "org.opencontainers.image.url=https://github.com/${{ github.repository_owner }}/${{ env.REPO_NAME }}/tree/${{ github.sha }}" \
             "org.opencontainers.image.documentation=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.REPO_NAME }}/${{ github.sha }}/README.md"
 
+      - name: Install secure artifact validation dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends dracut-core
+
       - name: Validate locally assembled secure artifact
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
         run: |
-          sudo ./test/bootc-secure-artifact-test.sh \
+          sudo SNOSI_REQUIRE_GPT_AUTO_VALIDATION=1 \
+            ./test/bootc-secure-artifact-test.sh \
             "output/${{ matrix.profile }}" \
             "$IMAGE:${{ steps.version.outputs.tag }}" \
             /var/tmp/bootc-secure-credentials/mok.crt \
             /var/tmp/bootc-secure-credentials/pcr.pub
+          echo '- Real assembled UKI: initramfs gpt-auto structural validation passed.' \
+            >> "$GITHUB_STEP_SUMMARY"
 
       - name: Remove protected bootc signing credentials
         if: always()
@@ -300,7 +308,8 @@ jobs:
         env:
           LOCAL_REF: localhost/snosi-verified-${{ matrix.profile }}:${{ steps.version.outputs.tag }}
         run: |
-          sudo ./test/bootc-secure-artifact-test.sh \
+          sudo SNOSI_REQUIRE_GPT_AUTO_VALIDATION=1 \
+            ./test/bootc-secure-artifact-test.sh \
             "output/${{ matrix.profile }}" "$LOCAL_REF" \
             "output/${{ matrix.profile }}/usr/lib/snosi/mok.crt" \
             "output/${{ matrix.profile }}/usr/lib/snosi/pcr-signing.pub"

--- a/test/bootc-secure-artifact-test.sh
+++ b/test/bootc-secure-artifact-test.sh
@@ -20,9 +20,63 @@ PCR_CERT=${4:?Usage: $0 ROOTFS OCI_IMAGE_REF MOK_CERT PCR_CERT [PREVIOUS_PCR_CER
 PREVIOUS_PCR_CERT=${5:-}
 
 [[ -d "$ROOTFS" ]] || { echo "Error: missing rootfs: $ROOTFS" >&2; exit 1; }
-for command in buildah jq objcopy objdump openssl podman sbverify; do
+for command in buildah chroot jq lsinitrd objcopy objdump openssl podman sbverify; do
     command -v "$command" >/dev/null || { echo "BLOCKED: missing $command" >&2; exit 2; }
 done
 
+if (( EUID != 0 )); then
+    echo "BLOCKED: bootc secure artifact validation must run as root" >&2
+    exit 2
+fi
+
+validate_gpt_auto_cryptsetup() {
+    local uki initrd initrd_root generator_root generator unit
+    uki=$(find "$ROOTFS/boot/EFI/Linux" -maxdepth 1 -type f -name '*.efi' -print -quit)
+    [[ -n $uki ]] || { echo "Error: assembled UKI is missing" >&2; return 1; }
+
+    initrd=$(mktemp)
+    initrd_root=$(mktemp -d)
+    trap 'rm -f "$initrd"; rm -rf "$initrd_root"' RETURN
+    objcopy --dump-section ".initrd=$initrd" "$uki"
+    (
+        cd "$initrd_root"
+        lsinitrd --unpack "$initrd"
+    )
+
+    generator=/usr/lib/systemd/system-generators/systemd-gpt-auto-generator
+    [[ -x "$initrd_root$generator" ]] || {
+        echo "Error: initramfs is missing $generator" >&2
+        return 1
+    }
+
+    generator_root=/run/snosi-gpt-auto-generator-test
+    mkdir -p \
+        "$initrd_root$generator_root/normal" \
+        "$initrd_root$generator_root/early" \
+        "$initrd_root$generator_root/late"
+    SYSTEMD_IN_INITRD=1 \
+    SYSTEMD_IN_CHROOT=0 \
+    SYSTEMD_PROC_CMDLINE='root=gpt-auto-force' \
+    SYSTEMD_VIRTUALIZATION=none \
+        chroot "$initrd_root" "$generator" \
+            "$generator_root/normal" \
+            "$generator_root/early" \
+            "$generator_root/late"
+
+    unit="$initrd_root$generator_root/late/systemd-cryptsetup@root.service"
+    [[ -f $unit ]] || {
+        echo "Error: initramfs gpt-auto-generator did not emit systemd-cryptsetup@root.service" >&2
+        return 1
+    }
+    grep -Fq "ExecStart=/usr/lib/systemd/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks'" "$unit"
+    grep -Fq 'BindsTo=dev-gpt\x2dauto\x2droot\x2dluks.device' "$unit"
+    find "$initrd_root$generator_root/late" -type l \
+        -lname '../systemd-cryptsetup@root.service' -print -quit | grep -q . || {
+        echo "Error: generated root cryptsetup unit has no LUKS device dependency" >&2
+        return 1
+    }
+}
+
 "$ASSEMBLER" --validate "$ROOTFS" "$IMAGE" "$MOK_CERT" "$PCR_CERT" "$PREVIOUS_PCR_CERT"
+validate_gpt_auto_cryptsetup
 echo "bootc secure artifact validation passed"

--- a/test/bootc-secure-artifact-test.sh
+++ b/test/bootc-secure-artifact-test.sh
@@ -14,11 +14,19 @@ validate_gpt_auto_cryptsetup() (
     local uki scratch initrd initrd_root generator_root generator unit
     for command in chroot lsinitrd objcopy; do
         if ! command -v "$command" >/dev/null; then
+            if [[ ${SNOSI_REQUIRE_GPT_AUTO_VALIDATION:-0} == 1 ]]; then
+                echo "Error: required initramfs gpt-auto validation is missing $command" >&2
+                return 1
+            fi
             echo "SKIP: initramfs gpt-auto validation requires $command" >&2
             return 0
         fi
     done
     if (( EUID != 0 )) && [[ ${SNOSI_GPT_AUTO_FIXTURE:-0} != 1 ]]; then
+        if [[ ${SNOSI_REQUIRE_GPT_AUTO_VALIDATION:-0} == 1 ]]; then
+            echo "Error: required initramfs gpt-auto validation needs root for chroot" >&2
+            return 1
+        fi
         echo "SKIP: initramfs gpt-auto validation requires root for chroot" >&2
         return 0
     fi
@@ -78,6 +86,7 @@ validate_gpt_auto_cryptsetup() (
         echo "Error: generated root cryptsetup unit has no LUKS device dependency" >&2
         return 1
     }
+    echo "bootc secure initramfs gpt-auto structural validation passed"
 )
 
 gpt_auto_fixture() (
@@ -91,7 +100,10 @@ gpt_auto_fixture() (
     cat >"$fixture/bin/objcopy" <<'EOF'
 #!/bin/bash
 set -euo pipefail
-[[ $# -eq 4 && $1 == --dump-section && $2 == .initrd=* ]]
+[[ $# -eq 4 && $1 == --dump-section && $2 == .initrd=* ]] || {
+    echo "stub objcopy: expected dump section, input, and explicit output arguments" >&2
+    exit 1
+}
 printf 'initrd fixture\n' >"${2#.initrd=}"
 cp -- "$3" "$4"
 EOF

--- a/test/bootc-secure-artifact-test.sh
+++ b/test/bootc-secure-artifact-test.sh
@@ -6,38 +6,35 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ASSEMBLER="$ROOT_DIR/shared/bootc-secure/assemble-uki.sh"
 
-if [[ ${1:-} == --fixtures ]]; then
-    "$ASSEMBLER" --self-test
-    "$ASSEMBLER" --credential-self-test
-    echo "bootc secure artifact fixtures passed"
-    exit 0
-fi
+# This is a structural initramfs check. Forced discovery proves that the exact
+# embedded generator can emit a root cryptsetup unit and has cryptsetup support;
+# it does not exercise production EFI discovery or reproduce issue 517's VM
+# failure. That remains the responsibility of the secure-install VM lane.
+validate_gpt_auto_cryptsetup() (
+    local uki scratch initrd initrd_root generator_root generator unit
+    for command in chroot lsinitrd objcopy; do
+        if ! command -v "$command" >/dev/null; then
+            echo "SKIP: initramfs gpt-auto validation requires $command" >&2
+            return 0
+        fi
+    done
+    if (( EUID != 0 )) && [[ ${SNOSI_GPT_AUTO_FIXTURE:-0} != 1 ]]; then
+        echo "SKIP: initramfs gpt-auto validation requires root for chroot" >&2
+        return 0
+    fi
 
-ROOTFS=${1:?Usage: $0 ROOTFS OCI_IMAGE_REF MOK_CERT PCR_CERT [PREVIOUS_PCR_CERT]}
-IMAGE=${2:?Usage: $0 ROOTFS OCI_IMAGE_REF MOK_CERT PCR_CERT [PREVIOUS_PCR_CERT]}
-MOK_CERT=${3:?Usage: $0 ROOTFS OCI_IMAGE_REF MOK_CERT PCR_CERT [PREVIOUS_PCR_CERT]}
-PCR_CERT=${4:?Usage: $0 ROOTFS OCI_IMAGE_REF MOK_CERT PCR_CERT [PREVIOUS_PCR_CERT]}
-PREVIOUS_PCR_CERT=${5:-}
-
-[[ -d "$ROOTFS" ]] || { echo "Error: missing rootfs: $ROOTFS" >&2; exit 1; }
-for command in buildah chroot jq lsinitrd objcopy objdump openssl podman sbverify; do
-    command -v "$command" >/dev/null || { echo "BLOCKED: missing $command" >&2; exit 2; }
-done
-
-if (( EUID != 0 )); then
-    echo "BLOCKED: bootc secure artifact validation must run as root" >&2
-    exit 2
-fi
-
-validate_gpt_auto_cryptsetup() {
-    local uki initrd initrd_root generator_root generator unit
     uki=$(find "$ROOTFS/boot/EFI/Linux" -maxdepth 1 -type f -name '*.efi' -print -quit)
     [[ -n $uki ]] || { echo "Error: assembled UKI is missing" >&2; return 1; }
 
-    initrd=$(mktemp)
-    initrd_root=$(mktemp -d)
-    trap 'rm -f "$initrd"; rm -rf "$initrd_root"' RETURN
-    objcopy --dump-section ".initrd=$initrd" "$uki"
+    scratch=$(mktemp -d)
+    initrd="$scratch/initrd"
+    initrd_root="$scratch/root"
+    mkdir -p "$initrd_root"
+    trap 'rm -rf "$scratch"' EXIT
+    # objcopy rewrites its input when no output is named, stripping a PE's
+    # Authenticode certificate table. Always write a disposable output and
+    # leave the assembled, signed UKI byte-for-byte untouched.
+    objcopy --dump-section ".initrd=$initrd" "$uki" "$scratch/uki.copy"
     (
         cd "$initrd_root"
         lsinitrd --unpack "$initrd"
@@ -68,14 +65,92 @@ validate_gpt_auto_cryptsetup() {
         echo "Error: initramfs gpt-auto-generator did not emit systemd-cryptsetup@root.service" >&2
         return 1
     }
-    grep -Fq "ExecStart=/usr/lib/systemd/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks'" "$unit"
-    grep -Fq 'BindsTo=dev-gpt\x2dauto\x2droot\x2dluks.device' "$unit"
+    grep -Fq "ExecStart=/usr/lib/systemd/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks'" "$unit" || {
+        echo "Error: generated root cryptsetup unit has the wrong attach command" >&2
+        return 1
+    }
+    grep -Fq 'BindsTo=dev-gpt\x2dauto\x2droot\x2dluks.device' "$unit" || {
+        echo "Error: generated root cryptsetup unit does not bind to the LUKS device" >&2
+        return 1
+    }
     find "$initrd_root$generator_root/late" -type l \
         -lname '../systemd-cryptsetup@root.service' -print -quit | grep -q . || {
         echo "Error: generated root cryptsetup unit has no LUKS device dependency" >&2
         return 1
     }
-}
+)
+
+gpt_auto_fixture() (
+    local fixture old_root before after
+    fixture=$(mktemp -d)
+    trap 'rm -rf "$fixture"' EXIT
+    mkdir -p "$fixture/bin" "$fixture/root/boot/EFI/Linux"
+    printf 'signed UKI fixture\n' >"$fixture/root/boot/EFI/Linux/test.efi"
+    before=$(sha256sum "$fixture/root/boot/EFI/Linux/test.efi")
+
+    cat >"$fixture/bin/objcopy" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $# -eq 4 && $1 == --dump-section && $2 == .initrd=* ]]
+printf 'initrd fixture\n' >"${2#.initrd=}"
+cp -- "$3" "$4"
+EOF
+    cat >"$fixture/bin/lsinitrd" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ $1 == --unpack && -s $2 ]]
+mkdir -p usr/lib/systemd/system-generators
+printf '#!/bin/sh\nexit 0\n' >usr/lib/systemd/system-generators/systemd-gpt-auto-generator
+chmod +x usr/lib/systemd/system-generators/systemd-gpt-auto-generator
+EOF
+    cat >"$fixture/bin/chroot" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+root=$1
+shift 2
+late=$3
+unit="$root$late/systemd-cryptsetup@root.service"
+cat >"$unit" <<'UNIT'
+[Unit]
+BindsTo=dev-gpt\x2dauto\x2droot\x2dluks.device
+[Service]
+ExecStart=/usr/lib/systemd/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks' 'none' 'tpm2-device=auto'
+UNIT
+mkdir -p "$root$late/dev-gpt\\x2dauto\\x2droot\\x2dluks.device.wants"
+ln -s ../systemd-cryptsetup@root.service \
+    "$root$late/dev-gpt\\x2dauto\\x2droot\\x2dluks.device.wants/systemd-cryptsetup@root.service"
+EOF
+    chmod +x "$fixture/bin/objcopy" "$fixture/bin/lsinitrd" "$fixture/bin/chroot"
+
+    old_root=${ROOTFS:-}
+    ROOTFS="$fixture/root"
+    PATH="$fixture/bin:$PATH" SNOSI_GPT_AUTO_FIXTURE=1 validate_gpt_auto_cryptsetup
+    ROOTFS=$old_root
+    after=$(sha256sum "$fixture/root/boot/EFI/Linux/test.efi")
+    [[ $after == "$before" ]] || {
+        echo "Error: gpt-auto validation modified the signed UKI" >&2
+        return 1
+    }
+)
+
+if [[ ${1:-} == --fixtures ]]; then
+    "$ASSEMBLER" --self-test
+    "$ASSEMBLER" --credential-self-test
+    gpt_auto_fixture
+    echo "bootc secure artifact fixtures passed"
+    exit 0
+fi
+
+ROOTFS=${1:?Usage: $0 ROOTFS OCI_IMAGE_REF MOK_CERT PCR_CERT [PREVIOUS_PCR_CERT]}
+IMAGE=${2:?Usage: $0 ROOTFS OCI_IMAGE_REF MOK_CERT PCR_CERT [PREVIOUS_PCR_CERT]}
+MOK_CERT=${3:?Usage: $0 ROOTFS OCI_IMAGE_REF MOK_CERT PCR_CERT [PREVIOUS_PCR_CERT]}
+PCR_CERT=${4:?Usage: $0 ROOTFS OCI_IMAGE_REF MOK_CERT PCR_CERT [PREVIOUS_PCR_CERT]}
+PREVIOUS_PCR_CERT=${5:-}
+
+[[ -d "$ROOTFS" ]] || { echo "Error: missing rootfs: $ROOTFS" >&2; exit 1; }
+for command in buildah jq objcopy objdump openssl podman sbverify; do
+    command -v "$command" >/dev/null || { echo "BLOCKED: missing $command" >&2; exit 2; }
+done
 
 "$ASSEMBLER" --validate "$ROOTFS" "$IMAGE" "$MOK_CERT" "$PCR_CERT" "$PREVIOUS_PCR_CERT"
 validate_gpt_auto_cryptsetup

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -12,12 +12,20 @@ artifact_validator="$root/test/bootc-secure-artifact-test.sh"
 
 # Live validation executes the candidate image's pinned bootc through Podman;
 # it must not depend on an independently installed host bootc.
-grep -Fq 'for command in buildah jq objcopy objdump openssl podman sbverify; do' \
+grep -Fq 'for command in buildah chroot jq lsinitrd objcopy objdump openssl podman sbverify; do' \
     "$artifact_validator"
 if grep -Eq '^for command in .*\bbootc\b' "$artifact_validator"; then
     echo "bootc secure artifact validation must use candidate-image bootc, not host bootc" >&2
     exit 1
 fi
+
+# Validate the exact initramfs embedded in the assembled UKI by executing its
+# own generator. A secure bootc artifact is unusable unless GPT auto discovery
+# emits the unit that unlocks its encrypted root.
+grep -Fq "SYSTEMD_PROC_CMDLINE='root=gpt-auto-force'" "$artifact_validator"
+grep -Fq 'chroot "$initrd_root" "$generator"' "$artifact_validator"
+grep -Fq 'late/systemd-cryptsetup@root.service' "$artifact_validator"
+grep -Fq "'/dev/gpt-auto-root-luks'" "$artifact_validator"
 
 [[ -f "$secure" ]]
 [[ -f "$package_manager/etc/apt/sources.list.d/forky.sources" ]]

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -12,20 +12,23 @@ artifact_validator="$root/test/bootc-secure-artifact-test.sh"
 
 # Live validation executes the candidate image's pinned bootc through Podman;
 # it must not depend on an independently installed host bootc.
-grep -Fq 'for command in buildah chroot jq lsinitrd objcopy objdump openssl podman sbverify; do' \
+grep -Fq 'for command in buildah jq objcopy objdump openssl podman sbverify; do' \
     "$artifact_validator"
 if grep -Eq '^for command in .*\bbootc\b' "$artifact_validator"; then
     echo "bootc secure artifact validation must use candidate-image bootc, not host bootc" >&2
     exit 1
 fi
 
-# Validate the exact initramfs embedded in the assembled UKI by executing its
-# own generator. A secure bootc artifact is unusable unless GPT auto discovery
-# emits the unit that unlocks its encrypted root.
+# Exercise the exact initramfs generator with forced GPT discovery. This catches
+# missing binaries and cryptsetup build support, but deliberately does not claim
+# to reproduce production EFI discovery or the runtime failure in issue 517.
 grep -Fq "SYSTEMD_PROC_CMDLINE='root=gpt-auto-force'" "$artifact_validator"
 grep -Fq 'chroot "$initrd_root" "$generator"' "$artifact_validator"
 grep -Fq 'late/systemd-cryptsetup@root.service' "$artifact_validator"
 grep -Fq "'/dev/gpt-auto-root-luks'" "$artifact_validator"
+grep -Fq 'objcopy --dump-section ".initrd=$initrd" "$uki" "$scratch/uki.copy"' \
+    "$artifact_validator"
+grep -Fq 'gpt_auto_fixture' "$artifact_validator"
 
 [[ -f "$secure" ]]
 [[ -f "$package_manager/etc/apt/sources.list.d/forky.sources" ]]

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -29,6 +29,10 @@ grep -Fq "'/dev/gpt-auto-root-luks'" "$artifact_validator"
 grep -Fq 'objcopy --dump-section ".initrd=$initrd" "$uki" "$scratch/uki.copy"' \
     "$artifact_validator"
 grep -Fq 'gpt_auto_fixture' "$artifact_validator"
+grep -Fq 'SNOSI_REQUIRE_GPT_AUTO_VALIDATION=1' \
+    "$root/.github/workflows/build-images.yml"
+grep -Fq 'sudo apt-get install --yes --no-install-recommends dracut-core' \
+    "$root/.github/workflows/build-images.yml"
 
 [[ -f "$secure" ]]
 [[ -f "$package_manager/etc/apt/sources.list.d/forky.sources" ]]


### PR DESCRIPTION
## Summary

- extract the exact initramfs embedded in each assembled secure bootc UKI without modifying the signed source artifact
- execute its own `systemd-gpt-auto-generator` in initrd mode with forced GPT root discovery
- require the generated `systemd-cryptsetup@root.service` and its `/dev/gpt-auto-root-luks` command/dependency
- exercise the new path in fixture CI and prove validation leaves its input UKI byte-identical
- install `dracut-core` in secure builds and fail closed if either real artifact validation cannot execute

This is a structural initramfs regression gate: it catches a missing generator or missing cryptsetup build support. Because forced discovery bypasses production EFI discovery, it does **not** reproduce or close #517; the secure-install VM lane remains responsible for that runtime path.

## Tests

- `bash -n test/bootc-secure-artifact-test.sh test/bootc-secure-static-test.sh`
- `./test/bootc-secure-static-test.sh`
- `./test/bootc-secure-artifact-test.sh --fixtures`
- `./test/bootc-publication-guard-test.sh`
- `./test/bootc-secure-docs-test.sh`
- `git diff --check`
- `shellcheck test/bootc-secure-artifact-test.sh test/bootc-secure-static-test.sh`

A repository-wide audit found every other executable `objcopy --dump-section` call already supplies a disposable output file.