### PR TITLE
Add Auto-QA self-tuning policy

### DIFF
--- a/.github/auto-qa-tuning.json
+++ b/.github/auto-qa-tuning.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "rolling_window_days": 30,
+  "minimum_sample_size": 10,
+  "signals": {
+    "pr_acceptance_rate": "docs/metrics.md#1-pr-acceptance-rate",
+    "review_iterations": "docs/metrics.md#2-review-iterations-to-merge",
+    "ci_first_pass_rate": "docs/metrics.md#4-ci-first-pass-rate"
+  },
+  "thresholds": {
+    "relative_regression": 0.1,
+    "consecutive_improved_windows_to_relax": 2
+  },
+  "actions": {
+    "pr_acceptance_rate": [
+      "tighten affected change guidance in AGENTS.md, CLAUDE.md, or yeti/"
+    ],
+    "review_iterations": [
+      "make the recurring expectation explicit in the pull request template or docs"
+    ],
+    "ci_first_pass_rate": [
+      "add or document the missing targeted local check"
+    ]
+  },
+  "guardrails": {
+    "insufficient_data": "hold",
+    "required_checks": "never_relax",
+    "security_checks": "never_relax",
+    "changes_via_pull_request": true
+  }
+}

--- a/docs/AI-QUALITY-ASSURANCE.md
+++ b/docs/AI-QUALITY-ASSURANCE.md
@@ -14,6 +14,14 @@ This repository uses existing build, test, and validation workflows as its quali
 2. Review failing job logs to identify regressions in build output, tests, or publication checks.
 3. Confirm issue-specific changes include targeted verification and preserve existing contract tests.
 
+## Auto-QA Self-Tuning
+
+`.github/auto-qa-tuning.json` defines the machine-readable feedback policy for
+the live outcome signals in `docs/metrics.md`. A meaningful regression routes
+to the relevant guidance or local-check improvement; small samples hold the
+current policy. Required and security checks are never relaxed, and any
+adjustment must be proposed through a pull request.
+
 ## Quality-Gated Change Expectation
 
 Changes should be considered ready only when relevant existing validations pass and no new security or secret-scanning concerns are introduced.


### PR DESCRIPTION
## Summary

- add `.github/auto-qa-tuning.json` as the ACMM Auto-QA tuning artifact
- bind tuning decisions to the repository existing acceptance, review-iteration, and CI first-pass signals
- keep required and security checks fail-safe and document the policy in the AI QA guide

## Type of change

- [x] Configuration / documentation

## Validation

- `jq` policy assertions
- `git diff --check`

Fixes #585
