### PR TITLE
docs: add contributor code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned with this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately to the project maintainer at
+[bketelsen@gmail.com](mailto:bketelsen@gmail.com). All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla-coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla-coc]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thanks for contributing to snosi.
 ## Before you start
 
 - Read `README.md` for project goals and build outputs.
+- Follow the [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) in all project spaces.
 - Read `CLAUDE.md` and `yeti/OVERVIEW.md` for repository architecture, contracts, and operational constraints.
 - For security issues, follow the private reporting instructions in
   `SECURITY.md`; do not open a public issue.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ See the [supported installation guide](docs/installing.md) to choose an image,
 verify the native installer, create boot media, install safely, and recover or
 update the installed system.
 
+## Community
+
+Contributions are welcome. Read the [contributing guide](CONTRIBUTING.md) and
+follow the [Code of Conduct](CODE_OF_CONDUCT.md). Report vulnerabilities only
+through the private channels in the [security policy](SECURITY.md), never in a
+public issue.
+
 ## What This Project Does
 
 snosi builds immutable, bootable OCI container images based on Debian Trixie. These images are designed for use with [bootc](https://bootc-dev.github.io/bootc/) / systemd-boot and can be deployed as atomic, updateable operating system images.


### PR DESCRIPTION
# Summary

- add the Contributor Covenant 2.1 as a repository-level code of conduct with a private enforcement contact
- link the conduct expectations from the contributing guide and a new README community section
- point vulnerability reports separately to the existing security policy

Addresses #681 for snosi. This provides an immediate repository-level fallback; creating the recommended public `frostyard/.github` repository and covering the other repositories still requires an organization maintainer.

Risk tier: 2 — this is documentation-only and has no runtime effect, but it establishes community moderation expectations and therefore needs human review.

## Type of change

- [ ] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [ ] Sysext change
- [ ] Build pipeline / CI change
- [x] Documentation only
- [ ] Other:

## Validation

- [ ] `shellcheck` / `validate.yml` static checks pass for touched scripts
- [ ] Relevant `just` build target(s) succeed
- [ ] Relevant tests in `test/` were run

Commands run:

```console
git diff --cached --check
```

No executable code or configuration changed, so build and script tests were not run. The new relative documentation links and the Contributor Covenant attribution/contact sections were reviewed directly.

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] New external downloads are pinned and go through `verified_download()` (not applicable; no downloads)
- [x] Documentation updated (`CLAUDE.md`, `README.md`, `docs/`, `yeti/`) where relevant
