### PR TITLE
fix(task9): build the persistence marker within the shipped signature policy

### DIFF
--- a/test/bootc-secure-update-test.sh
+++ b/test/bootc-secure-update-test.sh
@@ -219,12 +219,21 @@ secure_runtime_subset() { # recovery MOK certificate
 }
 
 copy_and_run_persistence() { # write|verify
+    # Four steps behind one caller-side FATAL. Name them: "could not write
+    # persistence markers" does not distinguish a missing script, a failed
+    # copy, and the guest script itself failing -- and the guest script is the
+    # interesting case, since its output is the finding.
     local action=$1
     local script="$ROOT_DIR/test/update-tests/persistence-$action.sh"
-    vm_ssh 'mkdir -p /tmp/task9-lib'
-    scp "${SSH_OPTS[@]}" -i "$SSH_KEY" -P "$SSH_PORT" "$ROOT_DIR/test/lib/helpers.sh" root@localhost:/tmp/task9-lib/helpers.sh
-    scp "${SSH_OPTS[@]}" -i "$SSH_KEY" -P "$SSH_PORT" "$script" root@localhost:/tmp/task9-persistence.sh
-    vm_ssh 'TEST_LIB_DIR=/tmp/task9-lib bash /tmp/task9-persistence.sh'
+    [[ -f $script ]] || { echo "  persistence: no such script: $script" >&2; return 1; }
+    vm_ssh 'mkdir -p /tmp/task9-lib' \
+        || { echo "  persistence: could not create /tmp/task9-lib in the guest" >&2; return 1; }
+    scp "${SSH_OPTS[@]}" -i "$SSH_KEY" -P "$SSH_PORT" "$ROOT_DIR/test/lib/helpers.sh" root@localhost:/tmp/task9-lib/helpers.sh \
+        || { echo "  persistence: could not copy helpers.sh to the guest" >&2; return 1; }
+    scp "${SSH_OPTS[@]}" -i "$SSH_KEY" -P "$SSH_PORT" "$script" root@localhost:/tmp/task9-persistence.sh \
+        || { echo "  persistence: could not copy ${script##*/} to the guest" >&2; return 1; }
+    vm_ssh 'TEST_LIB_DIR=/tmp/task9-lib bash /tmp/task9-persistence.sh' \
+        || { echo "  persistence: ${script##*/} failed IN THE GUEST (its output is above)" >&2; return 1; }
 }
 
 guest_digest() { vm_ssh 'bootc status --format json' | jq -r ".status.$1.image.imageDigest // empty"; }

--- a/test/update-tests/persistence-write.sh
+++ b/test/update-tests/persistence-write.sh
@@ -22,10 +22,28 @@ fi
 echo "home-marker" > /var/home/persisttest/marker.txt
 chown persisttest:persisttest /var/home/persisttest/marker.txt
 
-# Container image in /var/lib/containers, built offline (no registry pull)
+# Container image in /var/lib/containers, built offline (no registry pull).
+#
+# `podman import` of a rootfs tarball is REJECTED on a secure system and that
+# is correct: the shipped policy.json defaults to reject and permits only the
+# three signed ghcr scopes plus containers-storage, so the `tarball:` transport
+# has no accepting scope. Observed on run 31293719998:
+#
+#     Error: Source image rejected: Running image tarball:/var/tmp/podman... is
+#     rejected by policy.
+#
+# `podman build` FROM scratch pulls no source image, so no transport is
+# consulted and no policy exception is needed. Verified directly against a
+# reject-by-default policy: the import is refused with the exact error above,
+# the build succeeds. The marker is still a real image in the store, so this
+# proves what it always did -- that /var/lib/containers survives an update.
+#
+# Do NOT "fix" this by adding a tarball/dir/oci scope to policy.json. The test
+# must fit the shipped security posture, not the other way round.
 tmpf=$(mktemp -d)
 echo "container-marker" > "$tmpf/marker"
-tar -C "$tmpf" -cf - marker | podman import --quiet - localhost/persist-test:1 >/dev/null
+printf 'FROM scratch\nCOPY marker /marker\n' > "$tmpf/Containerfile"
+podman build --quiet --tag localhost/persist-test:1 --file "$tmpf/Containerfile" "$tmpf" >/dev/null
 rm -rf "$tmpf"
 
 # /opt is a bind to /var/opt


### PR DESCRIPTION
**The pre-update gate is clear.** Run [31293719998](https://github.com/frostyard/snosi/actions/runs/31293719998) passed every install assertion, both recovery legs, and *all* of `secure_runtime_subset` — then failed on the first genuinely new step:

```
# Writing persistence markers
Error: Source image rejected: Running image tarball:/var/tmp/podman... is rejected by policy.
```

## This is the policy working, not a defect in it

`policy.json` defaults to `reject` and permits only the three signed ghcr scopes plus `containers-storage`. `podman import` of a rootfs tarball has no accepting scope. It also has no `--signature-policy` flag, and skopeo can't synthesise an image from a rootfs tarball.

`podman build` **FROM scratch** pulls no source image, so no transport is consulted and no exception is needed.

Verified directly against a reject-by-default policy:

```
podman import  -> Error: Source image rejected: ... tarball:... is rejected by policy
podman build   -> succeeds
```

The marker is still a real image in the store under the same name and tag, so `persistence-verify.sh` is unchanged and still proves what it always did — that `/var/lib/containers` survives an update.

The comment says explicitly **not** to "fix" this by adding a `tarball`/`dir`/`oci` scope to `policy.json`. The test fits the security posture, not the reverse.

## Also

`copy_and_run_persistence` had four steps behind one caller-side FATAL, which couldn't distinguish a missing script from a failed copy from the guest script failing — and the guest script is the interesting case. Each step now names itself.

## Worth your judgement separately

The global `reject` means a secure system cannot `podman import`, `podman load`, or use `dir:`/`oci:` transports **at all**. That's a real usability consequence for anyone doing local image work on an installed machine. Task 6's note only says not to broaden the `docker` scope; it doesn't speak to local transports. Not blocking D6 — flagging it rather than deciding it.