### PR TITLE
ci: bound installer redirect deployment

### DIFF
--- a/.github/workflows/deploy-native-installer-redirect.yml
+++ b/.github/workflows/deploy-native-installer-redirect.yml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: native-promotion
     permissions:
       contents: read
@@ -69,7 +70,7 @@ jobs:
           url=https://repository.frostyard.org/isos/native/v1/snosi-native-installer-latest-x86-64.iso
           base=https://repository.frostyard.org/isos/native/v1
           version=""
-          if sums="$(curl -fsS "$base/SHA256SUMS")"; then
+          if sums="$(curl -fsS --max-time 15 "$base/SHA256SUMS")"; then
             version="$(awk '$2 ~ /^snosi-native-installer_[0-9]{14}_x86-64\.iso$/ {name=$2} END {sub(/^snosi-native-installer_/, "", name); sub(/_x86-64\.iso$/, "", name); print name}' <<<"$sums")"
           fi
           for attempt in 1 2 3 4 5 6; do
@@ -78,7 +79,7 @@ jobs:
                 exit 0
               fi
             else
-              status="$(curl -sS -o /dev/null -w '%{http_code}' "$url")"
+              status="$(curl -sS --max-time 15 -o /dev/null -w '%{http_code}' "$url")"
               if [[ "$status" == 503 ]]; then
                 echo "Worker route active (HTTP 503 is expected before the first ISO promotion)."
                 exit 0


### PR DESCRIPTION
## Summary

- limit the Cloudflare-credentialed deployment job to 15 minutes
- cap both route-verification `curl` requests at 15 seconds
- prevent stalled deployment checks from retaining Cloudflare credentials for the six-hour runner default

Closes #645