### PR TITLE
fix(worker): update nanoid past zero-size DoS

### DIFF
--- a/workers/native-installer-redirect/package-lock.json
+++ b/workers/native-installer-redirect/package-lock.json
@@ -2564,9 +2564,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- update the transitive `nanoid` lock from 3.3.16 to patched 3.3.18
- leave the direct toolchain versions unchanged for a minimal, issue-specific fix
- remove GHSA-2v37-7h3g-55p8 from `npm audit` results

## Verification

- `npm ci --ignore-scripts`
- `npm ls nanoid` (resolves `nanoid@3.3.18`)
- `npm audit --json` (`nanoid` finding absent; total findings decrease from 7 to 6)
- `npm test` (15 passed)
- `npm run typecheck`

PR #611 includes this remediation as part of a broader toolchain update. This PR is the focused fallback and can be closed if #611 lands first.

Fixes #608
