### PR TITLE
fix(worker): update PostCSS for source map read advisory

### DIFF
--- a/workers/native-installer-redirect/package-lock.json
+++ b/workers/native-installer-redirect/package-lock.json
@@ -2564,9 +2564,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2651,7 +2651,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

- update the transitive PostCSS lock entry from 8.5.19 to patched 8.5.26
- refresh PostCSS's required NanoID dependency from 3.3.16 to 3.3.18
- leave the Worker's direct dependency ranges unchanged for a minimal advisory fix

Closes #609

This is a focused alternative to the broader multi-advisory dependency upgrade in #611.

## Security impact

PostCSS 8.5.19 is affected by GHSA-fxqj-rqcc-2cmp/CVE-2026-69153: with `from` unset, an attacker-controlled `sourceMappingURL` can read an arbitrary valid `.map` file. PostCSS 8.5.26 includes the fix introduced in 8.5.23.

## Validation

- direct absolute-`.map` exploit probe with `from` unset
- `npm audit --json` no longer reports `postcss`
- `npm run check`
- `npm run deploy:dry-run`
