### PR TITLE
feat(dev): add GTK4/WebKitGTK development headers

### DIFF
--- a/mkosi.images/dev/mkosi.conf
+++ b/mkosi.images/dev/mkosi.conf
@@ -37,7 +37,14 @@ Packages=build-essential
     # for the snow installer
     live-build
     debootstrap
+    # GTK4/WebKitGTK application development
+    libgtk-4-dev
+    libwebkitgtk-6.0-dev
 
 
 [Build]
 Environment=KEYPACKAGE=build-essential
+# r1 (2026-08-07): republish with libgtk-4-dev/libwebkitgtk-6.0-dev added —
+# the build-essential version is unchanged, so publishing would otherwise
+# skip-duplicates the existing filename. Remove when build-essential bumps.
+Environment=SYSEXT_REVISION=1

--- a/mkosi.images/dev/required-paths.txt
+++ b/mkosi.images/dev/required-paths.txt
@@ -6,3 +6,7 @@
 /usr/bin/gdb
 /usr/bin/ninja
 /usr/bin/automake
+# GTK4/WebKitGTK development headers (libgtk-4-dev, libwebkitgtk-6.0-dev) —
+# -dev packages are not in base, so their include trees must be in the delta.
+/usr/include/gtk-4.0
+/usr/include/webkitgtk-6.0


### PR DESCRIPTION
Adds `libgtk-4-dev` and `libwebkitgtk-6.0-dev` to the dev sysext for GTK4/WebKitGTK application development. `pkg-config` was requested too but is already in the package list.

- Both packages verified present in Trixie (`libgtk-4-dev` 4.18.6+ds-2, `libwebkitgtk-6.0-dev` 2.52.3-2~deb13u1 / 2.52.5 security).
- `required-paths.txt` pins `/usr/include/gtk-4.0` and `/usr/include/webkitgtk-6.0` — the -dev packages aren't in base, so their headers must land in the sysext delta.
- `SYSEXT_REVISION=1` set so the content change republishes: the `build-essential` KEYPACKAGE version is unchanged and publishing otherwise skip-duplicates the existing filename. Remove when `build-essential` bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)