### PR TITLE
fix(task9): read the installed UKI off the ESP too, and guard every /boot path

### DIFF
--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -231,4 +231,23 @@ done
 # bootc writes `uki`; requiring `efi` alone rejects every genuine install.
 grep -Fq '(uki|efi)' "$lib"
 
+# No guest command in these harnesses may reach into /boot. bootc mounts it only
+# while it is using it, so every /boot path reports absent on a HEALTHY system:
+# it produced "BLS entries are not Type #2-only" on one run and "no UKI at the
+# composefs path" on the next, both for state that was present the whole time.
+# Boot assets are read off the ESP (esp_cat) or from /usr.
+#
+# Comments are stripped first: the harnesses explain this at length, and that
+# prose must not trip the guard. Same shape as the ssh_private_key check that
+# matched its own documentation.
+for harness in "$root/test/bootc-secure-install-test.sh" \
+               "$root/test/bootc-secure-update-test.sh" \
+               "$lib"; do
+    if sed 's/#.*//' "$harness" | grep -Eq '(vm_ssh|scp)[^#]*/boot/'; then
+        echo "${harness##*/} reaches into /boot in a guest command; use esp_cat" >&2
+        sed 's/#.*//' "$harness" | grep -nE '(vm_ssh|scp)[^#]*/boot/' >&2
+        exit 1
+    fi
+done
+
 echo "Bootc secure static validation passed"

--- a/test/bootc-secure-update-test.sh
+++ b/test/bootc-secure-update-test.sh
@@ -186,10 +186,30 @@ secure_runtime_subset() { # recovery MOK certificate
         || subset_fail "the recovery credential no longer opens $backing" || return 1
     vm_ssh "source=/usr/lib/snosi/bootc/systemd-bootx64.efi; test -s \"\$source\"; sbverify --cert /usr/lib/snosi/mok.crt \"\$source\" >/dev/null" \
         || subset_fail "the immutable second-stage source is missing or not MOK-signed" || return 1
-    vm_ssh "test -e /boot/EFI/Linux/bootc/bootc_composefs-$(composefs_from_cmdline "$cmdline").efi" \
-        || subset_fail "no UKI at the composefs path for $(composefs_from_cmdline "$cmdline")" || return 1
-    vm_ssh "sbverify --cert /usr/lib/snosi/mok.crt /boot/EFI/Linux/bootc/bootc_composefs-$(composefs_from_cmdline "$cmdline").efi >/dev/null" \
-        || subset_fail "the installed UKI is not MOK-signed" || return 1
+    # The UKI is read off the ESP, for the same reason the BLS entries are:
+    # bootc leaves /boot unmounted unless it is using it, so `test -e
+    # /boot/EFI/Linux/...` reports absent on a perfectly healthy system. That is
+    # exactly what it did on run 31293274112 -- "no UKI at the composefs path"
+    # for a UKI that was present the whole time.
+    #
+    # Fixing only the BLS read last time and not sweeping the rest of this
+    # function for the same mistake is what produced that run. Every remaining
+    # guest path here is now ESP-relative or /usr.
+    #
+    # Signature verification runs HOST-side against the MOK identity the caller
+    # supplied, rather than in-guest against the guest's own copy: the guest
+    # certificate is separately compared to the supplied one below, so verifying
+    # against the supplied identity is the stronger check and needs no second
+    # in-guest tool.
+    local composefs_id uki_local
+    composefs_id=$(composefs_from_cmdline "$cmdline")
+    uki_local="$WORK/uki-installed.efi"
+    esp_cat "EFI/Linux/bootc/bootc_composefs-${composefs_id}.efi" >"$uki_local" 2>/dev/null \
+        || subset_fail "no UKI on the ESP at EFI/Linux/bootc/bootc_composefs-${composefs_id}.efi" || return 1
+    [[ -s $uki_local ]] \
+        || subset_fail "the UKI on the ESP for ${composefs_id} is empty" || return 1
+    sbverify --cert "$mok" "$uki_local" >/dev/null 2>&1 \
+        || subset_fail "the installed UKI is not signed by the supplied MOK identity" || return 1
 
     guest_mok=$(mktemp "$WORK/mok-guest.XXXXXX") || return 1
     rm -f -- "$guest_mok"


### PR DESCRIPTION
Run [31293274112](https://github.com/frostyard/snosi/actions/runs/31293274112) cleared the BLS check — `esp_cat` and the shared `type2_only` both worked — and then failed on:

```
no UKI at the composefs path for 1ebe973a...
```

for a UKI that was **present the entire time**. Same root cause as the BLS entries: bootc mounts `/boot` only while it's using it, so `test -e /boot/EFI/Linux/...` reports absent on a healthy system.

## What I did wrong

I fixed the BLS read last time and **didn't sweep the rest of the function for the same mistake**. Two more `/boot` paths were sitting three lines below it.

That is precisely the failure the rule I wrote in #616 warns about — *"when a fix applies to a behaviour that exists twice, move the behaviour rather than copying the fix"* — made while writing it. One more run spent on a defect I was already looking at.

## The fix

Both paths are now ESP-relative. Signature verification moves **host-side** against the MOK identity the caller supplied, rather than in-guest against the guest's own copy: the guest certificate is separately compared to the supplied one a few lines later, so verifying against the supplied identity is the stronger check and needs no second in-guest tool.

## The durable part

No guest command in either harness or the shared library may reference `/boot`. Comments are stripped first — these files explain the rule at length and that prose must not trip it, the same shape as the `ssh_private_key` check that matched its own documentation.

| check | result |
|---|---|
| reintroduced `/boot` guest read | exit 1 |
| restored | exit 0 |
| `/boot` guest reads remaining | none |
| install / update fixtures | pass |