### PR TITLE
diag(task9): name the failed units instead of reporting that some failed

### DIFF
--- a/test/bootc-secure-update-test.sh
+++ b/test/bootc-secure-update-test.sh
@@ -140,7 +140,23 @@ secure_runtime_subset() { # recovery MOK certificate
     vm_ssh 'mokutil --sb-state | grep -q "SecureBoot enabled"'                     || subset_fail "Secure Boot is not enabled" || return 1
     vm_ssh 'bootctl --no-pager status | grep -q "Measured UKI: yes"'                || subset_fail "booted chain is not a measured UKI" || return 1
     vm_ssh 'grep -Eq "\[(integrity|confidentiality)\]" /sys/kernel/security/lockdown' || subset_fail "kernel lockdown is not integrity/confidentiality" || return 1
-    vm_ssh "test -z \"\$(systemctl --failed --no-legend)\""                         || subset_fail "system units have failed" || return 1
+    # Print WHICH units, not just that some did. "system units have failed" is
+    # a fact nobody can act on, and this check runs after the recovery legs --
+    # the install harness asserts the same thing BEFORE them and passes, so
+    # anything failing here was left behind by TPM replacement or recovery
+    # re-enrolment, and the unit name is the entire finding.
+    local failed
+    failed=$(vm_ssh 'systemctl --failed --no-legend --plain' 2>/dev/null || true)
+    [[ -z $failed ]] || {
+        subset_fail "system units have failed:"
+        printf '%s\n' "$failed" | sed 's/^/      /' >&2
+        printf '    --- status of each ---\n' >&2
+        while read -r unit _; do
+            [[ -n $unit ]] || continue
+            vm_ssh "systemctl status --no-pager --lines=15 '$unit'" 2>&1 | sed 's/^/      /' >&2
+        done <<<"$failed"
+        return 1
+    }
 
     reconciler=$(vm_ssh 'systemctl show --property=ActiveState --property=Result snosi-bootc-bootloader-reconcile.service')
     reconciler_succeeded "$reconciler" || subset_fail "ESP reconciler did not succeed: $reconciler" || return 1


### PR DESCRIPTION
The composefs fix worked — run [31232998123](https://github.com/frostyard/snosi/actions/runs/31232998123) got past it — and the named diagnostics immediately produced the next failure:

```
secure_runtime_subset: FAILED -- system units have failed
```

Which is a fact nobody can act on. This prints the units and their status.

## Why this one matters more than it looks

| | |
|---|---|
| install harness, 01:39:29 | `ok - no system units failed` |
| update harness, 01:41:38 | **system units have failed** |
| in between | TPM replacement, then recovery re-enrolment |

So whatever is failing was **left behind by the recovery legs**. The unit name is the entire finding — it's either a real product defect in the recovery path or an artifact of how the harness drives it, and those two are indistinguishable from the current output.

## Verified

- failed units → each listed with per-unit `systemctl status`, function returns 1
- no failed units → returns 0 and continues
- update fixtures 22/22