### PR TITLE
docs: expose cross-session knowledge store

### DIFF
--- a/.knowledge/README.md
+++ b/.knowledge/README.md
@@ -1,0 +1,9 @@
+# Cross-session knowledge
+
+This directory is a discovery entry point for tools that look for a
+`.knowledge/` store. Snosi's canonical, version-controlled agent-learning store
+is [`.memory/`](../.memory/README.md), where corrections are recorded in the
+append-only `corrections.jsonl` log.
+
+Follow the format and promotion guidance in `.memory/README.md`. Do not put
+secrets, credentials, or personal data in either directory.


### PR DESCRIPTION
## Summary

- add the ACMM-discoverable `.knowledge/` directory
- direct agents to the existing canonical `.memory/` correction store
- preserve the repository's guidance against recording sensitive data

Closes #592

## Validation

- `git diff --check`
- verified `.knowledge/` and `.memory/README.md` exist