### PR TITLE
docs: provide a working private security reporting path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,5 +32,6 @@ Include relevant, sanitized logs. Do not include credentials or other secrets.
 
 ## Security vulnerabilities
 
-Do not report security vulnerabilities here. Instead, create a draft security
-advisory: https://github.com/frostyard/snosi/security/advisories/new
+Do not report security vulnerabilities here. Follow the private reporting
+instructions in the
+[security policy](https://github.com/frostyard/snosi/security/policy).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ Thanks for contributing to snosi.
 
 - Read `README.md` for project goals and build outputs.
 - Read `CLAUDE.md` and `yeti/OVERVIEW.md` for repository architecture, contracts, and operational constraints.
-- For security issues, follow `SECURITY.md` and use GitHub Security Advisories (not public issues).
+- For security issues, follow the private reporting instructions in
+  `SECURITY.md`; do not open a public issue.
 - If you work with an AI coding agent, start from a prompt in `.github/prompts/`.
 
 ## Development workflow

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,24 +1,28 @@
 # Security
 
-If you believe you have found a new security vulnerability in this repository, please report it to us as follows.
+If you believe you have found a security vulnerability in this repository,
+please report it privately.
 
 ## Reporting Security Issues
 
-* Please do **not** report security vulnerabilities through public GitHub issues.
+- Do **not** report security vulnerabilities through public GitHub issues.
+- Email the project maintainer at
+  [bketelsen@gmail.com](mailto:bketelsen@gmail.com). Use a subject such as
+  `[snosi security] Brief description`.
+- If this repository's **Security** tab displays a **Report a vulnerability**
+  button, you may use that private form instead.
 
-* Please create a draft security advisory on the Github page: the reporting form is under `> Security > Advisories`. The URL is https://github.com/frostyard/snosi/security/advisories/new.
+The **New draft security advisory** page is a maintainer workflow and is not a
+fallback reporting channel for people without repository write access.
 
-## Guidelines 
+## Guidelines
 
-* When reporting a vulnerability, please include as much information as possible, including the complete steps to reproduce the issue. 
-
-* Avoid sending us executables.
-
-* Feel free to include any script you wrote and used but avoid sending us scripts that download and run binaries. 
-
-* We will prioritise reports that show how the exploits work in realistic environments. 
-
-* We prefer all communications to be in English. 
-
-* We do not offer financial rewards. We are happy to acknowledge your research publicly when possible. 
-
+- Include the affected version or commit, impact, and complete reproduction
+  steps when possible.
+- Do not send credentials, private signing material, or executables.
+- You may include scripts you wrote, but do not send scripts that download and
+  run binaries.
+- We prioritize reports that demonstrate realistic impact.
+- We prefer communications in English.
+- We do not offer financial rewards. We are happy to acknowledge your research
+  publicly when possible.


### PR DESCRIPTION
# Summary

Replaces the maintainer-only draft-advisory instruction with a private channel external reporters can actually use.

- names the primary maintainer's publicly listed contact address in `SECURITY.md`
- keeps GitHub's private vulnerability form as an option when the repository exposes it
- routes `CONTRIBUTING.md` and the public bug template through the security policy instead of the inaccessible advisory URL

Addresses the high-severity documentation finding in the living advisory report #657. Closes #682.

**Risk tier: 3 — High.** This is documentation-only with no runtime effect, but it changes the repository's security-reporting contract and requires maintainer approval of the contact channel.

## Type of change

- [ ] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [ ] Sysext change
- [ ] Build pipeline / CI change
- [x] Documentation only
- [ ] Other:

## Validation

- [x] Reviewed the rendered Markdown and cross-document routing
- [x] Confirmed no stale `security/advisories/new` instruction remains
- [x] Confirmed `https://github.com/frostyard/snosi/security/policy` returns HTTP 200

Commands run:

```text
git diff --check
rg 'security/advisories/new|use GitHub Security Advisories|create a draft security advisory' SECURITY.md CONTRIBUTING.md .github/ISSUE_TEMPLATE/bug_report.md
curl -L -sS -o /dev/null -w '%{http_code}' https://github.com/frostyard/snosi/security/policy
```

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] New external downloads are pinned and go through `verified_download()` (not applicable)
- [x] Documentation updated where relevant
