### PR TITLE
feat: enable the Pilothouse k3s backend

### DIFF
--- a/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf
+++ b/mkosi.images/pilothouse/mkosi.extra/usr/lib/systemd/system/pilothoused.service.d/10-snosi-backends.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/pilothoused --socket /run/pilothouse/broker.sock --socket-group pilothouse --admin-group sudo --updex /usr/bin/updex --podman-socket /run/podman/podman.sock --docker unix:///var/run/docker.sock --incus
+ExecStart=/usr/bin/pilothoused --socket /run/pilothouse/broker.sock --socket-group pilothouse --admin-group sudo --updex /usr/bin/updex --podman-socket /run/podman/podman.sock --docker unix:///var/run/docker.sock --incus --k3s /usr/bin/k3s

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -50,9 +50,9 @@
     "version": "0.3.1"
   },
   "pilothouse": {
-    "url": "https://github.com/frostyard/pilothouse/releases/download/v0.7.0/frostyard-pilothouse_0.7.0_amd64.deb",
-    "sha256": "af3c7bcfff75e9323f3b78fa6a538b0cce4cc63abd69acf9c76fff41c945b838",
-    "version": "0.7.0"
+    "url": "https://github.com/frostyard/pilothouse/releases/download/v0.8.0/frostyard-pilothouse_0.8.0_amd64.deb",
+    "sha256": "f0b8dc6eac080f9fcdcd71024f4f5265b1a9bef24cefeaf2e21a4697f6496410",
+    "version": "0.8.0"
   },
   "sunshine": {
     "url": "https://github.com/LizardByte/Sunshine/releases/download/v2026.516.143833/sunshine-debian-trixie-amd64.deb",

--- a/test/pilothouse-sysext-test.sh
+++ b/test/pilothouse-sysext-test.sh
@@ -17,6 +17,7 @@ pilothouse_arguments=(
     '--podman-socket /run/podman/podman.sock'
     '--docker unix:///var/run/docker.sock'
     '--incus'
+    '--k3s /usr/bin/k3s'
 )
 
 assert_count() {
@@ -55,8 +56,8 @@ assert_pilothouse_arguments() {
 }
 
 pilothouse_version=$(jq -er '.pilothouse.version' "$checksums")
-if ! dpkg --compare-versions "$pilothouse_version" ge 0.7.0; then
-    printf 'expected pinned Pilothouse version >= 0.7.0, found %s in %s\n' \
+if ! dpkg --compare-versions "$pilothouse_version" ge 0.8.0; then
+    printf 'expected pinned Pilothouse version >= 0.8.0, found %s in %s\n' \
         "$pilothouse_version" "$checksums" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary

- bump the verified Pilothouse package pin to v0.8.0
- enable k3s visibility with `--k3s /usr/bin/k3s`
- extend the sysext contract test to require the new flag and minimum version

## Testing

- `./test/pilothouse-sysext-test.sh`
- `shellcheck test/pilothouse-sysext-test.sh`
- `jq -e . shared/download/sysext-checksums.json`
- `git diff --check`

Closes #686