### PR TITLE
docs(contract): write down the recovery state manifest schema

### DIFF
--- a/docs/bootc-secure-install-contract.md
+++ b/docs/bootc-secure-install-contract.md
@@ -296,6 +296,37 @@ files, MOK passwords, extracted public keys, and any copied private credential
 before handoff; no private key may be written to the target, installer logs, or
 provenance record.
 
+## Recovery State Manifest
+
+The harness writes a state manifest and passes its path to the external
+recovery runners (`BOOTC_SECURE_RECOVERY_COMMAND`,
+`BOOTC_SECURE_NEGATIVE_COMMAND`). It is **paths only** — the file names
+credentials, it never contains them — and it is mode `0600`.
+
+This schema was previously undocumented, and the two sides disagreed: the
+harness wrote `ssh_key` while Dakota's runner required `ssh_private_key`, so
+every manifest was rejected as "not path-only Task 9 state". Writing it down is
+what stops that recurring.
+
+| key | meaning |
+|---|---|
+| `schema` | integer `1` |
+| `profile` | `cayo`, `snow`, or `snowfield` |
+| `tracking_ref` | the same-repository tag being followed |
+| `accepted_oci_ref` | the immutable `…@sha256:…` reference installed |
+| `target_disk` | path to the installed disk image or block device |
+| `ovmf_code` / `ovmf_vars` | paths to the firmware the install used |
+| `tpm_state` / `tpm_socket` | paths to the swtpm state directory and control socket |
+| `recovery_key` | **path** to the recovery credential, never its bytes |
+| `mok_cert` / `pcr_public` | paths to the public MOK certificate and PCR public key |
+| `ssh_key` | **path** to the harness SSH private key, never its bytes |
+
+A runner must treat every value as a path it may read, and must not copy
+credential bytes into logs, evidence, or retained state. `ovmf_vars`,
+`tpm_state` and `tpm_socket` name the *same* firmware and TPM state the install
+used; a runner that substitutes fresh state invalidates the enrollment it is
+supposed to be exercising.
+
 ## Provenance And Repair
 
 Fisherman records `/var/lib/snosi/bootc-secure-install.json` in the encrypted


### PR DESCRIPTION
## Why

The manifest the harness passes to the external recovery runners had **no documented schema**, and the two repos disagreed about it. The harness writes `ssh_key`; Dakota's runner required `ssh_private_key`. Every manifest was therefore rejected:

```
ERROR: secure state manifest is not path-only Task 9 state
```

which failed both recovery hooks on an install that was otherwise entirely healthy.

Renaming the identifier on one side fixes today's run. Writing the schema down is what stops it recurring — neither side was wrong to have guessed at an undocumented interface.

## What is documented

The eleven keys the harness actually writes, taken from the code that writes them, plus the two properties a runner has to honour:

- **Every value is a path**, never credential bytes. `recovery_key` and `ssh_key` name files; a runner must not copy their contents into logs, evidence, or retained state.
- **`ovmf_vars`, `tpm_state` and `tpm_socket` name the same firmware and TPM state the install used.** A runner that substitutes fresh state invalidates the enrollment it is supposed to be exercising — which is a subtle way to get a green run that proves nothing.

Paired with **frostyard/dakota-iso#24**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)