### PR TITLE
fix: bound APT package index decompression

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -25,36 +25,29 @@ jobs:
       # resolves packages from APT during the sysext build.
       - name: Check latest package versions
         run: |
-          get_latest_version() {
-            local url="$1" pkg="$2" latest=""
-            while IFS= read -r ver; do
-              if [ -z "$latest" ] || dpkg --compare-versions "$ver" gt "$latest"; then
-                latest="$ver"
-              fi
-            done < <(curl --retry 3 --connect-timeout 10 -fsSL "${url}" | gunzip | awk -v pkg="$pkg" '
-              /^Package: / { current = $2 }
-              /^Version: / && current == pkg { print $2 }
-            ')
-            if [ -z "$latest" ]; then
-              echo "ERROR: no version found for ${pkg}" >&2
-              return 1
-            fi
-            echo "$latest"
-          }
+          set -euo pipefail
+          source shared/download/package-version.sh
 
           {
-            echo "code=$(get_latest_version \
+            version="$(get_latest_package_version \
               'https://packages.microsoft.com/repos/code/dists/stable/main/binary-amd64/Packages.gz' \
               'code')"
-            echo "docker-ce=$(get_latest_version \
+            printf 'code=%s\n' "$version"
+
+            version="$(get_latest_package_version \
               'https://download.docker.com/linux/debian/dists/trixie/stable/binary-amd64/Packages.gz' \
               'docker-ce')"
-            echo "1password-cli=$(get_latest_version \
+            printf 'docker-ce=%s\n' "$version"
+
+            version="$(get_latest_package_version \
               'https://downloads.1password.com/linux/debian/amd64/dists/stable/main/binary-amd64/Packages.gz' \
               '1password-cli')"
-            echo "claude-desktop=$(get_latest_version \
+            printf '1password-cli=%s\n' "$version"
+
+            version="$(get_latest_package_version \
               'https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages.gz' \
               'claude-desktop')"
+            printf 'claude-desktop=%s\n' "$version"
           } > latest-versions.txt
           cat latest-versions.txt
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -164,6 +164,11 @@ jobs:
         # siblings stay byte-identical. No root, no network, no image build.
         run: ./test/update-checksums-split-test.sh
 
+      - name: Validate bounded APT package-index parsing
+        # PATH-stubbed curl fixtures cover transfer deadlines, decompressed-size
+        # limits, gzip integrity, and Debian version ordering without network.
+        run: ./test/check-packages-test.sh
+
       - name: Validate expensive-workflow path filters
         # Static guard: docs and the standalone redirect worker must not fan
         # out into image matrices, and Scorecard remains schedule-driven.

--- a/shared/download/package-version.sh
+++ b/shared/download/package-version.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Fetch and parse an APT Packages.gz index with bounded transfer time and
+# decompressed size.
+
+get_latest_package_version() (
+    set -o pipefail
+
+    local url="$1"
+    local package="$2"
+    local max_bytes="${3:-52428800}"
+    local max_seconds="${4:-60}"
+    local work_dir packages_file versions_file
+    local pipeline_status=0
+    local size latest="" version
+
+    if [[ ! "$max_bytes" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: decompressed size limit must be a positive integer" >&2
+        return 1
+    fi
+    if [[ ! "$max_seconds" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: transfer timeout must be a positive integer" >&2
+        return 1
+    fi
+
+    work_dir="$(mktemp -d)" || return 1
+    trap 'rm -rf "$work_dir"' EXIT
+    packages_file="$work_dir/Packages"
+    versions_file="$work_dir/versions"
+
+    timeout --kill-after=5s "${max_seconds}s" \
+        curl --retry 3 --connect-timeout 10 \
+            --max-time "$max_seconds" --retry-max-time "$max_seconds" \
+            --fail --silent --show-error --location "$url" |
+        gzip -dc |
+        head -c "$((max_bytes + 1))" >"$packages_file" ||
+        pipeline_status=$?
+
+    size="$(wc -c <"$packages_file")"
+    if (( size > max_bytes )); then
+        echo "ERROR: decompressed package index exceeds $max_bytes bytes" >&2
+        return 1
+    fi
+    if (( pipeline_status != 0 )); then
+        echo "ERROR: transfer or gzip validation failed for $url" >&2
+        return 1
+    fi
+
+    awk -v package="$package" '
+        /^Package: / { current = $2 }
+        /^Version: / && current == package { print $2 }
+    ' "$packages_file" >"$versions_file"
+
+    while IFS= read -r version; do
+        if [[ -z "$latest" ]] ||
+            dpkg --compare-versions "$version" gt "$latest"; then
+            latest="$version"
+        fi
+    done <"$versions_file"
+
+    if [[ -z "$latest" ]]; then
+        echo "ERROR: no version found for $package" >&2
+        return 1
+    fi
+    printf '%s\n' "$latest"
+)

--- a/test/check-packages-test.sh
+++ b/test/check-packages-test.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Regression tests for bounded external APT package-index parsing.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$PROJECT_ROOT/shared/download/package-version.sh"
+WORK_DIR=""
+PASS=0
+FAIL=0
+RUN_STATUS=0
+RUN_STDOUT=""
+RUN_STDERR=""
+
+cleanup() {
+    if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+record_pass() {
+    echo "ok - $1"
+    (( PASS++ )) || true
+}
+
+record_fail() {
+    echo "not ok - $1"
+    if [[ $# -gt 1 ]]; then
+        echo "  $2" >&2
+    fi
+    (( FAIL++ )) || true
+}
+
+assert_equals() {
+    local desc="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [[ "$actual" == "$expected" ]]; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "expected '$expected', got '$actual'"
+    fi
+}
+
+assert_stderr_contains() {
+    local desc="$1"
+    local expected="$2"
+
+    if [[ "$RUN_STDERR" == *"$expected"* ]]; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "stderr lacked '$expected': $RUN_STDERR"
+    fi
+}
+
+assert_curl_argument() {
+    local desc="$1"
+    local expected="$2"
+
+    if grep -qxF -- "$expected" "$CURL_LOG"; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "curl arguments lacked '$expected'"
+    fi
+}
+
+run_lookup() {
+    local fixture="$1"
+    local max_bytes="$2"
+    local max_seconds="$3"
+    local sleep_seconds="${4:-}"
+
+    export CURL_FIXTURE="$fixture"
+    export CURL_SLEEP="$sleep_seconds"
+    : >"$CURL_LOG"
+    RUN_STATUS=0
+    get_latest_package_version \
+        "https://packages.example.invalid/Packages.gz" \
+        "fixture" "$max_bytes" "$max_seconds" \
+        >"$WORK_DIR/stdout.log" 2>"$WORK_DIR/stderr.log" ||
+        RUN_STATUS=$?
+    RUN_STDOUT="$(cat "$WORK_DIR/stdout.log")"
+    RUN_STDERR="$(cat "$WORK_DIR/stderr.log")"
+}
+
+[[ -f "$HELPER" ]] || { echo "Error: helper not found: $HELPER" >&2; exit 1; }
+
+WORK_DIR="$(mktemp -d)"
+mkdir -p "$WORK_DIR/bin"
+CURL_LOG="$WORK_DIR/curl.log"
+export CURL_LOG
+
+cat >"$WORK_DIR/bin/curl" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$@" >"$CURL_LOG"
+if [[ -n "$CURL_SLEEP" ]]; then
+    sleep "$CURL_SLEEP"
+fi
+cat "$CURL_FIXTURE"
+EOF
+chmod +x "$WORK_DIR/bin/curl"
+export PATH="$WORK_DIR/bin:$PATH"
+
+# shellcheck source=shared/download/package-version.sh
+source "$HELPER"
+
+cat >"$WORK_DIR/Packages" <<'EOF'
+Package: fixture
+Version: 1.9-1
+
+Package: unrelated
+Version: 99
+
+Package: fixture
+Version: 1.10-1
+
+EOF
+gzip -c "$WORK_DIR/Packages" >"$WORK_DIR/Packages.gz"
+packages_size="$(wc -c <"$WORK_DIR/Packages")"
+
+echo "# bounded APT package-index parsing"
+
+run_lookup "$WORK_DIR/Packages.gz" "$packages_size" 60
+assert_equals "an index exactly at the size limit succeeds" 0 "$RUN_STATUS"
+assert_equals "the highest Debian package version is selected" "1.10-1" "$RUN_STDOUT"
+assert_curl_argument "curl has a per-transfer timeout" "--max-time"
+assert_curl_argument "curl bounds time across retries" "--retry-max-time"
+
+# The producer pipeline can exit zero when the index exceeds the limit by one
+# byte, so this case specifically verifies the MAX+1 size check.
+run_lookup "$WORK_DIR/Packages.gz" "$((packages_size - 1))" 60
+assert_equals "an index one byte over the limit fails" 1 "$RUN_STATUS"
+assert_stderr_contains "an oversized index reports the size limit" \
+    "decompressed package index exceeds"
+
+{
+    cat "$WORK_DIR/Packages"
+    head -c 1048576 /dev/zero | tr '\0' x
+} >"$WORK_DIR/oversized-Packages"
+gzip -c "$WORK_DIR/oversized-Packages" >"$WORK_DIR/oversized-Packages.gz"
+run_lookup "$WORK_DIR/oversized-Packages.gz" "$packages_size" 60
+assert_equals "a gzip bomb that causes producer SIGPIPE fails" 1 "$RUN_STATUS"
+assert_stderr_contains "producer SIGPIPE is reported as an oversized index" \
+    "decompressed package index exceeds"
+
+cp "$WORK_DIR/Packages.gz" "$WORK_DIR/truncated.gz"
+truncate -s -8 "$WORK_DIR/truncated.gz"
+run_lookup "$WORK_DIR/truncated.gz" "$packages_size" 60
+assert_equals "a truncated gzip containing an early version fails" 1 "$RUN_STATUS"
+assert_stderr_contains "a truncated gzip reports validation failure" \
+    "transfer or gzip validation failed"
+
+run_lookup "$WORK_DIR/Packages.gz" "$packages_size" 1 3
+assert_equals "the hard transfer deadline aborts a stalled curl" 1 "$RUN_STATUS"
+assert_stderr_contains "a transfer timeout reports validation failure" \
+    "transfer or gzip validation failed"
+
+echo ""
+echo "# Results: $PASS passed, $FAIL failed, $(( PASS + FAIL )) total"
+exit "$FAIL"


### PR DESCRIPTION
## Summary

- enforce a 60-second total transfer deadline for external APT package indexes
- cap decompressed `Packages.gz` data at 50 MiB and fail closed on oversized, truncated, or corrupt streams
- move version parsing into a testable helper and propagate lookup failures before writing update data
- add network-free regression coverage for boundary sizes, gzip SIGPIPE, corruption, timeouts, and Debian version ordering

Closes #638

## Testing

- `./test/check-packages-test.sh`
- `shellcheck -S warning -x shared/download/package-version.sh test/check-packages-test.sh`
- `actionlint .github/workflows/check-packages.yml .github/workflows/validate.yml`
- bounded live lookup against the Microsoft VS Code APT index