### PR TITLE
ci: avoid direct GitHub actor interpolation

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -252,10 +252,11 @@ jobs:
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.profile }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
           # The job-scoped token has only this repository's packages:write.
           # Pass it via stdin so it never appears in process arguments.
-          printf '%s' "$GH_TOKEN" | sudo buildah login -u "${{ github.actor }}" --password-stdin ghcr.io
+          printf '%s' "$GH_TOKEN" | sudo buildah login -u "$GHCR_USER" --password-stdin ghcr.io
 
           sudo TMPDIR="$TMPDIR" buildah push \
             --compression-format=zstd:chunked \
@@ -328,8 +329,9 @@ jobs:
       - name: Login to GHCR with ORAS
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
-          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "$GHCR_USER" --password-stdin
 
       - name: Upload SBOM
         id: upload-sbom
@@ -566,8 +568,9 @@ jobs:
         if: steps.current.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
-          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "$GHCR_USER" --password-stdin
 
       - name: Resolve previous and current snow tags
         id: versions

--- a/.github/workflows/build-mechanics.yml
+++ b/.github/workflows/build-mechanics.yml
@@ -157,9 +157,10 @@ jobs:
           # Scoped to this repository and this run, matching the secure
           # publisher's least-privilege credential model.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
           # Login via stdin so the token never appears in process arguments.
-          echo "$GH_TOKEN" | sudo buildah login -u "${{ github.actor }}" --password-stdin ghcr.io
+          printf '%s' "$GH_TOKEN" | sudo buildah login -u "$GHCR_USER" --password-stdin ghcr.io
 
           # Immutable, version-stamped.
           sudo TMPDIR="$TMPDIR" buildah push --compression-format=zstd:chunked \

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -52,7 +52,10 @@ jobs:
       # under rootless podman), and the image must be pulled into root's
       # storage for the install container to see it.
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | sudo podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: printf '%s' "$GH_TOKEN" | sudo podman login ghcr.io -u "$GHCR_USER" --password-stdin
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,10 @@ Docker login config explicitly: inspections use `--authfile`, root policy copy
 uses source-only `--src-authfile`, and promotion uses source and destination
 auth files. The run-scoped `GITHUB_TOKEN` is the only GHCR credential:
 `secure-build` grants `packages: write`, while `release` grants only
-`packages: read`; Buildah and ORAS receive it through stdin. The successful
+`packages: read`; Buildah and ORAS receive it through stdin. Shell `run:`
+steps expose `github.actor` only through the quoted `GHCR_USER` environment
+variable; never interpolate GitHub context values directly into shell source.
+The successful
 three-profile mechanics publication run `31150007630` proves repository-token
 write access to the same cayo, snow, and snowfield packages, so a long-lived
 GHCR PAT is neither required nor permitted. Pinned Cosign v2.6.1 receives

--- a/README.md
+++ b/README.md
@@ -524,7 +524,9 @@ policy copy, and artifact before moving `latest`; a failed candidate cannot
 move `latest`. GHCR authentication uses only the run-scoped `GITHUB_TOKEN`
 (`packages: write` for secure publication and `packages: read` for release
 discovery); command-line logins receive it through stdin, never process
-arguments. Native pull requests likewise use disposable RSA-4096 MOK and
+arguments. Shell login steps pass `github.actor` through a quoted `GHCR_USER`
+environment variable instead of interpolating context data into shell source.
+Native pull requests likewise use disposable RSA-4096 MOK and
 RSA-2048 PCR credentials and cannot publish. Fixture success proves runner and
 publication-contract behavior only, not a live secure installation, update,
 rotation, full rollback window, or Snowfield hardware result.

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -205,10 +205,14 @@ else
             capture && /^      - name: / && $0 != "      - name: Push immutable version tag" { exit }
             capture { print }
         ' <<<"$secure_job")
+        # shellcheck disable=SC2016 # GitHub expressions are exact literal markers.
         require_text "$workflow secure push token" "$push_step" \
             '          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+        # shellcheck disable=SC2016 # GitHub expression is an exact literal marker.
+        require_text "$workflow secure push actor" "$push_step" \
+            '          GHCR_USER: ${{ github.actor }}'
         push_login_line=$(cat <<'EOF'
-          printf '%s' "$GH_TOKEN" | sudo buildah login -u "${{ github.actor }}" --password-stdin ghcr.io
+          printf '%s' "$GH_TOKEN" | sudo buildah login -u "$GHCR_USER" --password-stdin ghcr.io
 EOF
 )
         require_text "$workflow secure Buildah login" "$push_step" "$push_login_line"
@@ -220,6 +224,7 @@ EOF
         ' <<<"$secure_job")
         require_text "$workflow secure registry login" "$login_step" \
             '        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3'
+        # shellcheck disable=SC2016 # GitHub expression is an exact literal marker.
         require_text "$workflow secure registry token" "$login_step" \
             '          password: ${{ secrets.GITHUB_TOKEN }}'
 
@@ -228,10 +233,14 @@ EOF
             capture && /^      - name: / && $0 != "      - name: Login to GHCR with ORAS" { exit }
             capture { print }
         ' <<<"$secure_job")
+        # shellcheck disable=SC2016 # GitHub expressions are exact literal markers.
         require_text "$workflow secure ORAS token" "$oras_login_step" \
             '          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+        # shellcheck disable=SC2016 # GitHub expression is an exact literal marker.
+        require_text "$workflow secure ORAS actor" "$oras_login_step" \
+            '          GHCR_USER: ${{ github.actor }}'
         oras_login_line=$(cat <<'EOF'
-          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "$GHCR_USER" --password-stdin
 EOF
 )
         require_text "$workflow secure ORAS login" "$oras_login_step" "$oras_login_line"
@@ -326,10 +335,14 @@ EOF
             capture && /^      - name: / && $0 != "      - name: Login to GHCR with ORAS" { exit }
             capture { print }
         ' <<<"$release_job")
+        # shellcheck disable=SC2016 # GitHub expressions are exact literal markers.
         require_text "$workflow release ORAS token" "$release_oras_login" \
             '          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+        # shellcheck disable=SC2016 # GitHub expression is an exact literal marker.
+        require_text "$workflow release ORAS actor" "$release_oras_login" \
+            '          GHCR_USER: ${{ github.actor }}'
         release_oras_login_line=$(cat <<'EOF'
-          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "$GHCR_USER" --password-stdin
 EOF
 )
         require_text "$workflow release ORAS login" \

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -119,8 +119,9 @@ jobs:
        - name: Push immutable version tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
-          printf '%s' "$GH_TOKEN" | sudo buildah login -u "${{ github.actor }}" --password-stdin ghcr.io
+          printf '%s' "$GH_TOKEN" | sudo buildah login -u "$GHCR_USER" --password-stdin ghcr.io
        - name: Log in to ghcr.io
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -143,8 +144,9 @@ jobs:
        - name: Login to GHCR with ORAS
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
-          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "$GHCR_USER" --password-stdin
        - name: Upload SBOM
        - name: Sign SBOM
        - name: Attest build provenance
@@ -168,8 +170,9 @@ jobs:
       - name: Login to GHCR with ORAS
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
-          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io -u "$GHCR_USER" --password-stdin
       - name: Resolve previous and current snow tags
         run: |
           ./shared/bootc-secure/ci/resolve-snow-release-predecessor.sh \
@@ -269,6 +272,10 @@ remove_release_oras_token() {
     perl -0pi -e 's/(  release:.*?      - name: Login to GHCR with ORAS\n        env:\n)          GH_TOKEN:[^\n]*\n/$1/s' \
         "$1/.github/workflows/build-images.yml"
 }
+interpolate_actor_directly() {
+    perl -pi -e 's/"\$GHCR_USER"/"\${{ github.actor }}"/g' \
+        "$1/.github/workflows/build-images.yml"
+}
 remove_buildah_password_stdin() {
     perl -0pi -e 's/ --password-stdin ghcr\.io/ ghcr.io/' \
         "$1/.github/workflows/build-images.yml"
@@ -335,6 +342,7 @@ assert_guard 'missing secure push GITHUB_TOKEN fails' 1 remove_push_github_token
 assert_guard 'wrong Docker login token fails' 1 replace_docker_login_token
 assert_guard 'missing secure ORAS GITHUB_TOKEN fails' 1 remove_secure_oras_token
 assert_guard 'missing release ORAS GITHUB_TOKEN fails' 1 remove_release_oras_token
+assert_guard 'direct actor interpolation in registry logins fails' 1 interpolate_actor_directly
 assert_guard 'Buildah login without password stdin fails' 1 remove_buildah_password_stdin
 for variable in SNOSI_BOOTC_SECURE SNOSI_BOOTC_MOK_KEY SNOSI_BOOTC_MOK_CERT SNOSI_BOOTC_PCR_KEY SNOSI_BOOTC_PCR_CERT; do
     assert_guard "missing $variable fails" 1 remove_package_variable "$variable"

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -57,8 +57,10 @@ Each matrix build resets mkosi dependencies to `base` (`--dependency= --dependen
 GHCR authentication is repository- and run-scoped: `secure-build` grants
 `packages: write`, while `release` grants only `packages: read`; both use
 `secrets.GITHUB_TOKEN`. Buildah and ORAS consume the token through stdin, and
-Docker login writes the user-context auth file used by Cosign and Skopeo. No
-long-lived GHCR PAT is required. Scheduled mechanics run `31150007630`
+Docker login writes the user-context auth file used by Cosign and Skopeo.
+Registry-login `run:` steps map `github.actor` to `GHCR_USER` in `env:` and
+quote that shell variable; direct GitHub context interpolation in shell source
+is forbidden. No long-lived GHCR PAT is required. Scheduled mechanics run `31150007630`
 successfully pushed all three profiles with the same repository token, proving
 the cayo, snow, and snowfield package access needed by secure publication.
 


### PR DESCRIPTION
## Summary
- pass `github.actor` through quoted `GHCR_USER` step environment variables in all affected registry login shell commands
- move the installation workflow token to `GH_TOKEN` rather than interpolating the secret into shell source
- extend the secure publication guard and fixture coverage to reject direct actor interpolation

## Validation
- `actionlint .github/workflows/build-images.yml .github/workflows/build-mechanics.yml .github/workflows/test-install.yml`
- `shellcheck check-bootc-publication-guard.sh test/bootc-publication-guard-test.sh`
- `./check-bootc-publication-guard.sh`
- `./test/bootc-publication-guard-test.sh`

Closes #631
