### PR TITLE
ci: replace GHCR PAT with scoped tokens

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -251,11 +251,11 @@ jobs:
         id: push
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Login via stdin instead of --creds so the secret never appears in
-          # process arguments (visible in /proc to every process on the runner)
-          echo "$GHCR_PAT" | sudo buildah login -u "${{ github.actor }}" --password-stdin ghcr.io
+          # The job-scoped token has only this repository's packages:write.
+          # Pass it via stdin so it never appears in process arguments.
+          printf '%s' "$GH_TOKEN" | sudo buildah login -u "${{ github.actor }}" --password-stdin ghcr.io
 
           sudo TMPDIR="$TMPDIR" buildah push \
             --compression-format=zstd:chunked \
@@ -275,7 +275,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
@@ -327,9 +327,9 @@ jobs:
 
       - name: Login to GHCR with ORAS
         env:
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "${GHCR_PAT}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Upload SBOM
         id: upload-sbom
@@ -532,6 +532,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
     permissions:
       contents: write
+      packages: read
     steps:
       - name: Download snow tag artifact
         # Missing artifact = the snow leg didn't push; skip the release.
@@ -564,8 +565,9 @@ jobs:
       - name: Login to GHCR with ORAS
         if: steps.current.outputs.tag != ''
         env:
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
-        run: echo "${GHCR_PAT}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Resolve previous and current snow tags
         id: versions

--- a/.github/workflows/build-mechanics.yml
+++ b/.github/workflows/build-mechanics.yml
@@ -154,8 +154,8 @@ jobs:
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
           TAG: mechanics-${{ steps.version.outputs.tag }}
-          # Scoped to this repository and this run, unlike the PAT used by the
-          # secure publisher. A mechanics push needs nothing broader.
+          # Scoped to this repository and this run, matching the secure
+          # publisher's least-privilege credential model.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Login via stdin so the token never appears in process arguments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,13 @@ sudo implicitly, and secret bytes remain only in the mode-0600 files.
 Every GHCR read and write in secure verification and promotion receives the
 Docker login config explicitly: inspections use `--authfile`, root policy copy
 uses source-only `--src-authfile`, and promotion uses source and destination
-auth files. Pinned Cosign v2.6.1 receives registry auth through command-scoped
+auth files. The run-scoped `GITHUB_TOKEN` is the only GHCR credential:
+`secure-build` grants `packages: write`, while `release` grants only
+`packages: read`; Buildah and ORAS receive it through stdin. The successful
+three-profile mechanics publication run `31150007630` proves repository-token
+write access to the same cayo, snow, and snowfield packages, so a long-lived
+GHCR PAT is neither required nor permitted. Pinned Cosign v2.6.1 receives
+registry auth through command-scoped
 `DOCKER_CONFIG`; it has no registry-config flag. Version-tag resolution must
 equal the pushed digest before policy copy. The verifier never relies on sudo
 preserving a usable user runtime auth path or on root Buildah's credential-store
@@ -1630,4 +1636,3 @@ The target (e.g. `gnome-session.target`) comes from the service's `WantedBy=` in
 **.memory/ directory** `.memory/` is the repository's committed agent-learning store: `.memory/README.md` documents the conventions and `.memory/corrections.jsonl` is an append-only JSON Lines log of corrections (fields: `date`, `scope`, `correction`, `evidence`, `promoted_to`). Append an entry whenever a session establishes that a previously-held belief about this codebase was wrong, with the evidence that settled it; when a correction hardens into a general rule, promote it into `CLAUDE.md` or `yeti/` and set `promoted_to`. Never record secrets or personal data there — the directory is committed.
 
 **Delivery metrics** `docs/metrics.md` defines the metrics snosi tracks about its own change-delivery process — PR acceptance rate (split by author, to detect drift between agent-authored and human-authored PRs), review iterations to merge, time to merge, and `validate.yml` first-pass rate — each with the exact on-demand `gh`/`jq` query that collects it. There is deliberately no scheduled collector, stored time series, or committed snapshot: the queries are the definition. Its "Acting on the numbers" table routes each adverse signal to a documentation or tooling fix (agent-PR acceptance drop → `AGENTS.md`/`CLAUDE.md`/`yeti/`; recurring corrections → `.memory/corrections.jsonl`, then promotion), never to a process reminder.
-

--- a/README.md
+++ b/README.md
@@ -531,7 +531,10 @@ mechanics images labelled `io.snosi.bootc.secureboot-capable=false`; they do not
 receive publication credentials or write a registry. Protected builds publish
 an immutable version tag, validate its digest, labels, signature, restrictive
 policy copy, and artifact before moving `latest`; a failed candidate cannot
-move `latest`. Native pull requests likewise use disposable RSA-4096 MOK and
+move `latest`. GHCR authentication uses only the run-scoped `GITHUB_TOKEN`
+(`packages: write` for secure publication and `packages: read` for release
+discovery); command-line logins receive it through stdin, never process
+arguments. Native pull requests likewise use disposable RSA-4096 MOK and
 RSA-2048 PCR credentials and cannot publish. Fixture success proves runner and
 publication-contract behavior only, not a live secure installation, update,
 rotation, full rollback window, or Snowfield hardware result.

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -72,6 +72,10 @@ workflow="$guard_root/.github/workflows/build-images.yml"
 if [[ ! -f $workflow ]]; then
     fail_check "missing publication workflow: .github/workflows/build-images.yml"
 else
+    if grep -Fq 'GHCR_PAT' "$workflow"; then
+        fail_check "$workflow: long-lived GHCR_PAT references are forbidden"
+    fi
+
     secure_job=$(awk '
         /^  secure-build:$/ { capture=1 }
         capture && /^  [A-Za-z0-9_-]+:$/ && $0 != "  secure-build:" { exit }
@@ -87,6 +91,7 @@ else
             capture { print }
         ' <<<"$secure_job")
         require_text "$workflow secure-build" "$secure_job" '    environment: native-build'
+        require_text "$workflow secure-build permissions" "$secure_job" '      packages: write'
         require_text "$workflow secure-build condition" "$job_condition" "      github.event_name != 'pull_request' &&"
         require_text "$workflow secure-build condition" "$job_condition" "      github.ref == 'refs/heads/main'"
         if grep -Fq '||' <<<"$job_condition"; then
@@ -195,6 +200,19 @@ else
         require_text "$workflow secure verifier auth argument" \
             "$verifier_step" '            "$IMAGE" "$VERSION_TAG" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"'
 
+        push_step=$(awk '
+            /^      - name: Push immutable version tag$/ { capture=1 }
+            capture && /^      - name: / && $0 != "      - name: Push immutable version tag" { exit }
+            capture { print }
+        ' <<<"$secure_job")
+        require_text "$workflow secure push token" "$push_step" \
+            '          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+        push_login_line=$(cat <<'EOF'
+          printf '%s' "$GH_TOKEN" | sudo buildah login -u "${{ github.actor }}" --password-stdin ghcr.io
+EOF
+)
+        require_text "$workflow secure Buildah login" "$push_step" "$push_login_line"
+
         login_step=$(awk '
             /^      - name: Log in to ghcr.io$/ { capture=1 }
             capture && /^      - name: / && $0 != "      - name: Log in to ghcr.io" { exit }
@@ -202,6 +220,21 @@ else
         ' <<<"$secure_job")
         require_text "$workflow secure registry login" "$login_step" \
             '        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3'
+        require_text "$workflow secure registry token" "$login_step" \
+            '          password: ${{ secrets.GITHUB_TOKEN }}'
+
+        oras_login_step=$(awk '
+            /^      - name: Login to GHCR with ORAS$/ { capture=1 }
+            capture && /^      - name: / && $0 != "      - name: Login to GHCR with ORAS" { exit }
+            capture { print }
+        ' <<<"$secure_job")
+        require_text "$workflow secure ORAS token" "$oras_login_step" \
+            '          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+        oras_login_line=$(cat <<'EOF'
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+EOF
+)
+        require_text "$workflow secure ORAS login" "$oras_login_step" "$oras_login_line"
 
         promotion_step=$(awk '
             /^      - name: Promote validated digest to latest$/ { capture=1 }
@@ -276,6 +309,8 @@ else
     if [[ -z $release_job ]]; then
         fail_check "$workflow: missing release job"
     else
+        require_text "$workflow release permissions" "$release_job" '      packages: read'
+
         release_checkout=$(awk '
             /^      - name: Checkout repository$/ { capture=1 }
             capture && /^      - name: / && $0 != "      - name: Checkout repository" { exit }
@@ -285,6 +320,20 @@ else
         require_text "$workflow release checkout" "$release_checkout" \
             '        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4'
         require_text "$workflow release checkout" "$release_checkout" '          persist-credentials: false'
+
+        release_oras_login=$(awk '
+            /^      - name: Login to GHCR with ORAS$/ { capture=1 }
+            capture && /^      - name: / && $0 != "      - name: Login to GHCR with ORAS" { exit }
+            capture { print }
+        ' <<<"$release_job")
+        require_text "$workflow release ORAS token" "$release_oras_login" \
+            '          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+        release_oras_login_line=$(cat <<'EOF'
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+EOF
+)
+        require_text "$workflow release ORAS login" \
+            "$release_oras_login" "$release_oras_login_line"
 
         resolver_step=$(awk '
             /^      - name: Resolve previous and current snow tags$/ { capture=1 }

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -81,6 +81,8 @@ jobs:
       github.event_name != 'pull_request' &&
       github.ref == 'refs/heads/main'
     environment: native-build
+    permissions:
+      packages: write
     steps:
       - name: Materialize protected bootc signing credentials
         env:
@@ -115,8 +117,14 @@ jobs:
         if: always()
         run: sudo rm -rf /var/tmp/bootc-secure-credentials
        - name: Push immutable version tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '%s' "$GH_TOKEN" | sudo buildah login -u "${{ github.actor }}" --password-stdin ghcr.io
        - name: Log in to ghcr.io
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
        - name: Sign immutable image digest
       - name: Verify pushed secure image
         run: |
@@ -132,6 +140,11 @@ jobs:
           AUTH_FILE="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
           ./shared/bootc-secure/ci/promote-published-image.sh \
             "$IMAGE" "${{ steps.push.outputs.digest }}" "$AUTH_FILE"
+       - name: Login to GHCR with ORAS
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
        - name: Upload SBOM
        - name: Sign SBOM
        - name: Attest build provenance
@@ -141,6 +154,8 @@ jobs:
        - name: Upload snow tag artifact
         if: matrix.profile == 'snow'
   release:
+    permissions:
+      packages: read
     steps:
       - name: Read snow tag
       - name: Checkout repository
@@ -152,8 +167,9 @@ jobs:
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2
       - name: Login to GHCR with ORAS
         env:
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
-        run: echo "${GHCR_PAT}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Resolve previous and current snow tags
         run: |
           ./shared/bootc-secure/ci/resolve-snow-release-predecessor.sh \
@@ -234,6 +250,29 @@ remove_tag_binding() {
     perl -0pi -e 's/^tag_digest=.*?^fi\n//ms' \
         "$1/shared/bootc-secure/ci/verify-published-image.sh"
 }
+add_ghcr_pat_reference() { printf '\n# GHCR_PAT\n' >>"$1/.github/workflows/build-images.yml"; }
+remove_secure_packages_write() { perl -0pi -e 's/^      packages: write\n//m' "$1/.github/workflows/build-images.yml"; }
+remove_release_packages_read() { perl -0pi -e 's/^      packages: read\n//m' "$1/.github/workflows/build-images.yml"; }
+remove_push_github_token() {
+    perl -0pi -e 's/(      - name: Push immutable version tag\n        env:\n)          GH_TOKEN:[^\n]*\n/$1/' \
+        "$1/.github/workflows/build-images.yml"
+}
+replace_docker_login_token() {
+    perl -0pi -e 's/password: \$\{\{ secrets\.GITHUB_TOKEN \}\}/password: \${{ secrets.SIGNING_SECRET }}/' \
+        "$1/.github/workflows/build-images.yml"
+}
+remove_secure_oras_token() {
+    perl -0pi -e 's/(      - name: Login to GHCR with ORAS\n        env:\n)          GH_TOKEN:[^\n]*\n/$1/' \
+        "$1/.github/workflows/build-images.yml"
+}
+remove_release_oras_token() {
+    perl -0pi -e 's/(  release:.*?      - name: Login to GHCR with ORAS\n        env:\n)          GH_TOKEN:[^\n]*\n/$1/s' \
+        "$1/.github/workflows/build-images.yml"
+}
+remove_buildah_password_stdin() {
+    perl -0pi -e 's/ --password-stdin ghcr\.io/ ghcr.io/' \
+        "$1/.github/workflows/build-images.yml"
+}
 move_promotion_early() {
     perl -0pi -e 's/      - name: Promote validated digest to latest\n//; s/(      - name: Push immutable version tag\n)/$1      - name: Promote validated digest to latest\n/' "$1/.github/workflows/build-images.yml"
 }
@@ -289,6 +328,14 @@ assert_guard 'pull-request publishing condition fails' 1 permit_pull_request
 assert_guard 'permissive publishing condition with || fails' 1 permit_pull_request_with_or
 assert_guard 'missing main publishing condition fails' 1 remove_main_condition
 assert_guard 'shell || in a secure-build run block passes' 0 allow_shell_or
+assert_guard 'long-lived GHCR PAT reference fails' 1 add_ghcr_pat_reference
+assert_guard 'missing secure packages write permission fails' 1 remove_secure_packages_write
+assert_guard 'missing release packages read permission fails' 1 remove_release_packages_read
+assert_guard 'missing secure push GITHUB_TOKEN fails' 1 remove_push_github_token
+assert_guard 'wrong Docker login token fails' 1 replace_docker_login_token
+assert_guard 'missing secure ORAS GITHUB_TOKEN fails' 1 remove_secure_oras_token
+assert_guard 'missing release ORAS GITHUB_TOKEN fails' 1 remove_release_oras_token
+assert_guard 'Buildah login without password stdin fails' 1 remove_buildah_password_stdin
 for variable in SNOSI_BOOTC_SECURE SNOSI_BOOTC_MOK_KEY SNOSI_BOOTC_MOK_CERT SNOSI_BOOTC_PCR_KEY SNOSI_BOOTC_PCR_CERT; do
     assert_guard "missing $variable fails" 1 remove_package_variable "$variable"
 done

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -49,6 +49,14 @@ Each matrix build resets mkosi dependencies to `base` (`--dependency= --dependen
 
 **Jobs:** `mechanics-build` runs on pull requests with read-only permissions. It performs the three-profile disk preparation, build, insecure local package, smoke test, and cleanup path without secrets or registry writes. `secure-build` runs only on `main` non-PR events inside the protected `native-build` environment.
 
+GHCR authentication is repository- and run-scoped: `secure-build` grants
+`packages: write`, while `release` grants only `packages: read`; both use
+`secrets.GITHUB_TOKEN`. Buildah and ORAS consume the token through stdin, and
+Docker login writes the user-context auth file used by Cosign and Skopeo. No
+long-lived GHCR PAT is required. Scheduled mechanics run `31150007630`
+successfully pushed all three profiles with the same repository token, proving
+the cayo, snow, and snowfield package access needed by secure publication.
+
 **Protected publication steps:**
 1. Transiently materialize the durable production MOK/PCR signing credentials supplied by the four `NATIVE_*` secrets, then build and package each profile. The supplied MOK certificate and derived PCR public key must byte-match the committed public identities; runner-local credential files are removed unconditionally after local artifact validation and before registry writes. The distinct disposable PR keys remain ephemeral.
    The package command repeats all five `SNOSI_BOOTC_*` names as explicit sudo
@@ -58,7 +66,7 @@ Each matrix build resets mkosi dependencies to `base` (`--dependency= --dependen
    Local validation requires host Podman, not host bootc: the validator runs the
    candidate image's pinned bootc 1.16.3 to recompute its storage composefs digest.
    The same boundary applies to the policy-copied validation after registry pull.
-2. Chunk, smoke test, and generate the SBOM, then use root Buildah's stdin login to push only the immutable timestamp tag and capture its digest.
+2. Chunk, smoke test, and generate the SBOM, then use root Buildah's stdin login with the job-scoped `GITHUB_TOKEN` to push only the immutable timestamp tag and capture its digest.
 3. Use the Docker credential context to sign `IMAGE@DIGEST`, verify its remote digest/secure labels and Cosign signature, and copy it through the restrictive repository policy before validating the copied UKI/composefs artifact.
 4. Copy the verified immutable digest registry-to-registry to `latest`, and assert that `latest` resolves to that same digest. No local Buildah bytes are pushed under the mutable tag.
 5. Only after promotion, attach/sign the SBOM, attest provenance, and upload manifests to R2. The Snow tag artifact is recorded only after all of those metadata steps succeed, so its presence authorizes the release job to use the current image.


### PR DESCRIPTION
## Summary

- replace every live `GHCR_PAT` use in `build-images.yml` with the run-scoped `GITHUB_TOKEN`
- retain `packages: write` only for secure publication and grant the release job only `packages: read`
- keep Buildah and ORAS credentials off process argv through `--password-stdin`; Docker login supplies the user auth file used by Cosign and Skopeo
- extend the bootc publication guard to forbid `GHCR_PAT` and enforce the token, permission, and stdin-login contract
- document the least-privilege registry credential boundary

The package-access prerequisite from the issue is now proven: [mechanics run 31150007630](https://github.com/frostyard/snosi/actions/runs/31150007630) used this repository's `GITHUB_TOKEN` to push all three target packages (`cayo`, `snow`, and `snowfield`) successfully.

## Validation

- `./test/bootc-publication-guard-test.sh` (62 assertions)
- `./check-bootc-publication-guard.sh`
- `shellcheck -S warning -x check-bootc-publication-guard.sh test/bootc-publication-guard-test.sh`
- `actionlint .github/workflows/build-images.yml .github/workflows/build-mechanics.yml`

After merge, the unused repository `GHCR_PAT` secret can be deleted.

Closes #303
