### PR TITLE
ci: publish signed sysext manifests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
           sudo ./manifestmv.sh
       - name: Publish sysexts to frostyard repo
         if: github.event_name != 'pull_request'
-        uses: frostyard/repogen/.github/actions/publish-to-r2@f762d00a036951587a84dcf6211cfdbdf0881818
+        uses: frostyard/repogen/.github/actions/publish-to-r2@6648671cec7015231fac1f278f09ee5799281bc9
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary

- pin the sysext publisher to repogen v0.4.0
- enable publication of detached `SHA256SUMS.gpg` signatures before clients require them
- keep this backfill separate from the `Verify=true` client change to avoid an unsafe publication race

This is the release-order prerequisite for #583 and #291. Merge and complete its `Build sysexts` run first, then confirm every `ext/*/SHA256SUMS.gpg` is live before merging #583.

Pinned release: https://github.com/frostyard/repogen/releases/tag/v0.4.0

## Type of change

- [x] Build pipeline / CI change
- [ ] Documentation only
- [ ] Other

## Validation

- [x] `git diff --check`
- [x] `actionlint` introduces no new findings (the two existing `GITHUB_OUTPUT` quoting findings remain unchanged from `main`)

## Checklist

- [x] Changes are as small and focused as possible
- [x] External action remains pinned to a full commit SHA
- [x] No secrets, keys, or credentials are committed
