### PR TITLE
fix: validate the real secure initramfs generator output

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Install secure artifact validation dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends dracut-core
+          sudo apt-get install --yes --no-install-recommends dracut-core zstd
 
       - name: Validate locally assembled secure artifact
         env:

--- a/test/bootc-secure-artifact-test.sh
+++ b/test/bootc-secure-artifact-test.sh
@@ -12,7 +12,7 @@ ASSEMBLER="$ROOT_DIR/shared/bootc-secure/assemble-uki.sh"
 # failure. That remains the responsibility of the secure-install VM lane.
 validate_gpt_auto_cryptsetup() (
     local uki scratch initrd initrd_root generator_root generator unit
-    for command in chroot lsinitrd objcopy; do
+    for command in chroot lsinitrd objcopy zstd; do
         if ! command -v "$command" >/dev/null; then
             if [[ ${SNOSI_REQUIRE_GPT_AUTO_VALIDATION:-0} == 1 ]]; then
                 echo "Error: required initramfs gpt-auto validation is missing $command" >&2
@@ -43,10 +43,13 @@ validate_gpt_auto_cryptsetup() (
     # Authenticode certificate table. Always write a disposable output and
     # leave the assembled, signed UKI byte-for-byte untouched.
     objcopy --dump-section ".initrd=$initrd" "$uki" "$scratch/uki.copy"
-    (
+    if ! (
         cd "$initrd_root"
         lsinitrd --unpack "$initrd"
-    )
+    ); then
+        echo "Error: failed to unpack the UKI initramfs with lsinitrd" >&2
+        return 1
+    fi
 
     generator=/usr/lib/systemd/system-generators/systemd-gpt-auto-generator
     [[ -x "$initrd_root$generator" ]] || {
@@ -73,7 +76,7 @@ validate_gpt_auto_cryptsetup() (
         echo "Error: initramfs gpt-auto-generator did not emit systemd-cryptsetup@root.service" >&2
         return 1
     }
-    grep -Fq "ExecStart=/usr/lib/systemd/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks'" "$unit" || {
+    grep -Eq "^ExecStart=/usr/(bin|lib/systemd)/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks'([[:space:]]|$)" "$unit" || {
         echo "Error: generated root cryptsetup unit has the wrong attach command" >&2
         return 1
     }
@@ -90,7 +93,7 @@ validate_gpt_auto_cryptsetup() (
 )
 
 gpt_auto_fixture() (
-    local fixture old_root before after
+    local fixture before after output status
     fixture=$(mktemp -d)
     trap 'rm -rf "$fixture"' EXIT
     mkdir -p "$fixture/bin" "$fixture/root/boot/EFI/Linux"
@@ -126,7 +129,7 @@ cat >"$unit" <<'UNIT'
 [Unit]
 BindsTo=dev-gpt\x2dauto\x2droot\x2dluks.device
 [Service]
-ExecStart=/usr/lib/systemd/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks' 'none' 'tpm2-device=auto'
+ExecStart=/usr/bin/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks' '' ''
 UNIT
 mkdir -p "$root$late/dev-gpt\\x2dauto\\x2droot\\x2dluks.device.wants"
 ln -s ../systemd-cryptsetup@root.service \
@@ -134,13 +137,31 @@ ln -s ../systemd-cryptsetup@root.service \
 EOF
     chmod +x "$fixture/bin/objcopy" "$fixture/bin/lsinitrd" "$fixture/bin/chroot"
 
-    old_root=${ROOTFS:-}
     ROOTFS="$fixture/root"
     PATH="$fixture/bin:$PATH" SNOSI_GPT_AUTO_FIXTURE=1 validate_gpt_auto_cryptsetup
-    ROOTFS=$old_root
     after=$(sha256sum "$fixture/root/boot/EFI/Linux/test.efi")
     [[ $after == "$before" ]] || {
         echo "Error: gpt-auto validation modified the signed UKI" >&2
+        return 1
+    }
+
+    cat >"$fixture/bin/lsinitrd" <<'EOF'
+#!/bin/bash
+echo "Need 'zstd' to unpack the initramfs." >&2
+exit 1
+EOF
+    chmod +x "$fixture/bin/lsinitrd"
+    set +e
+    output=$(PATH="$fixture/bin:$PATH" SNOSI_GPT_AUTO_FIXTURE=1 \
+        validate_gpt_auto_cryptsetup 2>&1)
+    status=$?
+    set -e
+    [[ $status -eq 1 && $output == *"Error: failed to unpack the UKI initramfs with lsinitrd"* ]] || {
+        echo "Error: initramfs unpack failure was not diagnosed correctly" >&2
+        return 1
+    }
+    [[ $output != *"initramfs is missing"* ]] || {
+        echo "Error: initramfs unpack failure was misreported as a missing generator" >&2
         return 1
     }
 )

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -31,8 +31,13 @@ grep -Fq 'objcopy --dump-section ".initrd=$initrd" "$uki" "$scratch/uki.copy"' \
 grep -Fq 'gpt_auto_fixture' "$artifact_validator"
 grep -Fq 'SNOSI_REQUIRE_GPT_AUTO_VALIDATION=1' \
     "$root/.github/workflows/build-images.yml"
-grep -Fq 'sudo apt-get install --yes --no-install-recommends dracut-core' \
+grep -Fq 'sudo apt-get install --yes --no-install-recommends dracut-core zstd' \
     "$root/.github/workflows/build-images.yml"
+grep -Fq 'if ! (' "$artifact_validator"
+grep -Fq 'Error: failed to unpack the UKI initramfs with lsinitrd' \
+    "$artifact_validator"
+grep -Fq "ExecStart=/usr/bin/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks' '' ''" \
+    "$artifact_validator"
 
 [[ -f "$secure" ]]
 [[ -f "$package_manager/etc/apt/sources.list.d/forky.sources" ]]


### PR DESCRIPTION
## Summary

- match the real Debian generator output at `/usr/bin/systemd-cryptsetup` while retaining compatibility with `/usr/lib/systemd/systemd-cryptsetup`
- replace the self-confirming fixture unit with the recorded real unit shape, including its empty trailing arguments
- explicitly fail at `lsinitrd --unpack` instead of later misreporting a missing generator
- install and require `zstd` alongside `dracut-core`, and cover unpack-failure diagnostics with a negative fixture

This fixes the real-artifact failures reported in the final post-merge comment on #518. It retains #518’s structural scope and does not claim to reproduce #517’s production EFI discovery path.

## Tests

- `bash -n test/bootc-secure-artifact-test.sh test/bootc-secure-static-test.sh`
- `./test/bootc-secure-static-test.sh`
- `./test/bootc-secure-artifact-test.sh --fixtures`
- `./test/bootc-publication-guard-test.sh`
- `git diff --check`
- `shellcheck test/bootc-secure-artifact-test.sh test/bootc-secure-static-test.sh`