### PR TITLE
feat(bootc-secure): let developers do local image work on an installed system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,10 +272,23 @@ documentation contracts are complete; live release evidence remains BLOCKED.
 `/usr/lib/snosi/cosign.pub`. Cosign v2.6.1 signatures record repository rather
 than tag identities, so this MUST use `signedIdentity: matchRepository` and
 the GHCR `registries.d` entry MUST retain `use-sigstore-attachments: true`.
-The sole local exception is the empty `containers-storage` transport scope with
-`insecureAcceptAnything`: it permits bootc to consume only the image already
-accepted by Podman's signed `docker` pull; do not broaden `docker` to a namespace
-or global acceptance. Secure install
+LOCAL transports are accepted with `insecureAcceptAnything`: `containers-storage`
+(so bootc consumes the image Podman's signed `docker` pull already accepted),
+plus `tarball`, `docker-archive`, `oci-archive`, `dir`, and `oci` so an operator
+can do ordinary image work on an installed system — `podman load`, `podman
+import`, OCI layouts. Those bytes are already on the machine and under the
+operator's control; the boundary this policy exists to enforce is the REGISTRY
+one. Blocking them was also inconsistent rather than strict: `podman build`
+FROM scratch consults no transport at all, so arbitrary local images were always
+constructible — the prohibition cost usability and bought nothing.
+
+**Do not broaden `docker`** to a namespace or global acceptance, and do not
+change `default` from `reject`. That is the half that matters, and
+`test/bootc-container-policy-test.sh` fails if either moves: it requires every
+`docker` scope to stay `sigstoreSigned`, forbids a catch-all `docker` scope, and
+pins the default to `reject`. Verified against the real policy that an unsigned
+`docker.io` pull and an unsigned `ghcr.io/frostyard/cayo` pull are both still
+refused while `podman import` succeeds. Secure install
 paths must not use `--skip-fetch-check`. Local rootfs test fixtures use their
 own disposable permissive policy only; registry paths use a disposable HOME
 containing the restrictive policy so host configuration is never changed.

--- a/shared/bootc-secure/tree/etc/containers/policy.json
+++ b/shared/bootc-secure/tree/etc/containers/policy.json
@@ -40,6 +40,41 @@
           "type": "insecureAcceptAnything"
         }
       ]
+    },
+    "tarball": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    },
+    "docker-archive": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    },
+    "oci-archive": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    },
+    "dir": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    },
+    "oci": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
     }
   }
 }

--- a/test/bootc-container-policy-test.sh
+++ b/test/bootc-container-policy-test.sh
@@ -76,6 +76,41 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
     else
         fail "only the three supported GHCR repositories are trusted"
     fi
+
+    # LOCAL file transports are accepted so an operator can actually do image
+    # work on an installed system -- podman load/import, dir:/oci: layouts.
+    # The bytes are already on the machine and under their control; the trust
+    # boundary this policy exists to enforce is the REGISTRY one.
+    #
+    # Blocking them was also inconsistent rather than strict: `podman build`
+    # FROM scratch consults no transport, so arbitrary local images were always
+    # constructible. The prohibition cost usability and bought nothing.
+    for transport in tarball docker-archive oci-archive dir oci; do
+        if jq -e --arg t "$transport" '.transports[$t][""] == [{"type":"insecureAcceptAnything"}]' "$POLICY" >/dev/null; then
+            pass "local $transport images are accepted"
+        else
+            fail "local $transport images are accepted"
+        fi
+    done
+
+    # The half that must NOT move. Permitting local transports must never turn
+    # into permitting unsigned registry pulls: `docker` keeps exactly the three
+    # sigstoreSigned scopes and the default stays reject.
+    if jq -e '.default == [{"type":"reject"}]' "$POLICY" >/dev/null; then
+        pass "the default policy is still reject"
+    else
+        fail "the default policy is still reject"
+    fi
+    if jq -e '[.transports.docker[][] | select(.type != "sigstoreSigned")] | length == 0' "$POLICY" >/dev/null; then
+        pass "every docker scope is still sigstoreSigned"
+    else
+        fail "every docker scope is still sigstoreSigned"
+    fi
+    if jq -e '.transports.docker[""] == null' "$POLICY" >/dev/null; then
+        pass "no catch-all docker scope was introduced"
+    else
+        fail "no catch-all docker scope was introduced"
+    fi
 else
     fail "policy is valid JSON (jq and the policy are required)"
 fi


### PR DESCRIPTION
The shipped policy defaulted to `reject` and permitted only the three signed ghcr scopes plus `containers-storage` — so `podman load`, `podman import`, and `dir:`/`oci:` layouts were **all refused** on an installed machine. Someone developing *on* snosi couldn't do ordinary image work.

## It was inconsistent, not strict

`podman build` FROM scratch consults no transport at all, so arbitrary local images were **always** constructible. Measured directly against a reject-by-default policy:

```
podman import  -> Error: Source image rejected: ... tarball:... is rejected by policy
podman build   -> succeeds
```

The prohibition cost usability and prevented nothing.

## The change

Local file transports — `tarball`, `docker-archive`, `oci-archive`, `dir`, `oci` — now accept anything. Those bytes are already on the machine and under the operator's control. The boundary this policy exists to enforce is the **registry** one, and that half is untouched.

Verified against the real edited policy, not by inspection:

| operation | result |
|---|---|
| `podman import localhost/...` | **succeeds** |
| `podman pull docker.io/library/busybox` | rejected by policy |
| `podman pull ghcr.io/frostyard/cayo` | *"a signature was required, but no signature exists"* |

## Both halves are pinned

Permitting local transports must never drift into permitting unsigned registry pulls. The test now requires: every local transport accepted, `default` stays `reject`, every `docker` scope stays `sigstoreSigned`, and no catch-all `docker` scope.

| mutation | exit |
|---|---|
| catch-all `docker` scope added | non-zero |
| `default` flipped to accept | non-zero |
| restored | 0 |

## Note

This removes the reason `persistence-write.sh` had to avoid `podman import` (#625). That change stands on its own merits — FROM scratch is a perfectly good way to build a marker — and is left alone.