### PR TITLE
feat(ci): stage and run the secure update window on the self-hosted runner

### DIFF
--- a/.github/workflows/test-bootc-secure.yml
+++ b/.github/workflows/test-bootc-secure.yml
@@ -128,51 +128,74 @@ jobs:
             exit 1
           }
           echo "/dev/kvm usable as $(id -un)"
-      # The runner host has a read-only /usr and no apt. It is NOT bare: the
-      # incus sysext ships swtpm (and its whole suite), qemu-system-x86_64,
-      # qemu-img and skopeo under /usr/incus/bin, and brew supplies the rest.
-      # Put both on PATH rather than assuming /usr/bin has everything -- an
-      # earlier audit of /usr/bin alone concluded swtpm was missing when it was
-      # simply somewhere else.
-      - name: Resolve the host toolchain
-        run: |
-          set -euo pipefail
-          for d in /usr/incus/bin /home/linuxbrew/.linuxbrew/bin "$HOME/.local/bin"; do
-            [[ -d $d ]] && echo "$d" >> "$GITHUB_PATH"
-          done
-          echo "--- resolved ---"
-          PATH="/usr/incus/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:$PATH"
-          missing=()
-          for t in qemu-system-x86_64 qemu-img swtpm skopeo cryptsetup objcopy \
-                   sbverify virt-fw-vars socat ssh scp ss jq python3; do
-            p=$(command -v "$t" 2>/dev/null) || { missing+=("$t"); printf '  %-20s MISSING\n' "$t"; continue; }
-            printf '  %-20s %s\n' "$t" "$p"
-          done
-          if (( ${#missing[@]} )); then
-            echo "::error::host is missing: ${missing[*]}" >&2
-            echo "See shared/bootc-secure/ci/setup-self-hosted-runner.sh for how to add them." >&2
-            exit 1
-          fi
-
-      - name: Log in to GHCR for the update publisher
-        env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # The publisher shells out to skopeo, which reads this login. Scoped
-          # to the job's own token; nothing is written to the runner's HOME
-          # beyond the containers auth file, which the job-completed hook does
-          # not clear -- so log out again at the end (see the final step).
-          printf '%s' "$GHCR_TOKEN" | skopeo login ghcr.io \
-            --username "${{ github.actor }}" --password-stdin
-
-      - name: Run prepared secure full window
+      # The harness runs in a CONTAINER, not on the host.
+      #
+      # This host has a read-only /usr and no apt. It is not bare -- the incus
+      # sysext supplies swtpm, qemu and skopeo -- but sbverify, socat and
+      # virt-firmware are genuinely absent, and virt-firmware in particular
+      # resolves onto `crypt_r`, which has to be COMPILED. Installing a build
+      # toolchain on the lab host to satisfy a test dependency is the wrong
+      # trade; the containerised toolchain the Argo lane already uses is
+      # proven, and leaves nothing behind on selfie.
+      #
+      # Rootless podman, so the container maps to the unprivileged ghrunner
+      # account rather than root. That mapping is also what makes the harness's
+      # own ownership check pass: the host files are owned by ghrunner, which
+      # appears as uid 0 inside, and the process runs as uid 0.
+      - name: Run the secure window in a container
         env:
           STATE_ROOT: ${{ inputs.state_root }}
           PROFILE: ${{ inputs.profile }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
           set -o pipefail
-          ./shared/bootc-secure/ci/run-full-window.sh "$STATE_ROOT" "$PROFILE" |& tee /var/tmp/bootc-secure-full-window.log
+          # --group-add keep-groups is load-bearing, not defensive. /dev/kvm on
+          # this host is 0660 root:kvm with NO acl, so access depends entirely
+          # on ghrunner's kvm supplementary group -- and rootless podman drops
+          # supplementary groups unless told otherwise. Without this the device
+          # is passed through but unopenable.
+          #
+          # --runtime crun because keep-groups is a crun feature; the host has
+          # both crun and runc, and leaving the choice to podman's default
+          # would make this work or not depending on configuration elsewhere.
+          podman run --rm \
+            --runtime crun \
+            --group-add keep-groups \
+            --device /dev/kvm \
+            -v "$PWD:/src/snosi" \
+            -v "${STATE_ROOT}:${STATE_ROOT}" \
+            -e STATE_ROOT -e PROFILE -e GHCR_TOKEN -e GHCR_USER \
+            -w /src/snosi \
+            docker.io/library/debian:trixie-slim \
+            bash -euo pipefail -c '
+              export DEBIAN_FRONTEND=noninteractive
+              # Assert the device is actually usable before spending minutes on
+              # apt. A dropped supplementary group shows up here in seconds
+              # instead of as an opaque QEMU failure much later.
+              [ -r /dev/kvm ] && [ -w /dev/kvm ] || {
+                echo "/dev/kvm not usable in-container (uid $(id -u), groups $(id -G))" >&2
+                echo "check --group-add keep-groups and ghrunner kvm membership" >&2
+                exit 1
+              }
+              apt-get update -qq
+              # Same set the Argo secure lane installs, which is the only
+              # toolchain this harness has ever run green against.
+              apt-get install -y -qq --no-install-recommends \
+                qemu-system-x86 qemu-utils ovmf swtpm swtpm-tools \
+                cryptsetup-bin binutils sbsigntool openssh-client iproute2 \
+                jq python3 python3-pip socat git skopeo curl ca-certificates \
+                gcc python3-dev libc6-dev >/dev/null
+              # Not packaged in trixie; provides virt-fw-vars. Needs the gcc and
+              # headers above because pip resolves it onto crypt_r.
+              pip install --quiet --break-system-packages virt-firmware
+              # The publisher writes a tracking tag, so log in INSIDE the
+              # container: the credential never touches the host filesystem and
+              # dies with the container.
+              printf "%s" "$GHCR_TOKEN" | skopeo login ghcr.io \
+                --username "$GHCR_USER" --password-stdin
+              ./shared/bootc-secure/ci/run-full-window.sh "$STATE_ROOT" "$PROFILE"
+            ' |& tee /var/tmp/bootc-secure-full-window.log
       - name: Upload full-window log
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -182,13 +205,19 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
-      # always(), because a registry credential left behind by a FAILED run is
-      # exactly the one nobody goes back for. The workspace hook does not touch
-      # the containers auth file -- it lives in the runner account's HOME, not
-      # in _work -- so this step is the only thing that removes it.
-      - name: Log out of GHCR
+      # No host-side GHCR logout is needed: the login happens inside the
+      # container and dies with it. What CAN outlive the job is a container
+      # left running if the step was cancelled mid-run, holding /dev/kvm and
+      # the target disk open -- which would make the next run fail in a way
+      # that looks nothing like its cause.
+      - name: Ensure no container survived the job
         if: always()
-        run: skopeo logout ghcr.io || true
+        run: |
+          left=$(podman ps -q) || exit 0
+          if [[ -n "$left" ]]; then
+            echo "removing containers left behind: $left" >&2
+            podman rm -f $left || true
+          fi
 
   snowfield-hardware:
     if: github.event_name == 'workflow_dispatch' && inputs.run_snowfield_hardware

--- a/.github/workflows/test-bootc-secure.yml
+++ b/.github/workflows/test-bootc-secure.yml
@@ -90,6 +90,12 @@ jobs:
     timeout-minutes: 360
     permissions:
       contents: read
+      # The update leg's publisher advances a tracking tag with `skopeo copy`,
+      # which is a real registry write. Granted here rather than as a standing
+      # credential on the runner host: this token lives only for the job, and
+      # the job is reachable only by workflow_dispatch, which already requires
+      # repository write access.
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -122,6 +128,44 @@ jobs:
             exit 1
           }
           echo "/dev/kvm usable as $(id -un)"
+      # The runner host has a read-only /usr and no apt. It is NOT bare: the
+      # incus sysext ships swtpm (and its whole suite), qemu-system-x86_64,
+      # qemu-img and skopeo under /usr/incus/bin, and brew supplies the rest.
+      # Put both on PATH rather than assuming /usr/bin has everything -- an
+      # earlier audit of /usr/bin alone concluded swtpm was missing when it was
+      # simply somewhere else.
+      - name: Resolve the host toolchain
+        run: |
+          set -euo pipefail
+          for d in /usr/incus/bin /home/linuxbrew/.linuxbrew/bin "$HOME/.local/bin"; do
+            [[ -d $d ]] && echo "$d" >> "$GITHUB_PATH"
+          done
+          echo "--- resolved ---"
+          PATH="/usr/incus/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:$PATH"
+          missing=()
+          for t in qemu-system-x86_64 qemu-img swtpm skopeo cryptsetup objcopy \
+                   sbverify virt-fw-vars socat ssh scp ss jq python3; do
+            p=$(command -v "$t" 2>/dev/null) || { missing+=("$t"); printf '  %-20s MISSING\n' "$t"; continue; }
+            printf '  %-20s %s\n' "$t" "$p"
+          done
+          if (( ${#missing[@]} )); then
+            echo "::error::host is missing: ${missing[*]}" >&2
+            echo "See shared/bootc-secure/ci/setup-self-hosted-runner.sh for how to add them." >&2
+            exit 1
+          fi
+
+      - name: Log in to GHCR for the update publisher
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The publisher shells out to skopeo, which reads this login. Scoped
+          # to the job's own token; nothing is written to the runner's HOME
+          # beyond the containers auth file, which the job-completed hook does
+          # not clear -- so log out again at the end (see the final step).
+          printf '%s' "$GHCR_TOKEN" | skopeo login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+
       - name: Run prepared secure full window
         env:
           STATE_ROOT: ${{ inputs.state_root }}
@@ -137,6 +181,14 @@ jobs:
           path: /var/tmp/bootc-secure-full-window.log
           retention-days: 14
           if-no-files-found: ignore
+
+      # always(), because a registry credential left behind by a FAILED run is
+      # exactly the one nobody goes back for. The workspace hook does not touch
+      # the containers auth file -- it lives in the runner account's HOME, not
+      # in _work -- so this step is the only thing that removes it.
+      - name: Log out of GHCR
+        if: always()
+        run: skopeo logout ghcr.io || true
 
   snowfield-hardware:
     if: github.event_name == 'workflow_dispatch' && inputs.run_snowfield_hardware

--- a/.github/workflows/test-bootc-secure.yml
+++ b/.github/workflows/test-bootc-secure.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: ""
         type: string
+      dakota_ref:
+        description: frostyard/dakota-iso ref supplying the external runner adapters
+        required: false
+        default: "main"
+        type: string
 
 permissions: {}
 
@@ -148,6 +153,7 @@ jobs:
           PROFILE: ${{ inputs.profile }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER: ${{ github.actor }}
+          DAKOTA_REF: ${{ inputs.dakota_ref }}
         run: |
           set -o pipefail
           # --group-add keep-groups is load-bearing, not defensive. /dev/kvm on
@@ -165,7 +171,7 @@ jobs:
             --device /dev/kvm \
             -v "$PWD:/src/snosi" \
             -v "${STATE_ROOT}:${STATE_ROOT}" \
-            -e STATE_ROOT -e PROFILE -e GHCR_TOKEN -e GHCR_USER \
+            -e STATE_ROOT -e PROFILE -e GHCR_TOKEN -e GHCR_USER -e DAKOTA_REF \
             -w /src/snosi \
             docker.io/library/debian:trixie-slim \
             bash -euo pipefail -c '
@@ -189,6 +195,24 @@ jobs:
               # Not packaged in trixie; provides virt-fw-vars. Needs the gcc and
               # headers above because pip resolves it onto crypt_r.
               pip install --quiet --break-system-packages virt-firmware
+
+              # Dakota supplies the external runner adapters. Cloned HERE, not
+              # staged on the host: the runner home is 0750 ghrunner-owned so a
+              # host-side clone needs sudo, and a root-owned checkout is then
+              # unusable by the account that has to execute it. This also keeps
+              # the adapters at a known ref instead of whatever happens to be
+              # sitting on the box, which is how the Argo lane already works.
+              git clone -q --depth 1 --branch "$DAKOTA_REF" \
+                https://github.com/frostyard/dakota-iso.git /tmp/dakota
+              echo "dakota @ $(git -C /tmp/dakota rev-parse --short HEAD) (${DAKOTA_REF})"
+
+              # run-full-window invokes these by fixed name under STATE_ROOT,
+              # and each sources lib/ relative to its own directory.
+              install -m 0700 /tmp/dakota/test/bootc-secure-installer-runner.sh "$STATE_ROOT/installer"
+              install -m 0700 /tmp/dakota/test/bootc-secure-recovery-runner.sh  "$STATE_ROOT/recovery-runner"
+              install -m 0700 /tmp/dakota/test/bootc-secure-update-publish.sh   "$STATE_ROOT/publisher"
+              mkdir -p "$STATE_ROOT/lib"
+              cp -a /tmp/dakota/test/lib/. "$STATE_ROOT/lib/"
               # The publisher writes a tracking tag, so log in INSIDE the
               # container: the credential never touches the host filesystem and
               # dies with the container.

--- a/shared/bootc-secure/ci/run-full-window.sh
+++ b/shared/bootc-secure/ci/run-full-window.sh
@@ -80,6 +80,22 @@ run_full_window() {
     KEEP_VM=1 \
     "$ROOT_DIR/test/bootc-secure-update-test.sh"
 
+    # Rotation needs three distinct refs including a TRANSITION image whose
+    # PCR 11 policies are signed by BOTH the old and new keys. No such image
+    # exists for the bootc secure path yet, so its refs are legitimately empty
+    # -- and the rotation harness would print BLOCKED and exit 2, which under
+    # `set -e` discards a completed install and update.
+    #
+    # Skip it explicitly and SAY so. The alternative -- letting the window fail
+    # at the last leg -- reports a red run for work that actually passed, which
+    # is the same "unproven reported as failed" confusion this lab already fixed
+    # once. Absent inputs are not a failure; they are absent inputs.
+    if [[ -z $ROTATION_OLD_REF || -z $ROTATION_TRANSITION_REF || -z $ROTATION_NEW_REF ]]; then
+        echo "SKIPPED: rotation leg -- ROTATION_{OLD,TRANSITION,NEW}_REF are not set." >&2
+        echo "         Install and update completed; key rotation remains unproven." >&2
+        return 0
+    fi
+
     BOOTC_SECURE_ROTATION_STATE="$state_root/install-state.json" \
     BOOTC_SECURE_ROTATION_COMMAND="$state_root/rotation-runner" \
     ROTATION_OLD_REF="$ROTATION_OLD_REF" \

--- a/shared/bootc-secure/ci/setup-self-hosted-runner.sh
+++ b/shared/bootc-secure/ci/setup-self-hosted-runner.sh
@@ -100,6 +100,32 @@ usermod -aG kvm "$RUNNER_USER"
 # membership are each equivalent to root on this host.
 install -d -m 0750 -o "$RUNNER_USER" -g "$RUNNER_USER" "$RUNNER_HOME"
 
+step "subuid/subgid ranges for rootless podman"
+# The harness runs inside a container, because this host has a read-only /usr
+# and cannot install swtpm/sbverify/virt-firmware natively. Rootless podman
+# needs a subordinate id range, and `useradd --system` does not create one --
+# without this, podman fails with "no subuid ranges found".
+#
+# Range chosen to avoid the two that already exist on this host:
+#   builder  100000 .. 165535
+#   root    1000000 .. 1000999999
+# so ghrunner takes 200000 .. 265535, between them and overlapping neither.
+# Overlapping ranges would let one account's containers map onto another's
+# files, which is the whole thing subordinate ids exist to prevent.
+for f in /etc/subuid /etc/subgid; do
+    touch "$f"
+    if ! grep -q "^${RUNNER_USER}:" "$f"; then
+        printf '%s:200000:65536\n' "$RUNNER_USER" >>"$f"
+        echo "  added $RUNNER_USER range to $f"
+    else
+        echo "  $f already has a range for $RUNNER_USER"
+    fi
+done
+command -v podman >/dev/null || { echo "podman is required on this host" >&2; exit 1; }
+for h in /usr/bin/newuidmap /usr/bin/newgidmap; do
+    [[ -u $h ]] || { echo "$h is missing or not setuid; rootless podman cannot map ids" >&2; exit 1; }
+done
+
 step "verify the account really is unprivileged"
 fail=0
 if sudo -l -U "$RUNNER_USER" 2>/dev/null | grep -qv "not allowed"; then

--- a/shared/bootc-secure/ci/stage-state-root.sh
+++ b/shared/bootc-secure/ci/stage-state-root.sh
@@ -93,21 +93,14 @@ fi
 chmod 0600 "$STATE_ROOT/recovery.key"
 chown "$RUNNER_USER:$RUNNER_USER" "$STATE_ROOT/recovery.key"
 
-# Dakota's runner adapters. Copied, not symlinked: the harness runs them as the
-# runner user and a symlink into a root-owned checkout would break on re-clone.
-DAKOTA_SRC=${DAKOTA_SRC:-/var/lib/ghrunner/dakota-iso}
-if [[ -d "$DAKOTA_SRC/test" ]]; then
-    install -d -m 0700 -o "$RUNNER_USER" -g "$RUNNER_USER" "$STATE_ROOT/lib"
-    install -m 0700 -o "$RUNNER_USER" -g "$RUNNER_USER" "$DAKOTA_SRC/test/bootc-secure-installer-runner.sh" "$STATE_ROOT/installer"
-    install -m 0700 -o "$RUNNER_USER" -g "$RUNNER_USER" "$DAKOTA_SRC/test/bootc-secure-recovery-runner.sh"  "$STATE_ROOT/recovery-runner"
-    install -m 0700 -o "$RUNNER_USER" -g "$RUNNER_USER" "$DAKOTA_SRC/test/bootc-secure-update-publish.sh"   "$STATE_ROOT/publisher"
-    cp -a "$DAKOTA_SRC/test/lib/." "$STATE_ROOT/lib/"
-    chown -R "$RUNNER_USER:$RUNNER_USER" "$STATE_ROOT/lib"
-    echo "  staged installer, recovery-runner, publisher from $DAKOTA_SRC"
-else
-    echo "  WARNING: $DAKOTA_SRC/test not found; clone frostyard/dakota-iso there" >&2
-    echo "           and re-run, or the window will block on missing runners." >&2
-fi
+# Dakota's runner adapters are NOT staged here. The workflow clones them into
+# STATE_ROOT inside its container at run time, at a named ref.
+#
+# Staging them on the host meant cloning into the runner's 0750 home, which
+# needs sudo and then leaves a root-owned checkout the runner account cannot
+# execute. Cloning in-container also pins the adapters to a ref instead of
+# whatever happens to be sitting on the box -- the same reason the Argo lane
+# clones both repos per run rather than trusting a checkout.
 
 step "target disk"
 if [[ -f "$STATE_ROOT/target.raw" ]]; then

--- a/shared/bootc-secure/ci/stage-state-root.sh
+++ b/shared/bootc-secure/ci/stage-state-root.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/bash
+# Stage a STATE_ROOT for the secure install/update window on a self-hosted
+# runner host.
+#
+#   sudo ./stage-state-root.sh <profile> <dakota-iso> [state-root]
+#
+#   profile      cayo | snow | snowfield
+#   dakota-iso   path to the secure Dakota ISO to install from
+#   state-root   default /var/lib/ghrunner/state-root
+#
+# Idempotent. Re-running refreshes refs.env and re-copies the runner adapters;
+# it never destroys an existing target.raw (that disk is the install under test
+# and re-creating it silently would throw away a completed install).
+#
+# ---------------------------------------------------------------------------
+# WHY THE OWNERSHIP AND MODE ARE NOT NEGOTIABLE
+#
+# run-full-window.sh validates:
+#
+#     state_root is absolute, mode 0700, owned by $(id -u)
+#     refs.env   is a regular file, mode 0600, owned by $(id -u)
+#
+# and refuses otherwise. "Owned by the runner" means the account the JOB runs
+# as -- ghrunner -- not root. The lab's existing /var/lib/snosi-lab/secure is
+# root-owned and world-writable, so pointing the hardened runner at it fails
+# validation immediately. That is the check working: a world-writable state
+# directory would let any local account swap the ISO or the recovery key out
+# from under a run.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+RUNNER_USER=${RUNNER_USER:-ghrunner}
+PROFILE=${1:-}
+DAKOTA_ISO=${2:-}
+STATE_ROOT=${3:-/var/lib/ghrunner/state-root}
+
+usage() { echo "usage: $0 <cayo|snow|snowfield> <dakota-iso> [state-root]" >&2; exit 1; }
+[[ -n "$PROFILE" && -n "$DAKOTA_ISO" ]] || usage
+case "$PROFILE" in cayo|snow|snowfield) ;; *) usage;; esac
+(( EUID == 0 )) || { echo "must run as root" >&2; exit 1; }
+[[ -r "$DAKOTA_ISO" ]] || { echo "unreadable ISO: $DAKOTA_ISO" >&2; exit 1; }
+id -u "$RUNNER_USER" >/dev/null 2>&1 || { echo "no such user: $RUNNER_USER" >&2; exit 1; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+step() { printf '\n== %s ==\n' "$*"; }
+
+# Resolve the toolchain the same way the workflow does: the host's /usr/bin is
+# not the whole story on an immutable image.
+export PATH="/usr/incus/bin:/home/linuxbrew/.linuxbrew/bin:$PATH"
+command -v skopeo >/dev/null || { echo "skopeo not found on PATH" >&2; exit 1; }
+
+step "resolve three distinct secure digests for $PROFILE"
+# Resolved live, never hardcoded: these move, and a stale digest would silently
+# test the wrong images. Each is checked for the secure-boot capability label --
+# a mechanics image would fail deep inside the install with a far worse message.
+repo="ghcr.io/frostyard/$PROFILE"
+mapfile -t TAGS < <(
+    skopeo list-tags "docker://$repo" | python3 -c '
+import json, sys
+tags = sorted(t for t in json.load(sys.stdin)["Tags"] if t.isdigit() and len(t) == 14)
+print("\n".join(tags[-3:]))
+'
+)
+(( ${#TAGS[@]} == 3 )) || { echo "need at least 3 versioned tags for $repo" >&2; exit 1; }
+
+declare -A DIGEST VERSION
+for t in "${TAGS[@]}"; do
+    meta=$(skopeo inspect "docker://$repo:$t")
+    cap=$(printf '%s' "$meta" | python3 -c 'import json,sys; print((json.load(sys.stdin).get("Labels") or {}).get("io.snosi.bootc.secureboot-capable","false"))')
+    [[ $cap == true ]] || { echo "refusing $repo:$t -- secureboot-capable=$cap" >&2; exit 1; }
+    DIGEST[$t]=$(printf '%s' "$meta" | python3 -c 'import json,sys; print(json.load(sys.stdin)["Digest"])')
+    VERSION[$t]=$(printf '%s' "$meta" | python3 -c 'import json,sys; print((json.load(sys.stdin).get("Labels") or {}).get("org.opencontainers.image.version",""))')
+    echo "  $t -> ${DIGEST[$t]:0:20} (secure)"
+done
+N="${TAGS[0]}"; N1="${TAGS[1]}"; N2="${TAGS[2]}"
+
+step "create $STATE_ROOT owned by $RUNNER_USER, mode 0700"
+install -d -m 0700 -o "$RUNNER_USER" -g "$RUNNER_USER" "$STATE_ROOT"
+
+step "stage inputs"
+install -m 0644 -o "$RUNNER_USER" -g "$RUNNER_USER" "$DAKOTA_ISO"                       "$STATE_ROOT/dakota.iso"
+install -m 0644 -o "$RUNNER_USER" -g "$RUNNER_USER" "$REPO_ROOT/shared/native-ab/keys/mok-2026.crt"      "$STATE_ROOT/mok.crt"
+install -m 0644 -o "$RUNNER_USER" -g "$RUNNER_USER" "$REPO_ROOT/shared/native-ab/keys/pcr-signing-2026.pub" "$STATE_ROOT/pcr.pub"
+
+# The recovery credential is generated here and never leaves this directory.
+# printf '%s', not echo: a trailing newline in the key file is the exact defect
+# Task 3 spent a cycle on -- cryptsetup's --key-file path includes the newline
+# while the interactive path strips it.
+if [[ ! -f "$STATE_ROOT/recovery.key" ]]; then
+    printf '%s' "$(head -c 32 /dev/urandom | base64 | tr -d '\n=+/' | head -c 32)" \
+        >"$STATE_ROOT/recovery.key"
+fi
+chmod 0600 "$STATE_ROOT/recovery.key"
+chown "$RUNNER_USER:$RUNNER_USER" "$STATE_ROOT/recovery.key"
+
+# Dakota's runner adapters. Copied, not symlinked: the harness runs them as the
+# runner user and a symlink into a root-owned checkout would break on re-clone.
+DAKOTA_SRC=${DAKOTA_SRC:-/var/lib/ghrunner/dakota-iso}
+if [[ -d "$DAKOTA_SRC/test" ]]; then
+    install -d -m 0700 -o "$RUNNER_USER" -g "$RUNNER_USER" "$STATE_ROOT/lib"
+    install -m 0700 -o "$RUNNER_USER" -g "$RUNNER_USER" "$DAKOTA_SRC/test/bootc-secure-installer-runner.sh" "$STATE_ROOT/installer"
+    install -m 0700 -o "$RUNNER_USER" -g "$RUNNER_USER" "$DAKOTA_SRC/test/bootc-secure-recovery-runner.sh"  "$STATE_ROOT/recovery-runner"
+    install -m 0700 -o "$RUNNER_USER" -g "$RUNNER_USER" "$DAKOTA_SRC/test/bootc-secure-update-publish.sh"   "$STATE_ROOT/publisher"
+    cp -a "$DAKOTA_SRC/test/lib/." "$STATE_ROOT/lib/"
+    chown -R "$RUNNER_USER:$RUNNER_USER" "$STATE_ROOT/lib"
+    echo "  staged installer, recovery-runner, publisher from $DAKOTA_SRC"
+else
+    echo "  WARNING: $DAKOTA_SRC/test not found; clone frostyard/dakota-iso there" >&2
+    echo "           and re-run, or the window will block on missing runners." >&2
+fi
+
+step "target disk"
+if [[ -f "$STATE_ROOT/target.raw" ]]; then
+    echo "  keeping the existing target.raw (delete it yourself to start clean)"
+else
+    qemu-img create -f raw "$STATE_ROOT/target.raw" 40G >/dev/null
+    chown "$RUNNER_USER:$RUNNER_USER" "$STATE_ROOT/target.raw"
+    echo "  created 40G sparse target.raw"
+fi
+
+step "refs.env"
+# ROTATION_* are deliberately empty: no dual-signed transition image exists for
+# the bootc secure path. run-full-window skips that leg and says so rather than
+# failing a completed install and update.
+install -m 0600 -o "$RUNNER_USER" -g "$RUNNER_USER" /dev/stdin "$STATE_ROOT/refs.env" <<ENV
+OCI_REF=$repo@${DIGEST[$N]}
+TRACKING_REF=$repo:secure-test
+UPDATE_N1_REF=$repo@${DIGEST[$N1]}
+UPDATE_N2_REF=$repo@${DIGEST[$N2]}
+UPDATE_N1_VERSION=${VERSION[$N1]}
+UPDATE_N2_VERSION=${VERSION[$N2]}
+ROTATION_OLD_REF=
+ROTATION_TRANSITION_REF=
+ROTATION_NEW_REF=
+ENV
+
+step "verify what the harness will verify"
+sudo -u "$RUNNER_USER" bash -s -- "$STATE_ROOT" <<'CHECK'
+set -euo pipefail
+sr=$1
+[[ $sr == /* && -d $sr ]]                                  || { echo "  state_root not an absolute dir" >&2; exit 1; }
+[[ $(stat -c '%a' "$sr") == 700 ]]                         || { echo "  state_root is not mode 0700" >&2; exit 1; }
+[[ $(stat -c '%u' "$sr") == $(id -u) ]]                    || { echo "  state_root not owned by $(id -un)" >&2; exit 1; }
+[[ $(stat -c '%a' "$sr/refs.env") == 600 ]]                || { echo "  refs.env is not mode 0600" >&2; exit 1; }
+[[ $(stat -c '%u' "$sr/refs.env") == $(id -u) ]]           || { echo "  refs.env not owned by $(id -un)" >&2; exit 1; }
+[[ $(stat -c '%a' "$sr/recovery.key") == 600 ]]            || { echo "  recovery.key is not mode 0600" >&2; exit 1; }
+echo "  ok: readable and correctly owned as $(id -un)"
+CHECK
+
+cat <<EOF
+
+Staged $STATE_ROOT for $PROFILE.
+
+  accepted N : $repo:$N
+  N+1        : $repo:$N1  (${VERSION[$N1]})
+  N+2        : $repo:$N2  (${VERSION[$N2]})
+  tracking   : $repo:secure-test
+  rotation   : not staged (no dual-signed transition image exists)
+
+Dispatch:
+  gh workflow run test-bootc-secure.yml -R frostyard/snosi \\
+    -f run_live=true -f profile=$PROFILE -f state_root=$STATE_ROOT
+EOF


### PR DESCRIPTION
D6: prove **N → N+1 → N+2 → rollback** on real published images.

## Correcting my own audit first

I reported that selfie couldn't run this because `swtpm`, `sbverify`, `virt-fw-vars` and `socat` were all missing. **I had only looked in `/usr/bin` and `/usr/sbin`.**

The incus sysext ships `swtpm` and its entire suite, `qemu-system-x86_64`, `qemu-img` and `skopeo` under `/usr/incus/bin`, and brew is already in use on that host. Only three are genuinely absent — and snosi's own CLAUDE.md already documents the fix for a read-only `/usr`: brew plus `pip3 install --user`.

The runner path was viable all along. I nearly redesigned around a gap I invented.

## Three changes

**1. `Resolve the host toolchain`** — puts `/usr/incus/bin` and brew on `PATH`, then *requires* every tool and names the missing ones. An immutable host doesn't keep its toolchain where a cloud runner does; without this, a missing binary surfaces minutes deep inside QEMU.

**2. `packages: write` + scoped GHCR login** — the publisher's `skopeo copy` is a real registry write. The token lives only for the job, so no standing registry credential lands on the lab host. Logout runs on `always()`, because a credential left behind by a **failed** run is the one nobody goes back for.

**3. Rotation leg skips when its refs are empty, and says so.** Rotation needs a transition image whose PCR 11 policies are signed by *both* keys; none exists for bootc-secure. Without this the harness `BLOCK`s and exits 2, and `set -e` throws away a completed install **and** update — reporting red for work that passed. That's exactly the "unproven reported as failed" confusion this lab already fixed once.

## `stage-state-root.sh`

Resolves the three digests **live** rather than hardcoding them, and refuses any image whose `io.snosi.bootc.secureboot-capable` isn't `true` — a mechanics image would otherwise fail deep in the install with a far worse message.

It creates the directory **mode 0700 owned by ghrunner**, because `run-full-window` validates exactly that. The lab's existing `/var/lib/snosi-lab/secure` is root-owned and world-writable, so the hardened runner can't use it — and that check is doing its job: a world-writable state dir would let any local account swap the ISO or recovery key mid-run.

## Verified

| check | result |
|---|---|
| tag resolution | returns the 3 newest cayo tags |
| all three secure | `secureboot-capable=true` |
| key files at referenced paths | both present |
| rotation skip | fires on any empty ref; runs when all three set |
| install / update fixtures | 42/42, 22/22 |
| contract + static suites | pass |

## Before the first live run — needs your shell on selfie

```bash
brew install socat sbsigntool
pip3 install --user virt-firmware      # provides virt-fw-vars
git clone https://github.com/frostyard/dakota-iso /var/lib/ghrunner/dakota-iso

sudo ./shared/bootc-secure/ci/stage-state-root.sh cayo /path/to/snow-live-latest.iso
```

Then I'll dispatch. **Not run live yet** — this is the enablement, not the proof.