### PR TITLE
fix(ci): a push to main cancelled the dispatched live run

### DIFF
--- a/.github/workflows/test-bootc-secure.yml
+++ b/.github/workflows/test-bootc-secure.yml
@@ -37,7 +37,18 @@ on:
 permissions: {}
 
 concurrency:
-  group: test-bootc-secure-${{ github.workflow }}-${{ github.ref }}
+  # github.event_name is part of the group so a push to main cannot cancel a
+  # dispatched LIVE run. It could, and did: run 31293104405 (workflow_dispatch,
+  # 03:45:45) was killed by an ordinary merge at 03:47:05, ~90 seconds in.
+  #
+  # The live job holds the single self-hosted runner and a real VM for 15-25
+  # minutes, so on a repository taking frequent merges it was effectively
+  # unrunnable -- and the failure looked like "cancelled", which reads as
+  # someone intervening rather than as a scheduling defect.
+  #
+  # Two dispatches still cancel each other, which is what we want: there is one
+  # runner and one target disk, so a newer live run should supersede an older.
+  group: test-bootc-secure-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Run [31293104405](https://github.com/frostyard/snosi/actions/runs/31293104405) was reported as **cancelled**, not failed.

```
03:47:05  success    [push]              main   <- cancelled the one below
03:45:45  cancelled  [workflow_dispatch] main   <- the live run, ~90s in
```

An ordinary merge to main killed it.

## Why it happened

The concurrency group was keyed on workflow + ref with unconditional `cancel-in-progress`, so pushes and dispatches shared one group. The live job holds the **single self-hosted runner and a real VM for 15–25 minutes**, so on a repository taking frequent merges it was effectively unrunnable — every live run raced whatever landed next.

## The worse part

`cancelled` reads as *someone intervened deliberately*, not as a scheduling defect. It invites a retry rather than a fix, and a retry would have raced the next merge just the same. I only looked because the conclusion wasn't `failure`.

## Fix

`github.event_name` now forms part of the group, so a push cannot cancel a dispatch.

Two dispatches still cancel each other, which is correct: there is one runner and one target disk, so a newer live run should supersede an older one.