### PR TITLE
fix(bootc-secure): seal lockdown in UKI command line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,14 @@ established bootc installation/testing path because of it.
 **Bootc secure composition (Task 4, 2026-07-28):** `cayo`, `snow`, and
 `snowfield` include `shared/bootc-secure/mkosi.conf`; native A/B profiles never
 include it. The fragment uses an isolated low-priority Forky APT sandbox and
-explicitly selects its coherent systemd family, adds `lockdown=integrity` via
-`/usr/lib/bootc/kargs.d/10-lockdown.toml` (the only effective immutable-karg
-mechanism for the directory-format bootc profiles; do not use mkosi
-`KernelCommandLine=` here), and ships only the existing native public MOK
-certificate and RSA-2048 PCR public key at `/usr/lib/snosi/`. Its schema-1
+explicitly selects its coherent systemd family, and declares
+`lockdown=integrity` in `/usr/lib/bootc/kargs.d/10-lockdown.toml`. The secure
+direct-ukify path bypasses bootc's kargs merge, so `assemble-uki.sh` must also
+seal that exact argument beside `rw composefs=?<digest>` and reject any rootfs
+declaration or final `.cmdline` that differs. Do not use mkosi
+`KernelCommandLine=` for these directory-format bootc profiles. The fragment
+ships only the existing native public MOK certificate and RSA-2048 PCR public
+key at `/usr/lib/snosi/`. Its schema-1
 `/usr/lib/snosi/bootc-secure.json` is the rootfs contract for later assembly
 and installer tasks; schema 1 pins its encrypted root mapper as `root`, which
 the reconciler and deferred installer must use. It is not a signed-UKI production path: do not add private
@@ -356,9 +359,11 @@ That focused proof now passes after Task 2 switched its recovery producer to
 1 cannot populate `/etc` during first boot (`Read-only file system`), followed
 by failed TPM setup/drift-report/logind units and no SSH. This is a distinct
 post-switch-root investigation; do not change `/etc` or services in this gate.
-The next `rw`-only cmdline proof passes real-root first boot and reaches SSH;
-the direct ukify command now carries exactly `rw composefs=?<OCI-digest>` and
-fixture-rejects root/LUKS identifiers. Task 3 now has a fail-closed temporary
+The next minimal cmdline proof passes real-root first boot and reaches SSH;
+the direct ukify command now carries exactly
+`rw composefs=?<OCI-digest> lockdown=integrity` and fixture-rejects missing or
+divergent lockdown policy plus root/LUKS identifiers. Task 3 now has a
+fail-closed temporary
 ESP assertion: it derives the backing disk from the booted root LUKS partition,
 requires exactly one sibling EFI System Partition, mounts it read-only at
 `/run/task3-esp`, and runs `bootctl --esp-path=/run/task3-esp --no-pager

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -14,9 +14,9 @@ The adapter relies on all of the following observed behavior:
    128-hex-character composefs ID.
 2. Adding files only below `/boot` to an image derived from that chunked
    candidate does not change that OCI-derived ID.
-3. Direct `ukify build` can produce a MOK-signed UKI with `rw` and exactly one
-   `composefs=?<ID>` argument, one kernel/initramfs pair, an RSA-2048 PCR public
-   key, and four PCR policies per signer.
+3. Direct `ukify build` can produce a MOK-signed UKI with exactly
+   `rw composefs=?<ID> lockdown=integrity`, one kernel/initramfs pair, an
+   RSA-2048 PCR public key, and four PCR policies per signer.
 4. `bootc install to-filesystem` consumes the resulting image as a Type #2 UKI
    deployment without raw `linux` or `initrd` BLS fallback.
 5. Forky `systemd-ukify 261.1-3` ships executable `/usr/bin/ukify` (package

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -13,9 +13,20 @@ readonly CANDIDATE_UKIFY_PREVIOUS_KEY=/run/snosi-ukify-previous-pcr.key
 readonly CANDIDATE_UKIFY_WORK=/run/snosi-ukify-work
 readonly CANDIDATE_UKIFY_LINUX="$CANDIDATE_UKIFY_WORK/linux"
 readonly CANDIDATE_UKIFY_INITRD="$CANDIDATE_UKIFY_WORK/initrd"
+readonly LOCKDOWN_KARG="lockdown=integrity"
+readonly LOCKDOWN_CONFIG_RELATIVE="usr/lib/bootc/kargs.d/10-lockdown.toml"
 
 die() { echo "Error: $*" >&2; exit 1; }
 valid_digest() { [[ ${1:-} =~ ^[[:xdigit:]]{128}$ ]]; }
+sealed_cmdline() { printf 'rw composefs=?%s %s' "$1" "$LOCKDOWN_KARG"; }
+
+validate_lockdown_config() { # rootfs
+    local config="$1/$LOCKDOWN_CONFIG_RELATIVE"
+    [[ -f "$config" ]] ||
+        die "bootc lockdown configuration is missing"
+    cmp -s "$config" <(printf 'kargs = ["%s"]\n' "$LOCKDOWN_KARG") ||
+        die "bootc lockdown configuration does not match the sealed UKI policy"
+}
 
 discover_kernel() { # rootfs
     local root=$1 path version
@@ -64,6 +75,7 @@ validate_root_contract() { # rootfs
     contract="$root/usr/lib/snosi/bootc-secure.json"
     [[ -f "$contract" ]] || die "missing bootc secure rootfs contract"
     jq -e '.schema == 1 and .mok_certificate == "/usr/lib/snosi/mok.crt" and .pcr_public_key == "/usr/lib/snosi/pcr-signing.pub" and .encrypted_root_mapper == "root" and .systemd_suite == "forky" and ((has("assembly") | not) or .assembly == {compatibility: "bootc-1.16.3-storage-digest-v1", bootc_version: "1.16.3", storage_digest_command: "bootc container compute-composefs-digest-from-storage", ukify: "direct-two-pass"})' "$contract" >/dev/null || die "unexpected bootc secure rootfs contract"
+    validate_lockdown_config "$root"
 }
 
 # The gate tracks only caller-owned private keys. Generic PEM scans reject
@@ -190,7 +202,7 @@ validate_pcrsig() { # json primary-public [previous-public]
 }
 
 validate_uki() ( # uki kernel initrd MOK-cert primary-pub digest [previous-pub]
-    local uki=$1 kernel=$2 initrd=$3 mok=$4 primary=$5 digest=$6 previous=${7:-} work cmdline
+    local uki=$1 kernel=$2 initrd=$3 mok=$4 primary=$5 digest=$6 previous=${7:-} work cmdline expected_cmdline
     work=$(mktemp -d)
     trap 'rm -rf -- "$work"' RETURN
     objcopy --dump-section ".cmdline=$work/cmdline" --dump-section ".linux=$work/linux" \
@@ -200,7 +212,9 @@ validate_uki() ( # uki kernel initrd MOK-cert primary-pub digest [previous-pub]
     cmp -s "$initrd" "$work/initrd" || die "UKI initrd section mismatch"
     cmp -s "$primary" "$work/pcrpkey" || die "UKI PCR public-key section mismatch"
     cmdline=$(tr '\0' ' ' <"$work/cmdline")
-    [[ "$cmdline" == "rw composefs=?$digest" ]] || die "UKI command line is not the pinned composefs-only shape"
+    expected_cmdline=$(sealed_cmdline "$digest")
+    [[ "$cmdline" == "$expected_cmdline" ]] ||
+        die "UKI command line does not match the pinned composefs and lockdown policy"
     validate_pcrsig "$work/pcrsig" "$work/pcrpkey" "$previous"
     sbverify --cert "$mok" "$uki" >/dev/null || die "UKI MOK Authenticode signature failed"
 )
@@ -357,12 +371,13 @@ verify_exposed_pcr_public_keys() { # active-public work-directory [previous-publ
 }
 
 candidate_ukify_args() { # rootfs kernel initrd digest version previous-key output-array
-    local root=$1 kernel=$2 initrd=$3 digest=$4 version=$5 previous_key=$6 output_name=$7
+    local root=$1 kernel=$2 initrd=$3 digest=$4 version=$5 previous_key=$6 output_name=$7 cmdline
     local -n output="$output_name"
     rootfs_image_path "$root" "$kernel" >/dev/null
     rootfs_image_path "$root" "$initrd" >/dev/null
+    cmdline=$(sealed_cmdline "$digest")
     output=(build --linux "$CANDIDATE_UKIFY_LINUX" --initrd "$CANDIDATE_UKIFY_INITRD"
-        --os-release @/usr/lib/os-release --cmdline "rw composefs=?$digest"
+        --os-release @/usr/lib/os-release --cmdline "$cmdline"
         --uname "$version" --pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY"
         --secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
         --secureboot-certificate "$CANDIDATE_UKIFY_MOK_CERT" --measure
@@ -468,7 +483,7 @@ EOF
     candidate_ukify_args "$root" "$root/usr/lib/modules/one/vmlinuz" "$root/usr/lib/modules/one/initramfs.img" \
         fixture one "" fixture_args
     expected_args=(build --linux /run/snosi-ukify-work/linux --initrd /run/snosi-ukify-work/initrd
-        --os-release @/usr/lib/os-release --cmdline 'rw composefs=?fixture' --uname one
+        --os-release @/usr/lib/os-release --cmdline 'rw composefs=?fixture lockdown=integrity' --uname one
         --pcr-private-key "$CANDIDATE_UKIFY_PCR_KEY" --secureboot-private-key "$CANDIDATE_UKIFY_MOK_KEY"
         --secureboot-certificate "$CANDIDATE_UKIFY_MOK_CERT" --measure --output "$CANDIDATE_UKIFY_WORK/uki.efi"
         --pcrpkey "$CANDIDATE_UKIFY_WORK/pcr.pub")
@@ -749,10 +764,11 @@ self_test() {
     local work key cert pcr pcr_cert rc=0
     work=$(mktemp -d); trap 'rm -rf -- "$work"' RETURN
     mkdir -p "$work/root/boot/EFI/Linux" "$work/root/usr/lib/modules/one"
-    mkdir -p "$work/root/usr/lib/snosi"
+    mkdir -p "$work/root/usr/lib/snosi" "$work/root/$(dirname "$LOCKDOWN_CONFIG_RELATIVE")"
     cat >"$work/root/usr/lib/snosi/bootc-secure.json" <<'EOF'
 {"schema":1,"mok_certificate":"/usr/lib/snosi/mok.crt","pcr_public_key":"/usr/lib/snosi/pcr-signing.pub","encrypted_root_mapper":"root","systemd_suite":"forky"}
 EOF
+    printf 'kargs = ["%s"]\n' "$LOCKDOWN_KARG" >"$work/root/$LOCKDOWN_CONFIG_RELATIVE"
     validate_root_contract "$work/root"
     touch "$work/root/boot/EFI/Linux/old.efi"
     if (refuse_existing_uki "$work/root") >/dev/null 2>&1; then rc=1; fi
@@ -844,13 +860,25 @@ scan_image() { # OCI-image MOK-key PCR-key [previous-PCR-key]
 
 negative_self_test() {
     self_test
-    local work fp section
+    local work fp section digest
     work=$(mktemp -d); trap 'rm -rf -- "$work"' RETURN
+    mkdir -p "$work/root/$(dirname "$LOCKDOWN_CONFIG_RELATIVE")"
+    printf 'kargs = ["%s"]\n' "$LOCKDOWN_KARG" >"$work/root/$LOCKDOWN_CONFIG_RELATIVE"
+    validate_lockdown_config "$work/root"
+    printf 'kargs = ["lockdown=none"]\n' >"$work/root/$LOCKDOWN_CONFIG_RELATIVE"
+    if (validate_lockdown_config "$work/root") >/dev/null 2>&1; then
+        die "divergent bootc lockdown configuration accepted"
+    fi
+    rm -f "$work/root/$LOCKDOWN_CONFIG_RELATIVE"
+    if (validate_lockdown_config "$work/root") >/dev/null 2>&1; then
+        die "missing bootc lockdown configuration accepted"
+    fi
     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$work/key" >/dev/null 2>&1
     openssl pkey -in "$work/key" -pubout -out "$work/pub" >/dev/null
     fp=$(pcr_fingerprint "$work/pub")
+    digest=$(printf '%0128d' 0)
     printf 'kernel' >"$work/kernel"; printf 'initrd' >"$work/initrd"; touch "$work/uki"
-    printf 'rw composefs=?%0128d' 0 >"$work/uki.cmdline"
+    sealed_cmdline "$digest" >"$work/uki.cmdline"
     cp "$work/kernel" "$work/uki.linux"; cp "$work/initrd" "$work/uki.initrd"; cp "$work/pub" "$work/uki.pcrpkey"
     jq -n --arg fp "$fp" '{sha256: [range(0; 4) | {pol: ("phase-" + tostring), pkfp: $fp}]}' >"$work/uki.pcrsig"
     mkdir "$work/bin"
@@ -870,17 +898,27 @@ EOF
 [[ ! -e "${@: -1}.bad-signature" ]]
 EOF
     chmod +x "$work/bin/objcopy" "$work/bin/sbverify"
-    PATH="$work/bin:$PATH" validate_uki "$work/uki" "$work/kernel" "$work/initrd" "$work/cert" "$work/pub" "$(printf '%0128d' 0)"
+    PATH="$work/bin:$PATH" validate_uki "$work/uki" "$work/kernel" "$work/initrd" "$work/cert" "$work/pub" "$digest"
+    cp "$work/uki.cmdline" "$work/uki.cmdline.saved"
+    printf 'rw composefs=?%s' "$digest" >"$work/uki.cmdline"
+    if (PATH="$work/bin:$PATH" validate_uki "$work/uki" "$work/kernel" "$work/initrd" "$work/cert" "$work/pub" "$digest") >/dev/null 2>&1; then
+        die "UKI command line without lockdown accepted"
+    fi
+    printf 'rw composefs=?%s lockdown=none' "$digest" >"$work/uki.cmdline"
+    if (PATH="$work/bin:$PATH" validate_uki "$work/uki" "$work/kernel" "$work/initrd" "$work/cert" "$work/pub" "$digest") >/dev/null 2>&1; then
+        die "UKI command line with divergent lockdown accepted"
+    fi
+    mv "$work/uki.cmdline.saved" "$work/uki.cmdline"
     for section in cmdline linux initrd pcrpkey pcrsig; do
         cp "$work/uki.$section" "$work/uki.$section.saved"
         printf 'mutated' >"$work/uki.$section"
-        if (PATH="$work/bin:$PATH" validate_uki "$work/uki" "$work/kernel" "$work/initrd" "$work/cert" "$work/pub" "$(printf '%0128d' 0)") >/dev/null 2>&1; then
+        if (PATH="$work/bin:$PATH" validate_uki "$work/uki" "$work/kernel" "$work/initrd" "$work/cert" "$work/pub" "$digest") >/dev/null 2>&1; then
             die "mutation fixture accepted UKI .$section mutation"
         fi
         mv "$work/uki.$section.saved" "$work/uki.$section"
     done
     touch "$work/uki.bad-signature"
-    if (PATH="$work/bin:$PATH" validate_uki "$work/uki" "$work/kernel" "$work/initrd" "$work/cert" "$work/pub" "$(printf '%0128d' 0)") >/dev/null 2>&1; then
+    if (PATH="$work/bin:$PATH" validate_uki "$work/uki" "$work/kernel" "$work/initrd" "$work/cert" "$work/pub" "$digest") >/dev/null 2>&1; then
         die "mutation fixture accepted UKI Authenticode mutation"
     fi
 }

--- a/test/bootc-secure-install-test.sh
+++ b/test/bootc-secure-install-test.sh
@@ -178,6 +178,14 @@ run_fixtures() {
     else
         fail 'composefs parser accepts its one digest'
     fi
+    assert_true 'lockdown parser accepts exactly one integrity policy' \
+        cmdline_has_lockdown_integrity 'rw composefs=?fixture lockdown=integrity'
+    assert_false 'lockdown parser rejects a missing policy' \
+        cmdline_has_lockdown_integrity 'rw composefs=?fixture'
+    assert_false 'lockdown parser rejects a divergent policy' \
+        cmdline_has_lockdown_integrity 'rw composefs=?fixture lockdown=none'
+    assert_false 'lockdown parser rejects duplicate policy arguments' \
+        cmdline_has_lockdown_integrity 'rw composefs=?fixture lockdown=integrity lockdown=integrity'
     if composefs_from_cmdline 'root=/dev/vda2' >/dev/null 2>&1; then
         fail 'composefs parser rejects root arguments'
     else
@@ -331,6 +339,7 @@ post_recovery_security_subset() {
     vm_ssh 'mokutil --sb-state | grep -q "SecureBoot enabled"' \
         && vm_ssh 'bootctl --no-pager status | grep -q "Measured UKI: yes"' \
         && vm_ssh 'grep -Eq "\[(integrity|confidentiality)\]" /sys/kernel/security/lockdown' \
+        && cmdline_has_lockdown_integrity "$(vm_ssh 'cat /proc/cmdline')" \
         && vm_ssh "cryptsetup isLuks '$backing'" \
         && vm_ssh "cryptsetup luksDump --dump-json-metadata '$backing'" | signed_pcr11_token \
         && vm_ssh "cryptsetup open --test-passphrase --key-file=- '$backing'" <"$RECOVERY_KEY"
@@ -389,6 +398,7 @@ assert_guest() {
     assert_true 'lockdown is integrity or confidentiality' vm_ssh 'grep -Eq "\[(integrity|confidentiality)\]" /sys/kernel/security/lockdown'
     cmdline=$(vm_ssh 'cat /proc/cmdline')
     if composefs_from_cmdline "$cmdline" >/dev/null; then pass 'kernel command line has a composefs binding without accepting raw root data'; else fail 'kernel command line has a composefs binding without accepting raw root data'; fi
+    if cmdline_has_lockdown_integrity "$cmdline"; then pass 'kernel command line seals exactly one lockdown=integrity policy'; else fail 'kernel command line seals exactly one lockdown=integrity policy'; fi
     assert_false 'kernel command line contains no root or LUKS identifier' cmdline_has_root_or_luks "$cmdline"
     entries=$(esp_cat 'loader/entries/*.conf')
     if type2_only <(printf '%s\n' "$entries"); then pass 'installed BLS entries are Type #2-only'; else fail 'installed BLS entries are Type #2-only'; fi

--- a/test/bootc-secure-spike-test.sh
+++ b/test/bootc-secure-spike-test.sh
@@ -328,15 +328,17 @@ require_stable_oci_digest() { # first-pass-digest final-digest
 }
 
 validate_task2_ukify_cmdline() { # cmdline expected-composefs-digest
-    local cmdline=$1 expected_digest=$2 token composefs_count=0 rw_count=0 token_count=0
+    local cmdline=$1 expected_digest=$2 token composefs_count=0 rw_count=0 lockdown_count=0 token_count=0
     valid_composefs_digest "$expected_digest" || return 1
     for token in $cmdline; do
         token_count=$((token_count + 1))
         [[ "$token" == rw ]] && rw_count=$((rw_count + 1))
         [[ "$token" == composefs=* ]] && composefs_count=$((composefs_count + 1))
+        [[ "$token" == lockdown=integrity ]] && lockdown_count=$((lockdown_count + 1))
+        [[ "$token" != lockdown=* || "$token" == lockdown=integrity ]] || return 1
         [[ "$token" != root=* && "$token" != luks.* && "$token" != rd.luks.* ]] || return 1
     done
-    [[ $token_count -eq 2 && $rw_count -eq 1 && $composefs_count -eq 1 ]] || return 1
+    [[ $token_count -eq 3 && $rw_count -eq 1 && $composefs_count -eq 1 && $lockdown_count -eq 1 ]] || return 1
     [[ "$(composefs_digest_from_cmdline "$cmdline")" == "$expected_digest" ]]
 }
 
@@ -505,15 +507,19 @@ EOF
     fi
     assert_failure "a final OCI image changing the first-pass composefs ID is rejected" \
         require_stable_oci_digest "$(printf 'd%.0s' {1..128})" "$(printf 'e%.0s' {1..128})"
-    if validate_task2_ukify_cmdline "rw composefs=?$(printf 'f%.0s' {1..128})" "$(printf 'f%.0s' {1..128})"; then
-        pass "Task 2 UKI cmdline carries rw plus only its composefs binding"
+    if validate_task2_ukify_cmdline "rw composefs=?$(printf 'f%.0s' {1..128}) lockdown=integrity" "$(printf 'f%.0s' {1..128})"; then
+        pass "Task 2 UKI cmdline carries rw, its composefs binding, and lockdown policy"
     else
-        fail "Task 2 UKI cmdline carries rw plus only its composefs binding"
+        fail "Task 2 UKI cmdline carries rw, its composefs binding, and lockdown policy"
     fi
+    assert_failure "Task 2 UKI cmdline rejects a missing lockdown policy" \
+        validate_task2_ukify_cmdline "rw composefs=?$(printf 'f%.0s' {1..128})" "$(printf 'f%.0s' {1..128})"
+    assert_failure "Task 2 UKI cmdline rejects a divergent lockdown policy" \
+        validate_task2_ukify_cmdline "rw composefs=?$(printf 'f%.0s' {1..128}) lockdown=none" "$(printf 'f%.0s' {1..128})"
     assert_failure "Task 2 UKI cmdline rejects dynamic root identifiers" \
-        validate_task2_ukify_cmdline "rw composefs=?$(printf 'f%.0s' {1..128}) root=/dev/vda2" "$(printf 'f%.0s' {1..128})"
+        validate_task2_ukify_cmdline "rw composefs=?$(printf 'f%.0s' {1..128}) lockdown=integrity root=/dev/vda2" "$(printf 'f%.0s' {1..128})"
     assert_failure "Task 2 UKI cmdline rejects dynamic LUKS identifiers" \
-        validate_task2_ukify_cmdline "rw composefs=?$(printf 'f%.0s' {1..128}) rd.luks.uuid=luks-test" "$(printf 'f%.0s' {1..128})"
+        validate_task2_ukify_cmdline "rw composefs=?$(printf 'f%.0s' {1..128}) lockdown=integrity rd.luks.uuid=luks-test" "$(printf 'f%.0s' {1..128})"
 
     printf 'dracut first error\nemergency\n' >"$fixture_root/console.raw"
     fixture_console_diagnostics="$(task3_console_diagnostics "$fixture_root/console.raw")"
@@ -587,7 +593,7 @@ storage_composefs_digest() { # local-image-reference
 validate_uki() { # rootfs uki kernel initrd pcr-public-key expected-digest
 (
     local rootfs=$1 uki=$2 kernel=$3 initrd=$4 pcr_public=$5 expected_digest=$6
-    local work composefs_value cmdline
+    local work cmdline
     work=$(mktemp -d)
     trap 'rm -rf "$work"' EXIT
 
@@ -604,9 +610,8 @@ validate_uki() { # rootfs uki kernel initrd pcr-public-key expected-digest
     objdump -h "$uki" | grep -q '[[:space:]]\.pcrpkey[[:space:]]'
     objdump -h "$uki" | grep -q '[[:space:]]\.pcrsig[[:space:]]'
     cmdline=$(tr '\0' ' ' <"$work/cmdline")
-    composefs_value=$(composefs_digest_from_cmdline "$cmdline")
-    [[ "$composefs_value" == "$expected_digest" ]] || {
-        echo "Error: UKI composefs value '$composefs_value' does not match '$expected_digest'" >&2
+    validate_task2_ukify_cmdline "$cmdline" "$expected_digest" || {
+        echo "Error: UKI command line does not match the composefs and lockdown policy: $cmdline" >&2
         return 1
     }
     sbverify --cert "$BOOTC_SECURE_MOK_CERT" "$uki" >/dev/null
@@ -680,7 +685,7 @@ run_task2_live_proof() {
         --linux "$kernel" \
         --initrd "$initrd" \
         --os-release "@$ROOTFS/usr/lib/os-release" \
-        --cmdline "rw composefs=?$first_digest" \
+        --cmdline "rw composefs=?$first_digest lockdown=integrity" \
         --uname "$version" \
         --pcrpkey "$PCR_PUBLIC" \
         --pcr-private-key "$BOOTC_SECURE_PCR_KEY" \
@@ -926,7 +931,8 @@ run_task3_live_proof() {
         return 2
     fi
     lockdown="$(vm_ssh 'cat /sys/kernel/security/lockdown')"; grep -Eq '\[(integrity|confidentiality)\]' <<<"$lockdown" || return 2
-    cmdline="$(vm_ssh 'cat /proc/cmdline')"; [[ "$(composefs_digest_from_cmdline "$cmdline")" == "$TASK2_FINAL_DIGEST" ]] || return 2
+    cmdline="$(vm_ssh 'cat /proc/cmdline')"
+    validate_task2_ukify_cmdline "$cmdline" "$TASK2_FINAL_DIGEST" || return 2
     failed="$(vm_ssh 'systemctl --failed --no-legend')"; [[ -z "$failed" ]] || return 2
     var_device="$(vm_ssh "lsblk -J -o PATH,FSTYPE | jq -er '.. | objects | select(.fstype? == \"crypto_LUKS\") | .path'" || true)"
     scp "${SSH_OPTS[@]}" -P "$SSH_PORT" -i "$SSH_KEY" "$PCR_PUBLIC" root@localhost:/run/task3-pcr.pub

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -221,7 +221,7 @@ for harness in "$root/test/bootc-secure-install-test.sh" "$root/test/bootc-secur
         echo "${harness##*/} must source the shared assertions library" >&2
         exit 1
     }
-    for shared in esp_cat composefs_from_cmdline type2_only signed_pcr11_token root_backing_device; do
+    for shared in esp_cat composefs_from_cmdline cmdline_has_lockdown_integrity type2_only signed_pcr11_token root_backing_device; do
         if grep -Eq "^${shared}\(\)" "$harness"; then
             echo "${harness##*/} redefines ${shared}; it belongs to the shared library" >&2
             exit 1

--- a/test/bootc-secure-update-test.sh
+++ b/test/bootc-secure-update-test.sh
@@ -168,6 +168,8 @@ secure_runtime_subset() { # recovery MOK certificate
 
     cmdline=$(vm_ssh 'cat /proc/cmdline')
     composefs_from_cmdline "$cmdline" >/dev/null || subset_fail "no composefs= in the kernel command line: $cmdline" || return 1
+    cmdline_has_lockdown_integrity "$cmdline" \
+        || subset_fail "kernel command line does not contain exactly one lockdown=integrity: $cmdline" || return 1
     [[ $cmdline != *root=* && $cmdline != *luks.* && $cmdline != *rd.luks.* ]] \
         || subset_fail "kernel command line carries a root/LUKS identifier: $cmdline" || return 1
 

--- a/test/lib/bootc-secure-assertions.sh
+++ b/test/lib/bootc-secure-assertions.sh
@@ -47,6 +47,15 @@ composefs_from_cmdline() {
     done
     [[ $count -eq 1 && $value =~ ^[[:xdigit:]]{128}$ ]] && printf '%s\n' "$value"
 }
+cmdline_has_lockdown_integrity() {
+    local token count=0
+    for token in $1; do
+        [[ $token == lockdown=* ]] || continue
+        [[ $token == lockdown=integrity ]] || return 1
+        count=$((count + 1))
+    done
+    [[ $count -eq 1 ]]
+}
 type2_only() { # path; materialize once because callers may provide a FIFO.
     local entries
     entries=$(cat "$1") || return

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -44,7 +44,7 @@ bootc and ostree install as regular APT packages from the Frostyard repository (
 `shared/bootc-secure/mkosi.conf` immediately after the bootc runtime package
 fragment. It owns an isolated, low-priority Forky APT sandbox and an explicit,
 ABI-coherent Forky systemd family, avoiding accidental Trixie/Forky library
-mixes in systemd-boot, cryptsetup, and TPM tooling. It adds
+mixes in systemd-boot, cryptsetup, and TPM tooling. It declares
 `lockdown=integrity` through
 `/usr/lib/bootc/kargs.d/10-lockdown.toml`, not mkosi `KernelCommandLine=`:
 these directory-format profiles do not have an mkosi-built UKI for that setting
@@ -52,7 +52,11 @@ to affect. Pinned bootc 1.16.3 loads sorted `*.toml` files from that directory;
 the strict schema is `kargs = ["..."]` with optional
 `match-architectures = ["x86_64"]`. The fragment also carries explicit
 MOK/recovery/TPM/UKI tools and the public-only native MOK certificate plus
-RSA-2048 PCR signing public key. The image contract is
+RSA-2048 PCR signing public key. Secure production assembly invokes ukify
+directly rather than bootc's kargs merge, so it independently requires the
+declaration above to match its canonical policy, seals
+`rw composefs=?<digest> lockdown=integrity`, and validates that exact final
+`.cmdline`. The image contract is
 `/usr/lib/snosi/bootc-secure.json` (schema 1). Task 5 adds
 `shared/bootc-secure/assemble-uki.sh`, called only through
 `buildah-package.sh` when `SNOSI_BOOTC_SECURE=1`: the pristine first OCI package


### PR DESCRIPTION
## Summary

- make `rw composefs=?<digest> lockdown=integrity` the canonical secure bootc UKI command line
- require the image-side `10-lockdown.toml` declaration to match that policy byte-for-byte
- validate the final signed UKI `.cmdline` and reject missing or divergent lockdown values
- assert exactly one `lockdown=integrity` token after secure install, recovery, and update boots
- update the feasibility fixtures and secure assembly documentation to match

Closes #615

## Security impact

The production direct-`ukify` path bypassed bootc's image-side `kargs.d` merge and sealed only `rw composefs=?<digest>`. Secure Boot authenticated that lockdown-free UKI, and Snowfield's kernel does not independently raise lockdown under Secure Boot. Assembly now fails closed unless the rootfs declaration, ukify input, and extracted signed UKI command line all agree on `lockdown=integrity`.

## Validation

- `./shared/bootc-secure/assemble-uki.sh --negative-self-test`
- `./shared/bootc-secure/assemble-uki.sh --credential-negative-self-test`
- `./test/bootc-secure-spike-test.sh --fixtures`
- `./test/bootc-secure-install-test.sh --fixtures`
- `./test/bootc-secure-update-test.sh --fixtures`
- `./test/bootc-secure-artifact-test.sh --fixtures`
- `./test/bootc-secure-static-test.sh`
- `./test/bootc-secure-docs-test.sh`
- `./test/bootc-secure-ci-test.sh`
- ShellCheck on changed shell scripts
