### PR TITLE
fix(task9): compare hashes, not hash-plus-filename

### DIFF
--- a/test/bootc-secure-install-test.sh
+++ b/test/bootc-secure-install-test.sh
@@ -377,7 +377,7 @@ trap "umount \"$mountpoint\" 2>/dev/null || true; rmdir \"$mountpoint\" 2>/dev/n
 mount "$esp" "$mountpoint" || { echo "reconciler: cannot mount ESP $esp"; exit 1; }
 shim_before=$(sha256sum "$mountpoint/EFI/BOOT/BOOTX64.EFI")
 mm_before=$(sha256sum "$mountpoint/EFI/BOOT/mmx64.efi")
-source_hash=$(sha256sum "$source")
+source_hash=$(sha256sum "$source" | cut -d" " -f1)
 grub_before=$(sha256sum "$mountpoint/EFI/BOOT/grubx64.efi")
 cp "$source" "$mountpoint/EFI/BOOT/grubx64.efi"
 printf task9-corruption >>"$mountpoint/EFI/BOOT/grubx64.efi"
@@ -386,7 +386,7 @@ systemctl start snosi-bootc-bootloader-reconcile.service || { echo "reconciler: 
 cmp "$source" "$mountpoint/EFI/BOOT/grubx64.efi" || { echo "reconciler: second stage was not restored from $source"; ls -l "$mountpoint/EFI/BOOT/grubx64.efi"; exit 1; }
 test "$shim_before" = "$(sha256sum "$mountpoint/EFI/BOOT/BOOTX64.EFI")" || { echo "reconciler: it modified shim, which it must never touch"; exit 1; }
 test "$mm_before" = "$(sha256sum "$mountpoint/EFI/BOOT/mmx64.efi")" || { echo "reconciler: it modified MokManager, which it must never touch"; exit 1; }
-test "$source_hash" = "$(sha256sum "$mountpoint/EFI/BOOT/grubx64.efi")" || { echo "reconciler: restored second stage does not match the immutable source"; exit 1; }
+test "$source_hash" = "$(sha256sum "$mountpoint/EFI/BOOT/grubx64.efi" | cut -d" " -f1)" || { echo "reconciler: restored second stage does not match the immutable source"; exit 1; }
 sbverify --cert /usr/lib/snosi/mok.crt "$mountpoint/EFI/BOOT/grubx64.efi" >/dev/null || { echo "reconciler: restored second stage fails MOK verification"; sbverify --list "$mountpoint/EFI/BOOT/grubx64.efi" 2>&1 | head -4; exit 1; }'
 }
 


### PR DESCRIPTION
## The check could not pass

```bash
source_hash=$(sha256sum "$source")
…
test "$source_hash" = "$(sha256sum "$mountpoint/EFI/BOOT/grubx64.efi")"
```

`sha256sum` output includes the **filename**:

```
abc…  /usr/lib/snosi/bootc/systemd-bootx64.efi
abc…  /run/task9-esp/EFI/BOOT/grubx64.efi
```

Different paths, so those strings never match however identical the files are.

## How it surfaced

#533's per-check diagnostics named it:

```
reconciler: restored second stage does not match the immutable source
```

— while `cmp "$source" "$mountpoint/EFI/BOOT/grubx64.efi"`, the check immediately before it on the same two files, **passed**. Two checks of one property disagreeing means one of them is broken, and `cmp` is the one that actually compares contents.

Demonstrated:

```
$ printf x > /tmp/a; cp /tmp/a /tmp/b
$ [ "$(sha256sum /tmp/a)" = "$(sha256sum /tmp/b)" ]     # false — identical files
$ [ "$(sha256sum /tmp/a|cut -d' ' -f1)" = "$(sha256sum /tmp/b|cut -d' ' -f1)" ]  # true
```

## Scope

Only the source-versus-restored comparison changes. The **shim and MokManager** comparisons are deliberately left alone: they hash the *same path* before and after, so the filename is identical on both sides and carries no error. Changing them would be churn.

## Where this leaves the suite

15 passing after this, including `persistent state and etc are ready` which #533 fixed. Remaining: the two recovery hooks, and `BLOCKED: signed causal fixture for unsigned was not supplied` — external signed artifacts rather than code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)