### PR TITLE
ci: run verified-download split checksum test

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -149,6 +149,12 @@ jobs:
         # hooks. No root, no bind mount, no image build.
         run: ./test/snosi-etc-diff-test.sh
 
+      - name: Validate verified-download split checksum lookup
+        # Fixture test ensures verified_download() resolves keys from both split
+        # metadata files and honors CHECKSUMS_FILE overrides. No root, network,
+        # or image build.
+        run: ./test/verified-download-split-checksums-test.sh
+
       - name: Validate update-checksums split-file selection
         # shared/download/update-checksums.sh resolves an existing key by
         # searching sysext-checksums.json then image-checksums.json relative to


### PR DESCRIPTION
# Summary

Run the existing verified-download split-checksum regression test in `validate.yml`, alongside the related update-checksums fixture test. This gives both split metadata lookup and `CHECKSUMS_FILE` override behavior an automated per-PR guard.

Closes #388

## Type of change

- [ ] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [ ] Sysext change
- [x] Build pipeline / CI change
- [ ] Documentation only
- [ ] Other:

## Validation

- [x] `shellcheck` / `validate.yml` static checks pass for touched scripts
- [ ] Relevant `just` build target(s) succeed (not applicable; workflow-only change)
- [x] Relevant tests in `test/` were run

Commands run:

```
./test/verified-download-split-checksums-test.sh  # 5 passed, 0 failed
actionlint .github/workflows/validate.yml
shellcheck -S warning -x test/verified-download-split-checksums-test.sh
git diff --check
```

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] New external downloads are pinned and go through `verified_download()` (not applicable; no downloads added)
- [x] Documentation updated (`CLAUDE.md`, `README.md`, `docs/`, `yeti/`) where relevant (not applicable; CI wiring only)
