### PR TITLE
bootc: update pinned version 1.16.3 -> 1.16.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ dracut or the Forky systemd family changes.
 
 **Bootc UKI assembly (Task 5, 2026-07-28):**
 `shared/bootc-secure/assemble-uki.sh` and the secure branch of
-`shared/outformat/image/buildah-package.sh` formalize the observed bootc 1.16.3
+`shared/outformat/image/buildah-package.sh` formalize the observed bootc 1.16.7
 hidden storage-digest plus direct two-pass ukify behavior as a maintained,
 fail-closed compatibility contract. This is NOT upstream-stable. Secure builds
 must set `SNOSI_BOOTC_SECURE=1` and caller-owned MOK/PCR credentials; Buildah

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ already-mounted read-only ESP. The real cayo proof validates immutable-source
 assembly only; FAT-ESP reconciler execution is deferred to Task 9 secure-install
 runtime coverage. Secure and insecure images carry explicit
 `io.snosi.bootc.secureboot-capable=true|false` labels. This is a maintained,
-fail-closed compatibility contract for Frostyard bootc 1.16.3, including its
+fail-closed compatibility contract for Frostyard bootc 1.16.7, including its
 hidden storage-digest command and direct two-pass ukify behavior, not an
 upstream-stable API. See `docs/bootc-secure-assembly-compatibility.md`.
 The protected packager checks its pinned bootc through the built rootfs with a

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -369,7 +369,7 @@ if [[ ! -f $verifier ]]; then
 else
     verifier_text=$(<"$verifier")
     require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-capable"] == "true" and'
-    require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.3-storage-digest-v1"'
+    require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.7-storage-digest-v1"'
     # shellcheck disable=SC1003,SC2016 # Match the literal verifier shell source.
     require_text "$verifier" "$verifier_text" \
         'inspection=$(skopeo inspect --authfile "$AUTH_FILE" \'

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -1,7 +1,7 @@
 # Bootc Secure Assembly Compatibility Contract
 
 `shared/bootc-secure/assemble-uki.sh` is a maintained compatibility adapter
-for the Frostyard `bootc` package at upstream version `1.16.3`. It is not an
+for the Frostyard `bootc` package at upstream version `1.16.7`. It is not an
 upstream-stable bootc interface.
 
 ## Pinned behavior

--- a/docs/bootc-secure-install-contract.md
+++ b/docs/bootc-secure-install-contract.md
@@ -15,7 +15,7 @@ authoritative. The `installer` object defines the requirements below.
 
 ## Prerequisites
 
-- The installer medium must provide bootc `1.16.3` exactly, and at minimum
+- The installer medium must provide bootc `1.16.7` exactly, and at minimum
   Cosign `2.6.1` and the coherent Forky systemd `261.1-3` family. The two
   policies are deliberately different:
 

--- a/docs/bootc-secure-operations.md
+++ b/docs/bootc-secure-operations.md
@@ -23,7 +23,7 @@ remains blocked until authorized signed secure N/N+1/N+2 and transition OCI
 artifacts, prepared Dakota/bootc-installer/Fisherman runners, and representative
 Snowfield hardware results exist. Do not use an image unless inspection confirms
 `io.snosi.bootc.secureboot-capable=true` and
-`io.snosi.bootc.secureboot-assembly=bootc-1.16.3-storage-digest-v1`.
+`io.snosi.bootc.secureboot-assembly=bootc-1.16.7-storage-digest-v1`.
 
 ## Trust Boundaries
 

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# Assemble the pinned bootc-1.16.3 compatibility UKI. This is deliberately not
+# Assemble the pinned bootc-1.16.7 compatibility UKI. This is deliberately not
 # an upstream-stable interface: buildah-package.sh supplies the OCI digest.
 set -euo pipefail
 umask 077
 
-readonly EXPECTED_BOOTC_VERSION="1.16.3"
+readonly EXPECTED_BOOTC_VERSION="1.16.7"
 readonly CANDIDATE_UKIFY_MOK_KEY=/run/snosi-ukify-mok.key
 readonly CANDIDATE_UKIFY_MOK_CERT=/run/snosi-ukify-mok.crt
 readonly CANDIDATE_UKIFY_PCR_KEY=/run/snosi-ukify-pcr.key
@@ -63,7 +63,7 @@ validate_root_contract() { # rootfs
     local root=$1 contract
     contract="$root/usr/lib/snosi/bootc-secure.json"
     [[ -f "$contract" ]] || die "missing bootc secure rootfs contract"
-    jq -e '.schema == 1 and .mok_certificate == "/usr/lib/snosi/mok.crt" and .pcr_public_key == "/usr/lib/snosi/pcr-signing.pub" and .encrypted_root_mapper == "root" and .systemd_suite == "forky" and ((has("assembly") | not) or .assembly == {compatibility: "bootc-1.16.3-storage-digest-v1", bootc_version: "1.16.3", storage_digest_command: "bootc container compute-composefs-digest-from-storage", ukify: "direct-two-pass"})' "$contract" >/dev/null || die "unexpected bootc secure rootfs contract"
+    jq -e '.schema == 1 and .mok_certificate == "/usr/lib/snosi/mok.crt" and .pcr_public_key == "/usr/lib/snosi/pcr-signing.pub" and .encrypted_root_mapper == "root" and .systemd_suite == "forky" and ((has("assembly") | not) or .assembly == {compatibility: "bootc-1.16.7-storage-digest-v1", bootc_version: "1.16.7", storage_digest_command: "bootc container compute-composefs-digest-from-storage", ukify: "direct-two-pass"})' "$contract" >/dev/null || die "unexpected bootc secure rootfs contract"
 }
 
 # The gate tracks only caller-owned private keys. Generic PEM scans reject

--- a/shared/bootc-secure/ci/verify-published-image.sh
+++ b/shared/bootc-secure/ci/verify-published-image.sh
@@ -49,7 +49,7 @@ inspection=$(skopeo inspect --authfile "$AUTH_FILE" \
 jq -e --arg digest "$EXPECTED_DIGEST" '
     .Digest == $digest and
     .Labels["io.snosi.bootc.secureboot-capable"] == "true" and
-    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.3-storage-digest-v1"
+    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.7-storage-digest-v1"
 ' <<<"$inspection" >/dev/null
 
 tag_digest=$(skopeo inspect --authfile "$AUTH_FILE" --format '{{.Digest}}' \

--- a/shared/bootc-secure/tree/usr/lib/snosi/bootc-secure.json
+++ b/shared/bootc-secure/tree/usr/lib/snosi/bootc-secure.json
@@ -5,14 +5,14 @@
   "encrypted_root_mapper": "root",
   "systemd_suite": "forky",
   "assembly": {
-    "compatibility": "bootc-1.16.3-storage-digest-v1",
-    "bootc_version": "1.16.3",
+    "compatibility": "bootc-1.16.7-storage-digest-v1",
+    "bootc_version": "1.16.7",
     "storage_digest_command": "bootc container compute-composefs-digest-from-storage",
     "ukify": "direct-two-pass"
   },
   "installer": {
     "minimum_versions": {
-      "bootc": "1.16.3",
+      "bootc": "1.16.7",
       "cosign": "2.6.1",
       "systemd": "261.1-3"
     },

--- a/shared/outformat/image/buildah-package.sh
+++ b/shared/outformat/image/buildah-package.sh
@@ -59,15 +59,15 @@ probe_rootfs_bootc_version() ( # rootfs
         printf 'Error: rootfs bootc execution failed:\n%s\n' "$output" >&2
         exit 1
     fi
-    [[ $output == 'bootc 1.16.3' ]] || {
-        printf 'Error: expected bootc 1.16.3, observed %s\n' "$output" >&2
+    [[ $output == 'bootc 1.16.7' ]] || {
+        printf 'Error: expected bootc 1.16.7, observed %s\n' "$output" >&2
         exit 1
     }
 )
 
 readonly SECURE_CAPABLE_LABEL="io.snosi.bootc.secureboot-capable=true"
 readonly SECURE_INCAPABLE_LABEL="io.snosi.bootc.secureboot-capable=false"
-readonly SECURE_ASSEMBLY_LABEL="io.snosi.bootc.secureboot-assembly=bootc-1.16.3-storage-digest-v1"
+readonly SECURE_ASSEMBLY_LABEL="io.snosi.bootc.secureboot-assembly=bootc-1.16.7-storage-digest-v1"
 first_image=""
 final_container=""
 final_mount=""
@@ -127,7 +127,7 @@ if [[ ${SNOSI_BOOTC_SECURE:-0} == 1 ]]; then
         --security-opt label=type:unconfined_t "$first_image" \
         bootc container compute-composefs-digest-from-storage "$first_image" | tr -d '\n')
     [[ $digest =~ ^[[:xdigit:]]{128}$ ]] || { echo "Error: unsupported bootc storage-digest interface" >&2; exit 1; }
-    SNOSI_BOOTC_SECURE_COMPOSEFS_DIGEST="$digest" SNOSI_BOOTC_SECURE_BOOTC_VERSION=1.16.3 \
+    SNOSI_BOOTC_SECURE_COMPOSEFS_DIGEST="$digest" SNOSI_BOOTC_SECURE_BOOTC_VERSION=1.16.7 \
         SNOSI_BOOTC_SECURE_UKIFY_IMAGE="$first_image" \
         SNOSI_BOOTC_PREVIOUS_PCR_KEY="${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-}" \
         "$ASSEMBLER" "$ROOTFS_DIR" \

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -57,7 +57,7 @@ sudo skopeo copy --src-authfile "$AUTH_FILE" \
 jq -e --arg digest "$EXPECTED_DIGEST" '
     .Digest == $digest and
     .Labels["io.snosi.bootc.secureboot-capable"] == "true" and
-    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.3-storage-digest-v1"
+    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.7-storage-digest-v1"
 ' <<<"$inspection" >/dev/null
 EOF
 

--- a/test/bootc-secure-docs-test.sh
+++ b/test/bootc-secure-docs-test.sh
@@ -27,7 +27,7 @@ required_headings=(
 
 required_strings=(
     'io.snosi.bootc.secureboot-capable=true'
-    'io.snosi.bootc.secureboot-assembly=bootc-1.16.3-storage-digest-v1'
+    'io.snosi.bootc.secureboot-assembly=bootc-1.16.7-storage-digest-v1'
     '/dev/mapper/root'
     "ROOT_BACKING_DEVICE=\$(cryptsetup status root | awk '/^[[:space:]]*device:/{print \$2; exit}')"
     "ROOT_BACKING_DEVICE_COUNT=\$(cryptsetup status root | awk '/^[[:space:]]*device:/{print \$2}' | grep -Ec '^/dev/')"

--- a/test/bootc-secure-install-contract-test.sh
+++ b/test/bootc-secure-install-contract-test.sh
@@ -19,7 +19,7 @@ assert contract["schema"] == 1
 assert contract["encrypted_root_mapper"] == "root"
 assert contract["installer"] == {
     "minimum_versions": {
-        "bootc": "1.16.3",
+        "bootc": "1.16.7",
         "cosign": "2.6.1",
         "systemd": "261.1-3",
     },

--- a/test/bootc-secure-package-cleanup-test.sh
+++ b/test/bootc-secure-package-cleanup-test.sh
@@ -47,7 +47,7 @@ if [[ ${BUILD_FIXTURE_CHROOT_FAIL:-0} == 1 ]]; then
     echo 'fixture rootfs loader failure' >&2
     exit 86
 fi
-printf '%s\n' "${BUILD_FIXTURE_BOOTC_VERSION:-bootc 1.16.3}"
+printf '%s\n' "${BUILD_FIXTURE_BOOTC_VERSION:-bootc 1.16.7}"
 EOF
     cat >"$state/bin/umount" <<'EOF'
 #!/bin/bash
@@ -309,7 +309,7 @@ remove_proc_dir() { rmdir "$2/proc"; }
 run_probe_failure_case proc-missing 'rootfs proc directory is missing' remove_proc_dir UNUSED 0
 run_probe_failure_case proc-pre-mounted 'rootfs proc is already mounted' mark_proc_mounted UNUSED 0
 run_probe_failure_case chroot-fails 'fixture rootfs loader failure' none BUILD_FIXTURE_CHROOT_FAIL 1
-run_probe_failure_case wrong-version 'expected bootc 1.16.3, observed bootc 1.16.2' none BUILD_FIXTURE_BOOTC_VERSION 'bootc 1.16.2'
+run_probe_failure_case wrong-version 'expected bootc 1.16.7, observed bootc 1.16.2' none BUILD_FIXTURE_BOOTC_VERSION 'bootc 1.16.2'
 run_probe_failure_case umount-fails 'failed to unmount rootfs proc' none BUILD_FIXTURE_UMOUNT_FAIL 1
 
 run_case assembler-fails
@@ -356,7 +356,7 @@ run_success_case() {
     ! grep -Fxq 'io.snosi.bootc.secureboot-capable=true' "$state/container-1-labels" || fail "first candidate gained the secure capability label"
     ! grep -Fq 'io.snosi.bootc.secureboot-assembly=' "$state/container-1-labels" || fail "first candidate gained the assembly label"
     grep -Fxq 'io.snosi.bootc.secureboot-capable=true' "$state/container-2-labels" || fail "final container lost the secure label"
-    grep -Fxq 'io.snosi.bootc.secureboot-assembly=bootc-1.16.3-storage-digest-v1' "$state/container-2-labels" || fail "final container lost the assembly label"
+    grep -Fxq 'io.snosi.bootc.secureboot-assembly=bootc-1.16.7-storage-digest-v1' "$state/container-2-labels" || fail "final container lost the assembly label"
     "$state/assembler" --remove-injected "$root"
 }
 

--- a/test/bootc-secure-publication-test.sh
+++ b/test/bootc-secure-publication-test.sh
@@ -104,7 +104,7 @@ EOF
 chmod +x "$WORK/bin/skopeo" "$WORK/bin/cosign" "$WORK/bin/sudo"
 
 export INSPECTION
-INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
 
 run_case "accepted immutable secure image is copied" success "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 grep -Fqx "skopeo inspect --authfile $AUTH_FILE docker://$IMAGE@$DIGEST" "$WORK/commands" && pass "Skopeo inspects immutable metadata with explicit auth" || fail "Skopeo inspects immutable metadata with explicit auth"
@@ -147,16 +147,16 @@ TAG_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     run_case "version tag digest mismatch is rejected" failure \
     "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
-INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "false", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "false", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
 run_case "false secure capability is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
-INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
 run_case "missing secure capability is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "wrong"}}')
 run_case "wrong secure assembly is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
-INSPECTION=$(jq -nc --arg digest "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
 run_case "remote digest mismatch is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
-INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.3-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
 COSIGN_VERIFY_FAIL=1 run_case "failed Cosign verification is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 SKOPEO_COPY_FAIL=1 run_case "failed policy copy is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 

--- a/test/bootc-secure-spike-test.sh
+++ b/test/bootc-secure-spike-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Feasibility gate for bootc 1.16.3 UKIs sealed to a composefs rootfs.
+# Feasibility gate for bootc 1.16.7 UKIs sealed to a composefs rootfs.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -138,7 +138,7 @@ for package in mokutil cryptsetup cryptsetup-bin tpm2-tools \
 done
 
 # Directory-format bootc profiles do not build a UKI through mkosi, so
-# KernelCommandLine= is inert. Pinned bootc 1.16.3 reads sorted *.toml files
+# KernelCommandLine= is inert. Pinned bootc 1.16.7 reads sorted *.toml files
 # from /usr/lib/bootc/kargs.d; its strict schema requires a kargs array.
 if grep -q '^KernelCommandLine=' "$secure"; then
     echo "bootc secure fragment must use bootc kargs.d, not mkosi KernelCommandLine=" >&2
@@ -172,8 +172,8 @@ assert {key: contract[key] for key in (
     "encrypted_root_mapper": "root",
     "systemd_suite": "forky",
     "assembly": {
-        "compatibility": "bootc-1.16.3-storage-digest-v1",
-        "bootc_version": "1.16.3",
+        "compatibility": "bootc-1.16.7-storage-digest-v1",
+        "bootc_version": "1.16.7",
         "storage_digest_command": "bootc container compute-composefs-digest-from-storage",
         "ukify": "direct-two-pass",
     },

--- a/yeti/build-pipeline.md
+++ b/yeti/build-pipeline.md
@@ -48,7 +48,7 @@ mixes in systemd-boot, cryptsetup, and TPM tooling. It adds
 `lockdown=integrity` through
 `/usr/lib/bootc/kargs.d/10-lockdown.toml`, not mkosi `KernelCommandLine=`:
 these directory-format profiles do not have an mkosi-built UKI for that setting
-to affect. Pinned bootc 1.16.3 loads sorted `*.toml` files from that directory;
+to affect. Pinned bootc 1.16.7 loads sorted `*.toml` files from that directory;
 the strict schema is `kargs = ["..."]` with optional
 `match-architectures = ["x86_64"]`. The fragment also carries explicit
 MOK/recovery/TPM/UKI tools and the public-only native MOK certificate plus
@@ -56,7 +56,7 @@ RSA-2048 PCR signing public key. The image contract is
 `/usr/lib/snosi/bootc-secure.json` (schema 1). Task 5 adds
 `shared/bootc-secure/assemble-uki.sh`, called only through
 `buildah-package.sh` when `SNOSI_BOOTC_SECURE=1`: the pristine first OCI package
-is chunked before its candidate bootc obtains bootc 1.16.3's hidden storage
+is chunked before its candidate bootc obtains bootc 1.16.7's hidden storage
 digest. That chunked candidate is digest authority; the adapter injects a
 MOK-signed UKI plus the ESP copy of systemd-boot under `/boot`. Before that first package, it
 places the same signed systemd-boot source at

--- a/yeti/ci-cd.md
+++ b/yeti/ci-cd.md
@@ -76,7 +76,7 @@ the cayo, snow, and snowfield package access needed by secure publication.
    sudo. Do not replace this with implicit preservation or pass secret bytes in
    arguments.
    Local validation requires host Podman, not host bootc: the validator runs the
-   candidate image's pinned bootc 1.16.3 to recompute its storage composefs digest.
+   candidate image's pinned bootc 1.16.7 to recompute its storage composefs digest.
    The same boundary applies to the policy-copied validation after registry pull.
 2. Chunk, smoke test, and generate the SBOM, then use root Buildah's stdin login with the job-scoped `GITHUB_TOKEN` to push only the immutable timestamp tag and capture its digest.
 3. Use the Docker credential context to sign `IMAGE@DIGEST`, verify its remote digest/secure labels and Cosign signature, and copy it through the restrictive repository policy before validating the copied UKI/composefs artifact.


### PR DESCRIPTION
## Summary
- The Frostyard bootc deb moved to upstream **1.16.7**, so the fail-closed rootfs version probe in `shared/outformat/image/buildah-package.sh` now rejects every protected secure build — [run 31418353072](https://github.com/frostyard/snosi/actions/runs/31418353072/job/93552829255) failed with `Error: expected bootc 1.16.3, observed bootc 1.16.7`.
- Updates the compatibility pin everywhere it is load-bearing:
  - packager version probe + `SNOSI_BOOTC_SECURE_BOOTC_VERSION` handoff (`buildah-package.sh`)
  - assembler `EXPECTED_BOOTC_VERSION` and rootfs-contract check (`assemble-uki.sh`)
  - shipped rootfs contract `bootc-secure.json` (assembly pin and installer exact-pin minimum)
  - the assembly label, now `io.snosi.bootc.secureboot-assembly=bootc-1.16.7-storage-digest-v1`, in the producer, `check-bootc-publication-guard.sh`, and `shared/bootc-secure/ci/verify-published-image.sh`
  - the fixture tests pinning those values (static, package-cleanup, publication, publication-guard, docs, install-contract)
  - normative docs (`docs/bootc-secure-install-contract.md`, `docs/bootc-secure-operations.md`, `docs/bootc-secure-assembly-compatibility.md`) and current-pin references in README/AGENTS(CLAUDE)/yeti
- Historical records deliberately keep 1.16.3: the migration record, dated superpowers plans/specs, `bootc <= 1.16.3` bug annotations, and observed-evidence statements describe facts established at that version, not the current pin.

## Validation
- `test/bootc-secure-install-contract-test.sh`, `test/bootc-secure-docs-test.sh`, `test/bootc-secure-static-test.sh`, `test/bootc-publication-guard-test.sh`, `test/bootc-secure-publication-test.sh`, `test/bootc-secure-package-cleanup-test.sh` — all PASS
- `check-bootc-publication-guard.sh` — PASS
- ShellCheck on all touched scripts: only pre-existing info-level notes; the diff changes version strings only

## Note
Per the assembly-compatibility contract's own caveat, the pinned hidden storage-digest + two-pass ukify behavior is not upstream-stable; the next protected `secure-build` run on this branch/main is the real proof that 1.16.7 still satisfies the observed command/output shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)