### PR TITLE
fix(bootc-secure): mask the NvPCR consumers a replaced TPM makes unusable

### DIFF
--- a/docs/bootc-secure-operations.md
+++ b/docs/bootc-secure-operations.md
@@ -124,6 +124,40 @@ unlock test result as evidence.
 **External privileged action:** Dakota/bootc-installer/Fisherman owns TPM
 replacement and reenrollment. Snosi provides no CLI for it.
 
+### Clear the stale SRK after replacing a TPM
+
+Rotating the LUKS TPM token is not sufficient. systemd separately stores the
+SRK public key of the TPM it last saw, and after a **replacement** that stored
+key belongs to the old device. `systemd-tpm2-setup` and
+`systemd-tpm2-setup-early` then fail on every subsequent boot:
+
+```text
+TPM key integrity check failed. Key most likely does not belong to this TPM.
+```
+
+The system still boots and still TPM-unlocks — the LUKS token is independent of
+this — but it is permanently `degraded`. Remove the stale key so systemd
+re-derives it from the new TPM on the next boot:
+
+```bash
+# /var on a composefs deployment is state/os/<stateroot>/var. <root>/var also
+# exists, is a different directory, and nothing mounts it.
+rm -f /var/lib/systemd/tpm2-srk-public-key.pem
+```
+
+Offline, with the root mounted at `$m`, that path is
+`$m/state/os/<stateroot>/var/lib/systemd/tpm2-srk-public-key.pem`; assert the
+stateroot glob matches exactly one existing directory before writing, or the
+removal silently does nothing.
+
+This is not required for reenrollment against the **same** TPM, where the
+stored key is still correct.
+
+NvPCR is a separate matter and needs no operator action: the secure profiles do
+not consume NvPCR attestation, and `systemd-pcrproduct`/`systemd-pcrlogin@` are
+masked in the shipped image precisely because their anchor cannot survive a
+TPM change or a PCR signing key rotation.
+
 `/dev/mapper/root` remains the opened Btrfs mapper for mounting and runtime; it
 is not the LUKS2 device. Before recovery authentication or TPM enrollment,
 derive and validate exactly one LUKS2 backing device:

--- a/shared/bootc-secure/tree/usr/lib/systemd/system/systemd-pcrlogin@.service
+++ b/shared/bootc-secure/tree/usr/lib/systemd/system/systemd-pcrlogin@.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/shared/bootc-secure/tree/usr/lib/systemd/system/systemd-pcrproduct.service
+++ b/shared/bootc-secure/tree/usr/lib/systemd/system/systemd-pcrproduct.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -50,6 +50,34 @@ grep -Fqx 'install_items+=" /usr/lib/udev/rules.d/90-image-dissect.rules "' \
 grep -Fq 'SYMLINK+="gpt-auto-root-luks"' "$artifact_validator"
 grep -Fq 'no udev rule creating /dev/gpt-auto-root-luks' "$artifact_validator"
 
+# systemd 261 cannot migrate its NvPCR anchor between PCR signing keys, and a
+# replaced TPM makes the anchor unreadable outright. The secure bootc profiles
+# do not consume NvPCR attestation, so the stale-anchor consumers are masked --
+# exactly as shared/native-ab-secure/finalize/disable-nvpcr.chroot already does
+# for the native profiles.
+#
+# Unmasked, they fail permanently after a TPM replacement:
+#     TPM key integrity check failed. Key most likely does not belong to this TPM.
+# leaving a recovered system degraded forever. Observed on run 31235071207.
+# The native decision simply had not been carried across to bootc.
+#
+# Masks are /dev/null symlinks in the shipped tree, the same mechanism ab-root
+# uses for the bootc/nbc updater units. SRK setup and the signed-PCR-11 LUKS
+# path are deliberately NOT masked -- those are load-bearing.
+for masked in systemd-pcrproduct.service 'systemd-pcrlogin@.service'; do
+    mask="$tree/usr/lib/systemd/system/$masked"
+    [[ -L "$mask" && $(readlink "$mask") == /dev/null ]] || {
+        echo "bootc secure tree must mask $masked with a /dev/null symlink" >&2
+        exit 1
+    }
+done
+for kept in systemd-tpm2-setup.service systemd-tpm2-setup-early.service; do
+    [[ -e "$tree/usr/lib/systemd/system/$kept" ]] && {
+        echo "bootc secure tree must NOT mask $kept; SRK setup is required" >&2
+        exit 1
+    }
+done
+
 [[ -f "$secure" ]]
 [[ -f "$package_manager/etc/apt/sources.list.d/forky.sources" ]]
 [[ -f "$package_manager/etc/apt/preferences.d/forky" ]]


### PR DESCRIPTION
snosi already made this decision — **for native profiles only**. `shared/native-ab-secure/finalize/disable-nvpcr.chroot` masks the NvPCR definitions plus `systemd-pcrproduct` and `systemd-pcrlogin@`, because:

> *"systemd 261 cannot migrate its NvPCR anchor credential between PCR signing keys… the secure profile does not consume NvPCR attestation"*

`shared/bootc-secure` had **nothing equivalent**. The identical reasoning applies — bootc-secure doesn't consume NvPCR attestation either. Fourth instance this session of a fix landing in one of two sibling paths.

## The failure

```
TPM key integrity check failed. Key most likely does not belong to this TPM.
Could not extend NvPCR: Object is remote
```

Permanent once the TPM changes, leaving a recovered system degraded forever. Observed on run [31235071207](https://github.com/frostyard/snosi/actions/runs/31235071207) after the harness's recovery legs replaced the TPM.

## Approach

Masked with `/dev/null` symlinks in the shipped tree — the mechanism `ab-root` already uses for the bootc/nbc updater units — rather than `/etc` symlinks, so nothing depends on bootc's `/etc` merge semantics.

`systemd-tpm2-setup` and `systemd-tpm2-setup-early` are **deliberately not masked**; SRK setup and the signed-PCR-11 LUKS path are load-bearing. Their failure is a *stale stored SRK*, fixed separately in frostyard/dakota-iso#33 and documented here.

## Static test pins both halves

| mutation | result |
|---|---|
| remove a mask | fails |
| mask SRK setup | fails |
| restored | passes |

Exit codes checked **directly**, not through a pipe — `cmd \| tail; echo $?` reports tail's status and has already misled me once this session.

## Operations

`docs/bootc-secure-operations.md` now tells an operator to clear the stale SRK after a physical TPM replacement, since that hits real hardware swaps and not just this harness.