### PR TITLE
fix(task9): share the secure assertions; the update copy of type2_only had drifted

### DIFF
--- a/test/bootc-secure-install-test.sh
+++ b/test/bootc-secure-install-test.sh
@@ -9,6 +9,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT_DIR/test/lib/secure-vm.sh"
 # shellcheck disable=SC1091
 source "$ROOT_DIR/test/lib/ssh.sh"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/test/lib/bootc-secure-assertions.sh"
 
 : "${PROFILE:=cayo}"
 : "${DAKOTA_ISO:=}"
@@ -50,43 +52,9 @@ disk_is_large_enough() {
     if [[ -b $disk ]]; then bytes=$(blockdev --getsize64 "$disk"); else bytes=$(stat -c '%s' "$disk"); fi
     (( bytes >= 32212254720 ))
 }
-composefs_from_cmdline() {
-    local token value='' count=0
-    for token in $1; do
-        [[ $token == composefs=* ]] || continue
-        value=${token#composefs=}; value=${value#\?}; value=${value%%,*}; count=$((count + 1))
-    done
-    [[ $count -eq 1 && $value =~ ^[[:xdigit:]]{128}$ ]] && printf '%s\n' "$value"
-}
-type2_only() { # path; materialize once because callers may provide a FIFO.
-    local entries
-    entries=$(cat "$1") || return
-    # `uki` OR `efi`. bootc writes `uki` -- verified from a real installed
-    # target, whose only BLS entry is:
-    #
-    #     title Cayo Linux 13
-    #     version 13
-    #     uki /EFI/Linux/bootc/bootc_composefs-<128 hex>.efi
-    #     sort-key bootc-cayo-0
-    #
-    # Requiring `efi` rejected every genuine install. Both spell a Type #2
-    # entry; what makes it Type #2 is a single bundled EFI image and the
-    # absence of `linux`/`initrd`, which is still enforced above.
-    # frostyard/fisherman#22 fixed the identical assumption in its validator.
-    ! grep -Eq '^[[:space:]]*(linux|initrd)[[:space:]]+' <<<"$entries" \
-        && grep -Eq '^[[:space:]]*(uki|efi)[[:space:]]+/EFI/Linux/bootc/bootc_composefs-[[:xdigit:]]{128}\.efi[[:space:]]*$' <<<"$entries"
-}
 cmdline_has_root_or_luks() { [[ $1 =~ (^|[[:space:]])(root=|luks\.|rd\.luks\.) ]]; }
 exactly_one_line() { [[ -n $1 && $1 != *$'\n'* ]]; }
 recovery_baseline_is_current() { [[ $1 == "$2" ]]; }
-signed_pcr11_token() {
-    jq -e '[.tokens[] | select(.type == "systemd-tpm2")] as $tokens | ($tokens | length == 1) and $tokens[0]."tpm2-pcrs" == [] and $tokens[0].tpm2_pubkey_pcrs == [11] and ($tokens[0] | has("tpm2-pcrlock") | not)' >/dev/null
-}
-root_backing_device() { # cryptsetup status root output
-    local device
-    device=$(awk '/^[[:space:]]*device:/{print $2}' <<<"$1")
-    [[ $device == /dev/* && $device != *$'\n'* ]] && printf '%s\n' "$device"
-}
 canonical_tpm_socket() { # workdir socket
     [[ $2 == "$1/tpm/swtpm-ctrl.sock" && $2 == "$1/tpm/"* ]]
 }
@@ -316,31 +284,7 @@ pre_mok_rejection() {
 
 # Reads a path from the ESP of the installed system.
 #
-# bootc mounts /boot only while it is using it, and leaves it unmounted
-# otherwise -- so an installed target has no /boot to read, and
-# `cat /boot/loader/entries/*.conf` fails with "No such file or directory" on a
-# perfectly healthy system. Mount the ESP the same way exercise_reconciler
-# does: locate it by GPT type GUID on the disk backing the root mapper, rather
-# than assuming any mount point exists.
-esp_cat() { # glob-relative-to-esp
-    # shellcheck disable=SC2016 # This complete script executes on the guest.
-    vm_ssh 'set -euo pipefail
-esp=""
-while read -r path ptype; do
-    if [ "${ptype,,}" = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" ]; then esp="$path"; break; fi
-done < <(lsblk -rno PATH,PARTTYPE)
-if [ -z "$esp" ]; then
-    echo "esp_cat: no partition carries the ESP type GUID; block layout follows" >&2
-    lsblk -rno PATH,TYPE,PARTTYPE,PKNAME >&2
-    exit 1
-fi
-mountpoint=$(mktemp -d /run/task9-esp-read.XXXXXX)
-trap "umount \"$mountpoint\" 2>/dev/null || true; rmdir \"$mountpoint\" 2>/dev/null || true" EXIT
-mount -o ro "$esp" "$mountpoint" || { echo "esp_cat: cannot mount $esp" >&2; exit 1; }
-cat "$mountpoint"/'"$1"' || { echo "esp_cat: no match for '"$1"' on $esp; ESP contains:" >&2; find "$mountpoint" -maxdepth 3 >&2; exit 1; }
-'
-}
-
+# esp_cat lives in test/lib/esp.sh; the update harness needs it too.
 exercise_reconciler() {
     # shellcheck disable=SC2016 # This complete script executes on the guest.
     vm_ssh 'set -euo pipefail

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -208,4 +208,27 @@ for profile in cayo-ab-raw cayo-ab snow-ab snowfield-ab; do
     fi
 done
 
+# The install and update harnesses must not carry private copies of these.
+# Independent copies are what produced the update leg's failure: type2_only
+# had drifted to accept only `efi` while bootc writes `uki`, so it could never
+# pass -- while the install harness asserted the same property and passed.
+# Sixth defect of that shape in this subsystem; the shared library is the fix,
+# and this check is what keeps it shared.
+lib="$root/test/lib/bootc-secure-assertions.sh"
+[[ -f "$lib" ]] || { echo "missing $lib" >&2; exit 1; }
+for harness in "$root/test/bootc-secure-install-test.sh" "$root/test/bootc-secure-update-test.sh"; do
+    grep -Fq 'test/lib/bootc-secure-assertions.sh' "$harness" || {
+        echo "${harness##*/} must source the shared assertions library" >&2
+        exit 1
+    }
+    for shared in esp_cat composefs_from_cmdline type2_only signed_pcr11_token root_backing_device; do
+        if grep -Eq "^${shared}\(\)" "$harness"; then
+            echo "${harness##*/} redefines ${shared}; it belongs to the shared library" >&2
+            exit 1
+        fi
+    done
+done
+# bootc writes `uki`; requiring `efi` alone rejects every genuine install.
+grep -Fq '(uki|efi)' "$lib"
+
 echo "Bootc secure static validation passed"

--- a/test/bootc-secure-update-test.sh
+++ b/test/bootc-secure-update-test.sh
@@ -17,6 +17,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT_DIR/test/lib/secure-vm.sh"
 # shellcheck disable=SC1091
 source "$ROOT_DIR/test/lib/ssh.sh"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/test/lib/bootc-secure-assertions.sh"
 
 : "${BOOTC_SECURE_INSTALL_STATE:=}"
 : "${BOOTC_SECURE_UPDATE_PUBLISH_COMMAND:=}"
@@ -115,18 +117,6 @@ start_vm() { # disk firmware-code firmware-vars TPM-socket workdir
     QEMU_PID=$(<"$work/qemu.pid")
 }
 
-composefs_from_cmdline() {
-    local token value='' count=0
-    for token in $1; do [[ $token == composefs=* ]] || continue; value=${token#composefs=}; value=${value#\?}; value=${value%%,*}; count=$((count + 1)); done
-    [[ $count -eq 1 && $value =~ ^[[:xdigit:]]{128}$ ]] && printf '%s\n' "$value"
-}
-type2_only() { local text; text=$(cat "$1") || return; ! grep -Eq '^[[:space:]]*(linux|initrd)[[:space:]]+' <<<"$text" && grep -Eq '^[[:space:]]*efi[[:space:]]+/EFI/Linux/bootc/bootc_composefs-[[:xdigit:]]{128}\.efi[[:space:]]*$' <<<"$text"; }
-signed_pcr11_token() { jq -e '[.tokens[] | select(.type == "systemd-tpm2")] as $t | ($t | length == 1) and $t[0]."tpm2-pcrs" == [] and $t[0].tpm2_pubkey_pcrs == [11] and ($t[0] | has("tpm2-pcrlock") | not)' >/dev/null; }
-root_backing_device() { # cryptsetup status root output
-    local device
-    device=$(awk '/^[[:space:]]*device:/{print $2}' <<<"$1")
-    [[ $device == /dev/* && $device != *$'\n'* ]] && printf '%s\n' "$device"
-}
 
 # Every check names itself on failure. This used to be one unbroken && chain
 # reported as a bare "FATAL: installed target failed secure runtime
@@ -181,7 +171,12 @@ secure_runtime_subset() { # recovery MOK certificate
     [[ $cmdline != *root=* && $cmdline != *luks.* && $cmdline != *rd.luks.* ]] \
         || subset_fail "kernel command line carries a root/LUKS identifier: $cmdline" || return 1
 
-    entries=$(vm_ssh 'cat /boot/loader/entries/*.conf')
+    # Off the ESP, not /boot. bootc leaves /boot unmounted unless it is using
+    # it, so `cat /boot/loader/entries/*.conf` fails on a HEALTHY system --
+    # which is exactly what this reported as "BLS entries are not Type #2-only"
+    # on run 31292423836, eleven seconds after the install harness asserted the
+    # same property and passed. It was fixed there (snosi#524) and not here.
+    entries=$(esp_cat 'loader/entries/*.conf')
     type2_only <(printf '%s\n' "$entries") || subset_fail "BLS entries are not Type #2-only" || return 1
 
     token=$(vm_ssh "cryptsetup luksDump --dump-json-metadata '$backing'")

--- a/test/lib/bootc-secure-assertions.sh
+++ b/test/lib/bootc-secure-assertions.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Assertions shared by the bootc secure install and update harnesses.
+#
+# These existed as independent copies in both harnesses, and three of the four
+# had drifted. One drift was semantic and load-bearing: type2_only accepted only
+# `efi` in the update harness while bootc writes `uki`, so the update leg could
+# never pass -- eleven seconds after the install harness asserted the same
+# property against the same system and passed.
+#
+# That is the sixth defect in this subsystem caused by a fix landing in one of
+# two sibling harnesses. One copy now, sourced by both.
+#
+# Requires vm_ssh from test/lib/ssh.sh.
+
+
+# bootc mounts /boot only while it is using it, and leaves it unmounted
+# otherwise -- so an installed target has no /boot to read, and
+# `cat /boot/loader/entries/*.conf` fails with "No such file or directory" on a
+# perfectly healthy system. Mount the ESP the same way exercise_reconciler
+# does: locate it by GPT type GUID on the disk backing the root mapper, rather
+# than assuming any mount point exists.
+esp_cat() { # glob-relative-to-esp
+    # shellcheck disable=SC2016 # This complete script executes on the guest.
+    vm_ssh 'set -euo pipefail
+esp=""
+while read -r path ptype; do
+    if [ "${ptype,,}" = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" ]; then esp="$path"; break; fi
+done < <(lsblk -rno PATH,PARTTYPE)
+if [ -z "$esp" ]; then
+    echo "esp_cat: no partition carries the ESP type GUID; block layout follows" >&2
+    lsblk -rno PATH,TYPE,PARTTYPE,PKNAME >&2
+    exit 1
+fi
+mountpoint=$(mktemp -d /run/task9-esp-read.XXXXXX)
+trap "umount \"$mountpoint\" 2>/dev/null || true; rmdir \"$mountpoint\" 2>/dev/null || true" EXIT
+mount -o ro "$esp" "$mountpoint" || { echo "esp_cat: cannot mount $esp" >&2; exit 1; }
+cat "$mountpoint"/'"$1"' || { echo "esp_cat: no match for '"$1"' on $esp; ESP contains:" >&2; find "$mountpoint" -maxdepth 3 >&2; exit 1; }
+'
+}
+
+composefs_from_cmdline() {
+    local token value='' count=0
+    for token in $1; do
+        [[ $token == composefs=* ]] || continue
+        value=${token#composefs=}; value=${value#\?}; value=${value%%,*}; count=$((count + 1))
+    done
+    [[ $count -eq 1 && $value =~ ^[[:xdigit:]]{128}$ ]] && printf '%s\n' "$value"
+}
+type2_only() { # path; materialize once because callers may provide a FIFO.
+    local entries
+    entries=$(cat "$1") || return
+    # `uki` OR `efi`. bootc writes `uki` -- verified from a real installed
+    # target, whose only BLS entry is:
+    #
+    #     title Cayo Linux 13
+    #     version 13
+    #     uki /EFI/Linux/bootc/bootc_composefs-<128 hex>.efi
+    #     sort-key bootc-cayo-0
+    #
+    # Requiring `efi` rejected every genuine install. Both spell a Type #2
+    # entry; what makes it Type #2 is a single bundled EFI image and the
+    # absence of `linux`/`initrd`, which is still enforced above.
+    # frostyard/fisherman#22 fixed the identical assumption in its validator.
+    ! grep -Eq '^[[:space:]]*(linux|initrd)[[:space:]]+' <<<"$entries" \
+        && grep -Eq '^[[:space:]]*(uki|efi)[[:space:]]+/EFI/Linux/bootc/bootc_composefs-[[:xdigit:]]{128}\.efi[[:space:]]*$' <<<"$entries"
+}
+signed_pcr11_token() {
+    jq -e '[.tokens[] | select(.type == "systemd-tpm2")] as $tokens | ($tokens | length == 1) and $tokens[0]."tpm2-pcrs" == [] and $tokens[0].tpm2_pubkey_pcrs == [11] and ($tokens[0] | has("tpm2-pcrlock") | not)' >/dev/null
+}
+root_backing_device() { # cryptsetup status root output
+    local device
+    device=$(awk '/^[[:space:]]*device:/{print $2}' <<<"$1")
+    [[ $device == /dev/* && $device != *$'\n'* ]] && printf '%s\n' "$device"
+}


### PR DESCRIPTION
Run [31292423836](https://github.com/frostyard/snosi/actions/runs/31292423836) cleared every previous blocker — NvPCR definitions masked, SRK cleared, **no failed units** — and then:

```
secure_runtime_subset: FAILED -- BLS entries are not Type #2-only
```

**Eleven seconds after the install harness asserted the same property against the same system and passed.**

## Two defects, both from duplication

**1. Reading BLS entries from `/boot`.** bootc leaves `/boot` unmounted unless it's using it, so `cat /boot/loader/entries/*.conf` fails on a *healthy* system. The install harness has `esp_cat` — locate the ESP by GPT type GUID, mount read-only — fixed there in #524 and never carried across.

**2. A private `type2_only` accepting only `efi`.** bootc writes `uki`. The install harness's version accepts `(uki|efi)` and carries a comment saying requiring `efi` *"rejected every genuine install"*. So the update leg couldn't have passed even with the ESP fix.

Four helpers were duplicated; **three had drifted**. Only `type2_only` drifted semantically — and that one was load-bearing.

## The sixth instance

| # | defect | fixed in | missed in |
|---|---|---|---|
| 1 | `ssh_key` vs `ssh_private_key` | validate_state | recovery runner |
| 2 | `uki` vs `efi` BLS key | install | recovery runner |
| 3 | `findmnt /` vs composefs mapper | install | update |
| 4 | NvPCR masking | native | bootc |
| 5 | sudo KVM step | test-bootc-secure | nightly |
| 6 | `esp_cat` + `type2_only` | install | update |

Copying the fix a sixth time would have set up the seventh. All five helpers now live in `test/lib/bootc-secure-assertions.sh`, sourced by both.

## Enforced, not just done

The static test requires each harness to source the library and **not redefine** any of the five, and requires the library to keep `(uki|efi)`.

| mutation | exit |
|---|---|
| harness redefines `type2_only` | 1 |
| library drops `uki` | 1 |
| restored | 0 |