### PR TITLE
fix(ci): the nightly never ran; share one container runner between both workflows

### DIFF
--- a/.github/workflows/bootc-secure-nightly.yml
+++ b/.github/workflows/bootc-secure-nightly.yml
@@ -96,28 +96,32 @@ jobs:
     timeout-minutes: 360
     permissions:
       contents: read
+      # The update leg's publisher advances a tracking tag with `skopeo copy`,
+      # a real registry write. Job-scoped so no standing credential lands on
+      # the runner host.
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | \
-            sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-      - name: Run prepared secure full window
+      - name: Run the secure window in a container
         env:
           PROFILE: ${{ needs.fixtures.outputs.profile }}
+          STATE_ROOT: ${{ vars.BOOTC_SECURE_STATE_ROOT || '/var/lib/ghrunner/state-root' }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+          DAKOTA_REF: main
+          WINDOW_LOG: /var/tmp/bootc-secure-nightly.log
         run: |
-          set -o pipefail
-          state_root="/var/lib/snosi/bootc-secure/$PROFILE"
-          if [[ ! -d $state_root ]]; then
-            ./test/bootc-secure-rotation-test.sh |& tee /var/tmp/bootc-secure-nightly.log
-          else
-            ./shared/bootc-secure/ci/run-full-window.sh "$state_root" "$PROFILE" |& tee /var/tmp/bootc-secure-nightly.log
+          set -euo pipefail
+          if [[ ! -d "$STATE_ROOT" ]]; then
+            echo "BLOCKED: $STATE_ROOT is not staged on this runner." >&2
+            echo "Run shared/bootc-secure/ci/stage-state-root.sh there first." >&2
+            exit 2
           fi
+          ./shared/bootc-secure/ci/run-window-in-container.sh
+
       - name: Upload harness logs
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-bootc-secure.yml
+++ b/.github/workflows/test-bootc-secure.yml
@@ -106,47 +106,10 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      # Assert KVM rather than granting it. This job runs on a self-hosted
-      # runner attached to a PUBLIC repository, so the account executing it
-      # must have no sudo at all: the previous `sudo tee /etc/udev/rules.d/...`
-      # plus `sudo udevadm control --reload-rules` required exactly the
-      # privilege an attacker would want, and required it on every run to set
-      # a rule that only ever needs setting once.
-      #
-      # The udev rule is now host setup, applied once by the operator (see
-      # docs/bootc-secure-operations.md). The runner account is a member of
-      # the `kvm` group and needs nothing further.
-      #
-      # Checking /dev/kvm is readable AND writable, rather than merely present:
-      # a missing group membership shows up as a permission error deep inside
-      # QEMU minutes later, which is a far worse place to discover it.
-      - name: Verify KVM is usable without privilege
-        run: |
-          set -euo pipefail
-          [[ -c /dev/kvm ]] || {
-            echo "/dev/kvm is missing; the host is not set up for this runner" >&2
-            exit 1
-          }
-          [[ -r /dev/kvm && -w /dev/kvm ]] || {
-            echo "/dev/kvm is not read-write for $(id -un) (groups: $(id -Gn))." >&2
-            echo "Add the runner account to the kvm group; do NOT grant it sudo." >&2
-            exit 1
-          }
-          echo "/dev/kvm usable as $(id -un)"
-      # The harness runs in a CONTAINER, not on the host.
-      #
-      # This host has a read-only /usr and no apt. It is not bare -- the incus
-      # sysext supplies swtpm, qemu and skopeo -- but sbverify, socat and
-      # virt-firmware are genuinely absent, and virt-firmware in particular
-      # resolves onto `crypt_r`, which has to be COMPILED. Installing a build
-      # toolchain on the lab host to satisfy a test dependency is the wrong
-      # trade; the containerised toolchain the Argo lane already uses is
-      # proven, and leaves nothing behind on selfie.
-      #
-      # Rootless podman, so the container maps to the unprivileged ghrunner
-      # account rather than root. That mapping is also what makes the harness's
-      # own ownership check pass: the host files are owned by ghrunner, which
-      # appears as uid 0 inside, and the process runs as uid 0.
+      # Both this workflow and bootc-secure-nightly.yml drive the same window.
+      # The invocation lives in one script so a change cannot land in one and
+      # miss the other -- which is exactly how the nightly ended up still doing
+      # `sudo tee /etc/udev/rules.d/...` on a runner account with no sudo.
       - name: Run the secure window in a container
         env:
           STATE_ROOT: ${{ inputs.state_root }}
@@ -154,72 +117,8 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER: ${{ github.actor }}
           DAKOTA_REF: ${{ inputs.dakota_ref }}
-        run: |
-          set -o pipefail
-          # --group-add keep-groups is load-bearing, not defensive. /dev/kvm on
-          # this host is 0660 root:kvm with NO acl, so access depends entirely
-          # on ghrunner's kvm supplementary group -- and rootless podman drops
-          # supplementary groups unless told otherwise. Without this the device
-          # is passed through but unopenable.
-          #
-          # --runtime crun because keep-groups is a crun feature; the host has
-          # both crun and runc, and leaving the choice to podman's default
-          # would make this work or not depending on configuration elsewhere.
-          podman run --rm \
-            --runtime crun \
-            --group-add keep-groups \
-            --device /dev/kvm \
-            -v "$PWD:/src/snosi" \
-            -v "${STATE_ROOT}:${STATE_ROOT}" \
-            -e STATE_ROOT -e PROFILE -e GHCR_TOKEN -e GHCR_USER -e DAKOTA_REF \
-            -w /src/snosi \
-            docker.io/library/debian:trixie-slim \
-            bash -euo pipefail -c '
-              export DEBIAN_FRONTEND=noninteractive
-              # Assert the device is actually usable before spending minutes on
-              # apt. A dropped supplementary group shows up here in seconds
-              # instead of as an opaque QEMU failure much later.
-              [ -r /dev/kvm ] && [ -w /dev/kvm ] || {
-                echo "/dev/kvm not usable in-container (uid $(id -u), groups $(id -G))" >&2
-                echo "check --group-add keep-groups and ghrunner kvm membership" >&2
-                exit 1
-              }
-              apt-get update -qq
-              # Same set the Argo secure lane installs, which is the only
-              # toolchain this harness has ever run green against.
-              apt-get install -y -qq --no-install-recommends \
-                qemu-system-x86 qemu-utils ovmf swtpm swtpm-tools \
-                cryptsetup-bin binutils sbsigntool openssh-client iproute2 \
-                jq python3 python3-pip socat git skopeo curl ca-certificates \
-                gcc python3-dev libc6-dev >/dev/null
-              # Not packaged in trixie; provides virt-fw-vars. Needs the gcc and
-              # headers above because pip resolves it onto crypt_r.
-              pip install --quiet --break-system-packages virt-firmware
+        run: ./shared/bootc-secure/ci/run-window-in-container.sh
 
-              # Dakota supplies the external runner adapters. Cloned HERE, not
-              # staged on the host: the runner home is 0750 ghrunner-owned so a
-              # host-side clone needs sudo, and a root-owned checkout is then
-              # unusable by the account that has to execute it. This also keeps
-              # the adapters at a known ref instead of whatever happens to be
-              # sitting on the box, which is how the Argo lane already works.
-              git clone -q --depth 1 --branch "$DAKOTA_REF" \
-                https://github.com/frostyard/dakota-iso.git /tmp/dakota
-              echo "dakota @ $(git -C /tmp/dakota rev-parse --short HEAD) (${DAKOTA_REF})"
-
-              # run-full-window invokes these by fixed name under STATE_ROOT,
-              # and each sources lib/ relative to its own directory.
-              install -m 0700 /tmp/dakota/test/bootc-secure-installer-runner.sh "$STATE_ROOT/installer"
-              install -m 0700 /tmp/dakota/test/bootc-secure-recovery-runner.sh  "$STATE_ROOT/recovery-runner"
-              install -m 0700 /tmp/dakota/test/bootc-secure-update-publish.sh   "$STATE_ROOT/publisher"
-              mkdir -p "$STATE_ROOT/lib"
-              cp -a /tmp/dakota/test/lib/. "$STATE_ROOT/lib/"
-              # The publisher writes a tracking tag, so log in INSIDE the
-              # container: the credential never touches the host filesystem and
-              # dies with the container.
-              printf "%s" "$GHCR_TOKEN" | skopeo login ghcr.io \
-                --username "$GHCR_USER" --password-stdin
-              ./shared/bootc-secure/ci/run-full-window.sh "$STATE_ROOT" "$PROFILE"
-            ' |& tee /var/tmp/bootc-secure-full-window.log
       - name: Upload full-window log
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/shared/bootc-secure/ci/run-window-in-container.sh
+++ b/shared/bootc-secure/ci/run-window-in-container.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/bash
+# Run the secure install/update window inside a container, from a self-hosted
+# runner whose host cannot supply the toolchain.
+#
+#   STATE_ROOT=... PROFILE=... [DAKOTA_REF=main] [GHCR_TOKEN=... GHCR_USER=...] \
+#       ./run-window-in-container.sh
+#
+# ---------------------------------------------------------------------------
+# WHY THIS IS A SCRIPT AND NOT A WORKFLOW STEP
+#
+# It was a workflow step, in test-bootc-secure.yml. bootc-secure-nightly.yml has
+# its own live-full-window job that did the same job a different, older way --
+# `sudo tee /etc/udev/rules.d/...` on a runner account that has no sudo, then
+# the harness directly on a host with no swtpm, sbverify or virt-fw-vars.
+#
+# That divergence is not a one-off. The same shape has now produced five
+# separate defects in this subsystem: ssh_key vs ssh_private_key, the uki vs
+# efi BLS key, findmnt / vs the composefs mapper, NvPCR masking on native but
+# not bootc, and this. Every one was a fix applied to one of two sibling paths.
+#
+# So the invocation lives here once and both workflows call it. A future change
+# cannot land in one and miss the other, because there is only one.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+: "${STATE_ROOT:?STATE_ROOT is required}"
+: "${PROFILE:?PROFILE is required}"
+: "${DAKOTA_REF:=main}"
+: "${GHCR_TOKEN:=}"
+: "${GHCR_USER:=}"
+: "${WINDOW_LOG:=/var/tmp/bootc-secure-full-window.log}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# Assert KVM rather than granting it. The runner account must have NO sudo:
+# this job runs on a self-hosted runner attached to a PUBLIC repository, and
+# the old `sudo tee /etc/udev/rules.d/99-kvm4all.rules` plus `sudo udevadm
+# control` required exactly the privilege a hostile workflow would want -- on
+# every run, to set a rule that only ever needs setting once. That rule is now
+# one-time host setup (setup-self-hosted-runner.sh), which also tightens it
+# from the old world-writable MODE 0666 to 0660 root:kvm.
+#
+# Read AND write, not merely present: a missing group membership otherwise
+# surfaces as a permission error deep inside QEMU minutes later.
+[[ -c /dev/kvm ]] || { echo "/dev/kvm is missing; host not set up for this runner" >&2; exit 1; }
+[[ -r /dev/kvm && -w /dev/kvm ]] || {
+    echo "/dev/kvm is not read-write for $(id -un) (groups: $(id -Gn))." >&2
+    echo "Add the runner account to the kvm group; do NOT grant it sudo." >&2
+    exit 1
+}
+echo "/dev/kvm usable as $(id -un)"
+
+# --group-add keep-groups is load-bearing, not defensive. /dev/kvm is 0660
+# root:kvm with no ACL, so access depends entirely on the runner account's kvm
+# supplementary group -- and rootless podman DROPS supplementary groups unless
+# told otherwise. Without it the device is passed through but unopenable.
+#
+# --runtime crun because keep-groups is a crun feature and the host has both
+# crun and runc; leaving the choice to podman's default would make this work or
+# not depending on configuration elsewhere.
+set -o pipefail
+podman run --rm \
+    --runtime crun \
+    --group-add keep-groups \
+    --device /dev/kvm \
+    -v "$REPO_ROOT:/src/snosi" \
+    -v "${STATE_ROOT}:${STATE_ROOT}" \
+    -e STATE_ROOT -e PROFILE -e GHCR_TOKEN -e GHCR_USER -e DAKOTA_REF \
+    -w /src/snosi \
+    docker.io/library/debian:trixie-slim \
+    bash -euo pipefail -c '
+      export DEBIAN_FRONTEND=noninteractive
+      # Assert the device is usable before spending minutes on apt. A dropped
+      # supplementary group shows up here in seconds instead of as an opaque
+      # QEMU failure later.
+      [ -r /dev/kvm ] && [ -w /dev/kvm ] || {
+        echo "/dev/kvm not usable in-container (uid $(id -u), groups $(id -G))" >&2
+        echo "check --group-add keep-groups and the runner account kvm membership" >&2
+        exit 1
+      }
+      apt-get update -qq
+      # The set the Argo secure lane installs -- the only toolchain this
+      # harness has ever run green against.
+      apt-get install -y -qq --no-install-recommends \
+        qemu-system-x86 qemu-utils ovmf swtpm swtpm-tools \
+        cryptsetup-bin binutils sbsigntool openssh-client iproute2 \
+        jq python3 python3-pip socat git skopeo curl ca-certificates \
+        gcc python3-dev libc6-dev >/dev/null
+      # Not packaged in trixie; provides virt-fw-vars. Needs the gcc and
+      # headers above because pip resolves it onto crypt_r.
+      pip install --quiet --break-system-packages virt-firmware
+
+      # Dakota supplies the external runner adapters. Cloned HERE, not staged
+      # on the host: the runner home is 0750 runner-owned, so a host-side clone
+      # needs sudo and then leaves a root-owned checkout the runner account
+      # cannot execute. Pinning the ref also makes a failure attributable.
+      git clone -q --depth 1 --branch "$DAKOTA_REF" \
+        https://github.com/frostyard/dakota-iso.git /tmp/dakota
+      echo "dakota @ $(git -C /tmp/dakota rev-parse --short HEAD) (${DAKOTA_REF})"
+      install -m 0700 /tmp/dakota/test/bootc-secure-installer-runner.sh "$STATE_ROOT/installer"
+      install -m 0700 /tmp/dakota/test/bootc-secure-recovery-runner.sh  "$STATE_ROOT/recovery-runner"
+      install -m 0700 /tmp/dakota/test/bootc-secure-update-publish.sh   "$STATE_ROOT/publisher"
+      mkdir -p "$STATE_ROOT/lib"
+      cp -a /tmp/dakota/test/lib/. "$STATE_ROOT/lib/"
+
+      # The publisher writes a tracking tag. Log in INSIDE the container so the
+      # credential never touches the host filesystem and dies with the
+      # container. Absent token means the update leg cannot publish; say so
+      # here rather than failing obscurely mid-window.
+      if [ -n "${GHCR_TOKEN:-}" ]; then
+        printf "%s" "$GHCR_TOKEN" | skopeo login ghcr.io \
+          --username "$GHCR_USER" --password-stdin
+      else
+        echo "WARNING: no GHCR_TOKEN; the update publisher will fail to advance the tracking tag" >&2
+      fi
+
+      ./shared/bootc-secure/ci/run-full-window.sh "$STATE_ROOT" "$PROFILE"
+    ' |& tee "$WINDOW_LOG"


### PR DESCRIPTION
> *"Bootc Secure Nightly Validation has never completed successfully in 10 runs; 9 consecutive cancellations, then failed at 'Enable KVM', indicating the runner lacks KVM hardware virtualization support."*

**The conclusion is wrong on both counts.**

**The runner has KVM.** Run [31227792302](https://github.com/frostyard/snosi/actions/runs/31227792302) printed `/dev/kvm usable as ghrunner` on this exact machine. What it lacks is **sudo** — deliberately, because it's attached to a public repository — and `Enable KVM` runs `sudo tee`.

**The 9 cancellations weren't KVM either.** No runner carried the `bootc-secure` label until it was registered on 2026-08-07, so the job queued and each run was cancelled. Registering the runner is what turned an invisible queue into a visible failure — the nightly has been dead since 2026-07-30 and the cancellations hid it.

## What was actually wrong

`bootc-secure-nightly.yml` had its own `live-full-window` that `test-bootc-secure.yml` had already outgrown:

| | |
|---|---|
| KVM | `sudo tee`, setting `MODE 0666` — world-writable, which host setup now tightens to `0660 root:kvm` |
| harness | run **directly on the host**, which has no swtpm/sbverify/virt-fw-vars |
| publisher | no `packages: write` |
| state_root | a path that doesn't exist |

## The fix addresses the pattern, not just this instance

Rather than paste the working version in a second time, it moves to `shared/bootc-secure/ci/run-window-in-container.sh` and **both workflows call it**.

That divergence is not a one-off. The same shape has produced **five** defects in this subsystem:

1. `ssh_key` vs `ssh_private_key`
2. `uki` vs `efi` BLS keys
3. `findmnt /` vs the composefs mapper
4. NvPCR masked on native but not bootc
5. this

Every one was a fix applied to one of two siblings. There is now one implementation to fix.

## Deliberately unchanged

The nightly's **fixtures** job keeps its own KVM enablement — it runs on `ubuntu-latest`, where sudo is expected and the udev rule is genuinely needed. Only the self-hosted job's copy was wrong.

The nightly now `BLOCK`s with an actionable message when `STATE_ROOT` isn't staged, instead of falling through to a rotation test that can't run either. `STATE_ROOT` is overridable via a repository variable.

## Verified

- both self-hosted jobs contain **zero** `sudo`
- the script's required-var guards fire
- static, install, update suites pass