### PR TITLE
fix(bootc-secure): mask the NvPCR DEFINITIONS, not just their two consumers

### DIFF
--- a/shared/bootc-secure/finalize/disable-nvpcr.chroot
+++ b/shared/bootc-secure/finalize/disable-nvpcr.chroot
@@ -1,0 +1,26 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -euo pipefail
+# systemd 261 cannot migrate its NvPCR anchor credential between PCR signing
+# keys, and a REPLACED TPM makes the anchor unreadable outright. The secure
+# bootc profiles do not consume NvPCR attestation, so disable the stale-anchor
+# consumers while keeping SRK setup and the signed-PCR-11 LUKS path, which are
+# load-bearing.
+#
+# This mirrors shared/native-ab-secure/finalize/disable-nvpcr.chroot. The
+# decision was made for native and simply never carried across to bootc.
+#
+# Masking the two consumer UNITS is not sufficient, which is how the first
+# attempt at this failed. systemd-tpm2-setup{,-early} also reach for the anchor:
+#
+#     TPM key integrity check failed. Key most likely does not belong to this TPM.
+#     Failed to acquire anchor secret: Object is remote
+#
+# and they cannot be masked, because SRK setup is required. Removing the
+# DEFINITIONS is what stops anything asking for an anchor at all. Observed on
+# run 31286871002, where masking only the units left these two still failing.
+mkdir -p /etc/nvpcr /etc/systemd/system
+for definition in /usr/lib/nvpcr/*.nvpcr; do
+    [[ -e "$definition" ]] || continue
+    ln -sfn /dev/null "/etc/nvpcr/${definition##*/}"
+done

--- a/shared/bootc-secure/mkosi.conf
+++ b/shared/bootc-secure/mkosi.conf
@@ -11,6 +11,10 @@ SandboxTrees=%D/shared/bootc-secure/package-manager
 
 [Content]
 ExtraTrees=%D/shared/bootc-secure/tree
+# Disables the NvPCR stale-anchor consumers. A tree cannot do this: the
+# definitions under /usr/lib/nvpcr are enumerated at build time, exactly as
+# shared/native-ab-secure does it. Keeps SRK setup and signed-PCR-11 LUKS.
+FinalizeScripts=%D/shared/bootc-secure/finalize/disable-nvpcr.chroot
 # The MOK certificate and PCR signer are public verification material shared
 # with native A/B. Private signing material must never enter an OCI image.
 ExtraTrees=%D/cosign.pub:/usr/lib/snosi/cosign.pub

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -78,6 +78,31 @@ for kept in systemd-tpm2-setup.service systemd-tpm2-setup-early.service; do
     }
 done
 
+# Masking the two consumer units is NOT sufficient, and assuming it was cost a
+# live run. systemd-tpm2-setup{,-early} also reach for the anchor --
+# "Failed to acquire anchor secret: Object is remote" -- and they cannot be
+# masked because SRK setup is required. Removing the DEFINITIONS is what stops
+# anything asking for an anchor at all, which is why native does both and this
+# must too.
+nvpcr_finalize="$root/shared/bootc-secure/finalize/disable-nvpcr.chroot"
+[[ -x "$nvpcr_finalize" ]] || {
+    echo "bootc secure must ship an executable disable-nvpcr finalize script" >&2
+    exit 1
+}
+grep -Fq '/usr/lib/nvpcr/*.nvpcr' "$nvpcr_finalize"
+grep -Fq 'ln -sfn /dev/null "/etc/nvpcr/' "$nvpcr_finalize"
+grep -Fq 'FinalizeScripts=%D/shared/bootc-secure/finalize/disable-nvpcr.chroot' \
+    "$root/shared/bootc-secure/mkosi.conf"
+# SRK setup must survive: the finalize must not mask those units either.
+# Comments are stripped first -- the script explains at length WHY it leaves
+# systemd-tpm2-setup alone, and that prose must not trip the guard against
+# touching it. (A grep that matches its own documentation is a recurring shape
+# in this repo; it already caught the ssh_private_key check once.)
+if sed 's/#.*//' "$nvpcr_finalize" | grep -Fq 'systemd-tpm2-setup'; then
+    echo "disable-nvpcr must not touch systemd-tpm2-setup; SRK setup is required" >&2
+    exit 1
+fi
+
 [[ -f "$secure" ]]
 [[ -f "$package_manager/etc/apt/sources.list.d/forky.sources" ]]
 [[ -f "$package_manager/etc/apt/preferences.d/forky" ]]


### PR DESCRIPTION
**My previous fix (#575) was half of one.** It masked `systemd-pcrproduct` and `systemd-pcrlogin@`, and I reasoned the NvPCR *definitions* were "inert without their consumers."

They are not.

## The evidence

Run [31286871002](https://github.com/frostyard/snosi/actions/runs/31286871002): those two units are now **clean** — the mask worked — and `systemd-tpm2-setup{,-early}` still fail:

```
TPM key integrity check failed. Key most likely does not belong to this TPM.
Failed to acquire anchor secret: Object is remote
```

`systemd-tpm2-setup` reaches for the anchor too, and it **cannot be masked** because SRK setup is load-bearing. Removing the definitions is what stops anything asking for an anchor at all — exactly why native's `disable-nvpcr.chroot` does both, and why copying half of it didn't work.

## What I should have caught

The evidence was already in this repo's own CLAUDE.md, naming all three units in one sentence:

> *"a new-only UKI then fails `systemd-tpm2-setup`, `systemd-pcrproduct`, and `systemd-pcrlogin`"*

I read that, masked two of the three, and never asked why the third was in the list.

## The fix

Mirrors native exactly: a finalize script enumerating `/usr/lib/nvpcr/*.nvpcr` at build time, since a static tree can't know those names.

## Static test pins all of it

The finalize must exist, be executable, be wired into `mkosi.conf`, enumerate the definitions — and must **not** touch `systemd-tpm2-setup`.

That last check strips comments first. Without it, the guard matched the script's own explanation of why it leaves SRK setup alone — the same shape as the `ssh_private_key` check that caught its own comment.

| mutation | exit |
|---|---|
| wiring removed | 1 |
| finalize masks SRK setup | 1 |
| unit mask removed | 1 |
| all restored | 0 |

## Note

This needs three **new** post-fix images again before the live run can use it, same as #575.