### PR TITLE
ci: ignore benign review application races

### DIFF
--- a/.github/workflows/copilot-review-apply.yml
+++ b/.github/workflows/copilot-review-apply.yml
@@ -49,12 +49,12 @@ jobs:
           pr_path="repos/${TARGET_REPOSITORY}/pulls/${PULL_NUMBER}"
           pr_json=$(gh api "$pr_path")
           if [[ $(jq -r '.state' <<<"$pr_json") != "open" ]]; then
-            echo "::error::Pull request #${PULL_NUMBER} is not open"
-            exit 1
+            echo "::notice::Pull request #${PULL_NUMBER} is no longer open; nothing to apply"
+            exit 0
           fi
           if [[ $(jq -r '.draft' <<<"$pr_json") != "false" ]]; then
-            echo "::error::Pull request #${PULL_NUMBER} is a draft"
-            exit 1
+            echo "::notice::Pull request #${PULL_NUMBER} is a draft; nothing to apply"
+            exit 0
           fi
           if [[ $(jq -r '.head.repo.full_name // ""' <<<"$pr_json") != "$TARGET_REPOSITORY" ]]; then
             echo "::error::Review application is restricted to same-repository branches"


### PR DESCRIPTION
## Summary

- treat pull requests that close between review submission and API validation as successful no-ops
- treat pull requests that become drafts during the same window as successful no-ops
- preserve hard failures for invalid numeric inputs, missing credentials, and cross-repository branches

Closes #671.

## Validation

- `actionlint .github/workflows/copilot-review-apply.yml`
- `git diff --check`
