### PR TITLE
fix(bootc-secure): ship 90-image-dissect.rules in the initramfs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,28 @@ validated one real cayo build with bootc 1.16.3, libostree 2026.2, and systemd
 261.1-3, then ran `bootc --version` and `bootc container --help` in a bwrap
 root containing only that output. Repeat that build/root check when either the
 Frostyard debs or the selected systemd family changes.
+**Issue 517 (2026-08-06) — Forky udev moved the gpt-auto symlink rules out of
+dracut's reach:** systemd 257 shipped the udev rules creating
+`/dev/gpt-auto-root[-luks]` in `99-systemd.rules` (which dracut installs by
+name); systemd 261 moved them into `90-image-dissect.rules`, which dracut
+106's hardcoded rules list does not install. The initrd's
+`systemd-gpt-auto-generator` still unconditionally writes
+`systemd-cryptsetup@root.service` bound to `/dev/gpt-auto-root-luks` (the
+generator does not probe the disk; udev's blkid builtin sets
+`ID_PART_GPT_AUTO_ROOT` and the rules create the symlink), so the unit sits
+unactivated, `cryptsetup.target` completes empty, `sysroot.mount` times out
+on `dev-gpt-auto-root.device`, and every secure bootc install drops to
+emergency mode. Fixed by
+`shared/bootc-secure/tree/usr/lib/dracut/dracut.conf.d/35-gpt-auto-udev-rules.conf`
+(`install_items+=" /usr/lib/udev/rules.d/90-image-dissect.rules "`; the file
+is shipped by `udev/forky`). `test/bootc-secure-artifact-test.sh`'s
+initramfs validation now fails any UKI whose unpacked initramfs has no udev
+rule creating `gpt-auto-root-luks`, and `test/bootc-secure-static-test.sh`
+pins the drop-in. Native A/B profiles are unaffected (verity root via UKI
+`roothash=`, explicit `systemd-cryptsetup attach` for `var` — no gpt-auto
+dependency). Upstream dracut-ng (as of 2026-08) still lacks
+`90-image-dissect.rules` in `01systemd-udevd`; re-check this drop-in when
+dracut or the Forky systemd family changes.
 
 **Bootc UKI assembly (Task 5, 2026-07-28):**
 `shared/bootc-secure/assemble-uki.sh` and the secure branch of

--- a/shared/bootc-secure/tree/usr/lib/dracut/dracut.conf.d/35-gpt-auto-udev-rules.conf
+++ b/shared/bootc-secure/tree/usr/lib/dracut/dracut.conf.d/35-gpt-auto-udev-rules.conf
@@ -1,0 +1,10 @@
+# systemd 261 (Forky) moved the gpt-auto-root udev symlink rules out of
+# 99-systemd.rules (their systemd 257 home, which dracut installs by name)
+# into 90-image-dissect.rules, which dracut 106's hardcoded rules list does
+# not install. Without that file the initrd's systemd-gpt-auto-generator
+# writes systemd-cryptsetup@root.service bound to /dev/gpt-auto-root-luks,
+# but no udev rule ever creates the symlink, the unit never activates, and
+# an encrypted root is never unlocked: every secure bootc install drops to
+# emergency mode (issue #517). Force the Forky udev rules file into the
+# initramfs; test/bootc-secure-artifact-test.sh asserts the result.
+install_items+=" /usr/lib/udev/rules.d/90-image-dissect.rules "

--- a/test/bootc-secure-artifact-test.sh
+++ b/test/bootc-secure-artifact-test.sh
@@ -57,6 +57,16 @@ validate_gpt_auto_cryptsetup() (
         return 1
     }
 
+    # The generated unit binds to /dev/gpt-auto-root-luks, which only a udev
+    # rule creates. systemd 261 moved that rule from 99-systemd.rules into
+    # 90-image-dissect.rules, which dracut does not install by default; a
+    # dracut.conf.d drop-in in shared/bootc-secure/tree forces it in. Without
+    # it the unit sits unactivated and boot dies in emergency mode (issue 517).
+    grep -Frqs 'SYMLINK+="gpt-auto-root-luks"' "$initrd_root/usr/lib/udev/rules.d" || {
+        echo "Error: initramfs has no udev rule creating /dev/gpt-auto-root-luks (issue 517)" >&2
+        return 1
+    }
+
     generator_root=/run/snosi-gpt-auto-generator-test
     mkdir -p \
         "$initrd_root$generator_root/normal" \
@@ -117,6 +127,11 @@ set -euo pipefail
 mkdir -p usr/lib/systemd/system-generators
 printf '#!/bin/sh\nexit 0\n' >usr/lib/systemd/system-generators/systemd-gpt-auto-generator
 chmod +x usr/lib/systemd/system-generators/systemd-gpt-auto-generator
+if [[ ${FIXTURE_OMIT_GPT_AUTO_RULE:-0} != 1 ]]; then
+    mkdir -p usr/lib/udev/rules.d
+    printf 'ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="gpt-auto-root-luks"\n' \
+        >usr/lib/udev/rules.d/90-image-dissect.rules
+fi
 EOF
     cat >"$fixture/bin/chroot" <<'EOF'
 #!/bin/bash
@@ -142,6 +157,16 @@ EOF
     after=$(sha256sum "$fixture/root/boot/EFI/Linux/test.efi")
     [[ $after == "$before" ]] || {
         echo "Error: gpt-auto validation modified the signed UKI" >&2
+        return 1
+    }
+
+    set +e
+    output=$(PATH="$fixture/bin:$PATH" SNOSI_GPT_AUTO_FIXTURE=1 \
+        FIXTURE_OMIT_GPT_AUTO_RULE=1 validate_gpt_auto_cryptsetup 2>&1)
+    status=$?
+    set -e
+    [[ $status -eq 1 && $output == *"no udev rule creating /dev/gpt-auto-root-luks"* ]] || {
+        echo "Error: missing gpt-auto-root-luks udev rule was not diagnosed" >&2
         return 1
     }
 

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -39,6 +39,17 @@ grep -Fq 'Error: failed to unpack the UKI initramfs with lsinitrd' \
 grep -Fq "ExecStart=/usr/bin/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks' '' ''" \
     "$artifact_validator"
 
+# Issue 517: systemd 261 moved the gpt-auto-root/-luks udev symlink rules into
+# 90-image-dissect.rules, which dracut does not install by default. The secure
+# tree must force it into the initramfs, and the artifact validator must fail
+# any initramfs that cannot create /dev/gpt-auto-root-luks.
+gpt_auto_dracut_conf="$tree/usr/lib/dracut/dracut.conf.d/35-gpt-auto-udev-rules.conf"
+[[ -f "$gpt_auto_dracut_conf" ]]
+grep -Fqx 'install_items+=" /usr/lib/udev/rules.d/90-image-dissect.rules "' \
+    "$gpt_auto_dracut_conf"
+grep -Fq 'SYMLINK+="gpt-auto-root-luks"' "$artifact_validator"
+grep -Fq 'no udev rule creating /dev/gpt-auto-root-luks' "$artifact_validator"
+
 [[ -f "$secure" ]]
 [[ -f "$package_manager/etc/apt/sources.list.d/forky.sources" ]]
 [[ -f "$package_manager/etc/apt/preferences.d/forky" ]]

--- a/yeti/testing.md
+++ b/yeti/testing.md
@@ -200,6 +200,43 @@ OVMF copying, MOK injection, and persistent swtpm startup/stop. Native wrappers
 retain that harness's existing assertions, logging, and QEMU lifecycle while
 the stateful primitives have one implementation shared with this spike.
 
+## Issue 517 initramfs gpt-auto validation (bootc-secure-artifact-test.sh)
+
+`validate_gpt_auto_cryptsetup` in `test/bootc-secure-artifact-test.sh`
+(added for issue 517, run by `--fixtures` via a stubbed fixture and by the
+real artifact validation after `assemble-uki.sh --validate`) unpacks the
+assembled signed UKI's `.initrd` (always through a disposable `objcopy`
+output copy — omitting the output rewrites the input in place and strips the
+Authenticode table) and asserts two independent halves of the encrypted-root
+unlock chain:
+
+1. **Generator capability:** it chroots into the unpacked initramfs and runs
+   the embedded `systemd-gpt-auto-generator` with
+   `SYSTEMD_PROC_CMDLINE='root=gpt-auto-force'`, requiring a generated
+   `systemd-cryptsetup@root.service` with the pinned attach command,
+   `BindsTo=dev-gpt\x2dauto\x2droot\x2dluks.device`, and the device-wants
+   symlink. Forced discovery bypasses `is_efi_boot()` +
+   `LoaderDevicePartUUID`, so this proves capability, not production EFI
+   discovery.
+2. **udev rule presence (the actual issue-517 defect):** the unpacked
+   `usr/lib/udev/rules.d/` must contain a rule with
+   `SYMLINK+="gpt-auto-root-luks"`. systemd 261 moved the gpt-auto symlink
+   rules from `99-systemd.rules` (in dracut's hardcoded install list) to
+   `90-image-dissect.rules` (not in it), so Forky-family initramfses lost
+   the only rule that materializes the device the generated unit binds to:
+   the generator ran, the unit existed, nothing ever activated it, and
+   secure installs died in emergency mode with `cryptsetup.target` reached
+   empty. The product fix is the
+   `shared/bootc-secure/tree/usr/lib/dracut/dracut.conf.d/35-gpt-auto-udev-rules.conf`
+   `install_items+=` drop-in; this assertion fails any future initramfs that
+   regresses it (e.g. dracut or systemd moving the rules again).
+
+The fixture mode covers the positive path, the missing-rule diagnosis
+(`FIXTURE_OMIT_GPT_AUTO_RULE=1`), the unpack-failure diagnosis, and that
+validation leaves the signed UKI byte-identical.
+`test/bootc-secure-static-test.sh` pins the drop-in's exact `install_items+=`
+line and the validator's rule assertion.
+
 ## Task 9 Secure Install Harness
 
 The normative operations status and recovery/evidence rules are in


### PR DESCRIPTION
## Summary

Fixes #517 — secure bootc installs boot to emergency mode because the encrypted root is never unlocked.

**Root cause:** systemd 261 (Forky) moved the udev rules that create `/dev/gpt-auto-root[-luks]` from `99-systemd.rules` (which dracut installs by name) into `90-image-dissect.rules`, which dracut 106's hardcoded rules list does not install — and upstream dracut-ng `main` still doesn't. The bootc-secure fragment pins `udev/forky`, so the initramfs got 261's `99-systemd.rules` (now without the symlink rules) and never got `90-image-dissect.rules`.

Contrary to the issue's original framing, v261's `gpt-auto-generator` does **not** probe the disk for LUKS — in the initrd EFI path it *unconditionally* writes `systemd-cryptsetup@root.service` bound to `/dev/gpt-auto-root-luks` whenever it writes the root mount. The unit was almost certainly generated in the failing boot; with no udev rule to materialize `/dev/gpt-auto-root-luks`, its `BindsTo=` never resolved, `cryptsetup.target` completed empty, and `sysroot.mount` timed out — matching the captured console line for line.

This also explains why Task 3's live feasibility gate saw a working `systemd-cryptsetup@root` prompt: it ran before Task 4 introduced the Forky family, on Trixie systemd 257 whose `99-systemd.rules` still carried the rules.

## Changes

- `shared/bootc-secure/tree/usr/lib/dracut/dracut.conf.d/35-gpt-auto-udev-rules.conf` (new): `install_items+=" /usr/lib/udev/rules.d/90-image-dissect.rules "`. The file is shipped by `udev/forky` (verified in its filelist); ExtraTrees land before the dracut PostInstallationScript, so the final bootc initrd honors it. Scoped to the bootc-secure tree — native A/B profiles are unaffected (verity root via `roothash=`, explicit `systemd-cryptsetup attach` for `var`, no gpt-auto dependency).
- `test/bootc-secure-artifact-test.sh`: the initramfs validation now also requires a udev rule with `SYMLINK+="gpt-auto-root-luks"` in the unpacked `.initrd` — the assertion that would have caught this regression. Fixture covers the positive path and the missing-rule diagnosis (`FIXTURE_OMIT_GPT_AUTO_RULE=1`).
- `test/bootc-secure-static-test.sh`: pins the drop-in's exact `install_items+=` line and the validator's new assertion.
- CLAUDE.md + yeti/testing.md: root cause, mechanism, and re-check triggers recorded.

## Validation

- `test/bootc-secure-static-test.sh` — pass
- `test/bootc-secure-artifact-test.sh --fixtures` — pass (including the new negative case)
- `shellcheck` on both test scripts, `check-runtime-etc-guard.sh` — clean
- The real end-to-end proof needs a rebuilt image through frostyard/lab's `run-secure-install-tests` lane; the new artifact assertion runs during the protected build before publication, so this class of regression can no longer ship silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)