### PR TITLE
governance: enforce agent policy as code

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,6 +67,11 @@ jobs:
             git ls-files | xargs awk 'FNR==1 && /^#!\/(usr\/)?bin\/(env )?(ba)?sh/ {print FILENAME} {nextfile}' 2>/dev/null
           } | grep -v '^saved-unused/' | sort -u | xargs -r shellcheck -S warning -x
 
+      - name: Validate policy as code
+        # Fail closed if agent autonomy, human review, risk classification,
+        # protected-boundary testing, or exception controls are weakened.
+        run: python3 ./test/policy-as-code-test.py
+
       - name: Validate native A/B invariants
         run: ./test/native-ab-static-test.sh
 

--- a/docs/SECURITY-AI.md
+++ b/docs/SECURITY-AI.md
@@ -71,6 +71,9 @@ quality signals. Repository-specific implementation constraints live in
 [`AGENTS.md`](../AGENTS.md) and `yeti/`.
 
 The workflows in `.github/workflows/` are structural gates; policy text does
-not replace them. Exceptions must be proposed transparently in a pull request,
-with rationale and compensating controls, and approved by a maintainer. An
-agent cannot authorize its own exception.
+not replace them. [`policies/agent-governance.json`](../policies/agent-governance.json)
+is the machine-readable, fail-closed form of the baseline agent controls, and
+`test/policy-as-code-test.py` enforces it in the validation workflow. Exceptions
+must be proposed transparently in a pull request, with rationale and
+compensating controls, and approved by a maintainer. An agent cannot authorize
+its own exception.

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,20 @@
+# Repository policies
+
+This directory contains machine-readable governance policy for automated and
+AI-assisted contributions. The policy supplements, and does not replace,
+[`AGENTS.md`](../AGENTS.md), [`docs/SECURITY-AI.md`](../docs/SECURITY-AI.md),
+and [`docs/risk-tiers.md`](../docs/risk-tiers.md).
+
+`agent-governance.json` is fail-closed: agents cannot merge, release, deploy,
+change protected environments, or approve their own exceptions. Every change
+requires a pull request, human review, risk classification, and validation
+evidence. Changes to a protected boundary also require rejection-path tests.
+
+`test/policy-as-code-test.py` validates the policy's schema and safety
+invariants and confirms that the repository validation workflow runs the gate.
+The test intentionally rejects unknown policy versions so schema changes need
+an explicit test and review update.
+
+Policy exceptions must be proposed in a pull request with rationale and
+compensating controls and require maintainer approval. Editing this policy is
+not itself an exception to it.

--- a/policies/agent-governance.json
+++ b/policies/agent-governance.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "defaultDecision": "deny",
+  "agentActions": {
+    "mergePullRequest": "deny",
+    "publishRelease": "deny",
+    "deployProduction": "deny",
+    "modifyProtectedEnvironment": "deny",
+    "approveOwnException": "deny"
+  },
+  "changeControls": {
+    "pullRequestRequired": true,
+    "humanReviewRequired": true,
+    "riskClassificationRequired": true,
+    "validationEvidenceRequired": true,
+    "securityRejectionTestsRequiredForProtectedBoundaries": true
+  },
+  "protectedBoundaries": [
+    "authentication",
+    "credentials",
+    "destructive-disk-operations",
+    "encryption",
+    "installer",
+    "publication",
+    "release",
+    "secure-boot",
+    "signing",
+    "tpm",
+    "update-verification",
+    "workflow-permissions"
+  ],
+  "exceptions": {
+    "pullRequestRationaleRequired": true,
+    "compensatingControlsRequired": true,
+    "maintainerApprovalRequired": true
+  }
+}

--- a/test/policy-as-code-test.py
+++ b/test/policy-as-code-test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "policies/agent-governance.json"
+WORKFLOW_PATH = ROOT / ".github/workflows/validate.yml"
+WORKFLOW_COMMAND = "python3 ./test/policy-as-code-test.py"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"policy-as-code-test: {message}")
+
+
+try:
+    policy = json.loads(POLICY_PATH.read_text())
+except (OSError, json.JSONDecodeError) as error:
+    fail(f"cannot load {POLICY_PATH.relative_to(ROOT)}: {error}")
+
+expected_top_level = {
+    "version",
+    "defaultDecision",
+    "agentActions",
+    "changeControls",
+    "protectedBoundaries",
+    "exceptions",
+}
+if set(policy) != expected_top_level:
+    fail("policy must contain exactly the version 1 top-level fields")
+if policy["version"] != 1:
+    fail("unknown policy version")
+if policy["defaultDecision"] != "deny":
+    fail("default decision must remain deny")
+
+expected_denials = {
+    "mergePullRequest",
+    "publishRelease",
+    "deployProduction",
+    "modifyProtectedEnvironment",
+    "approveOwnException",
+}
+actions = policy["agentActions"]
+if not isinstance(actions, dict) or set(actions) != expected_denials:
+    fail("agentActions must contain exactly the governed autonomous actions")
+if any(decision != "deny" for decision in actions.values()):
+    fail("all governed autonomous actions must remain denied")
+
+expected_controls = {
+    "pullRequestRequired",
+    "humanReviewRequired",
+    "riskClassificationRequired",
+    "validationEvidenceRequired",
+    "securityRejectionTestsRequiredForProtectedBoundaries",
+}
+controls = policy["changeControls"]
+if not isinstance(controls, dict) or set(controls) != expected_controls:
+    fail("changeControls must contain exactly the required review controls")
+if any(value is not True for value in controls.values()):
+    fail("all change controls must remain required")
+
+required_boundaries = {
+    "authentication",
+    "credentials",
+    "destructive-disk-operations",
+    "encryption",
+    "installer",
+    "publication",
+    "release",
+    "secure-boot",
+    "signing",
+    "tpm",
+    "update-verification",
+    "workflow-permissions",
+}
+boundaries = policy["protectedBoundaries"]
+if not isinstance(boundaries, list) or any(not isinstance(item, str) for item in boundaries):
+    fail("protectedBoundaries must be a list of names")
+if len(boundaries) != len(set(boundaries)):
+    fail("protectedBoundaries must not contain duplicates")
+missing_boundaries = required_boundaries - set(boundaries)
+if missing_boundaries:
+    fail(f"protected boundaries removed: {', '.join(sorted(missing_boundaries))}")
+
+expected_exceptions = {
+    "pullRequestRationaleRequired",
+    "compensatingControlsRequired",
+    "maintainerApprovalRequired",
+}
+exceptions = policy["exceptions"]
+if not isinstance(exceptions, dict) or set(exceptions) != expected_exceptions:
+    fail("exceptions must contain exactly the required controls")
+if any(value is not True for value in exceptions.values()):
+    fail("all exception controls must remain required")
+
+try:
+    workflow = WORKFLOW_PATH.read_text()
+except OSError as error:
+    fail(f"cannot load validation workflow: {error}")
+if workflow.count(WORKFLOW_COMMAND) != 1:
+    fail("validate.yml must run the policy gate exactly once")
+
+print("policy-as-code-test: PASSED")

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -29,6 +29,16 @@ still belong in `CLAUDE.md` or the topic files here — the correction entry
 records how the rule was learned and points at it via `promoted_to`. It carries
 no secrets or personal data.
 
+## Policy as code
+
+`policies/agent-governance.json` is the machine-readable baseline for agent
+autonomy, change controls, protected boundaries, and exceptions. It defaults
+to deny autonomous merge, release, deployment, protected-environment changes,
+and self-approved exceptions. `test/policy-as-code-test.py`, wired into
+`.github/workflows/validate.yml`, fails if those denials or required human
+review, risk, validation, rejection-test, and exception controls are weakened.
+The normative prose remains in `docs/SECURITY-AI.md` and `docs/risk-tiers.md`.
+
 ## Bootc Secure Operations
 
 The normative operator entry point for the secure bootc fresh-install path is


### PR DESCRIPTION
# Summary

Adds a machine-readable, fail-closed agent governance policy rather than an empty criterion marker:

- denies autonomous merge, release, production deployment, protected-environment changes, and self-approved exceptions
- requires pull requests, human review, risk classification, validation evidence, and rejection tests for protected security boundaries
- requires maintainer-approved exception rationale and compensating controls
- adds a standard-library Python gate that validates the policy schema and safety invariants
- wires that gate into the existing validation workflow
- documents the relationship between the executable policy and the normative AI security/risk guidance

Closes #665. This provides a complete implementation beyond the plan-only WIP in #667.

Risk tier: 3 — High. This changes a governance CI gate. Failure is fail-closed in the `shell-lint` validation job; rollback is reverting this commit, with no image, runtime, credential, or publication behavior affected.

## Type of change

- [ ] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [ ] Sysext change
- [x] Build pipeline / CI change
- [ ] Documentation only
- [x] Other: machine-readable governance policy

## Validation

- [x] `shellcheck` / `validate.yml` static checks pass for touched scripts
- [ ] Relevant `just` build target(s) succeed — no image or profile behavior changed
- [x] Relevant tests in `test/` were run

Commands run:

```text
python3 ./test/policy-as-code-test.py
python3 -m py_compile ./test/policy-as-code-test.py
python3 -m json.tool policies/agent-governance.json
shellcheck -S warning -x <all tracked shell scripts>
actionlint .github/workflows/validate.yml
./test/workflow-path-filter-test.sh
./test/bootc-secure-ci-test.sh
git diff --check
```

All passed.

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] New external downloads are pinned and go through `verified_download()` — no downloads added
- [x] Documentation updated (`CLAUDE.md`, `README.md`, `docs/`, `yeti/`) where relevant
