### PR TITLE
chore: update image dependencies

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -253,7 +253,7 @@ jobs:
         id: setup-syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          syft-version: v1.39.0
+          syft-version: v1.51.0
 
       - name: Generate SBOM
         id: generate-sbom
@@ -301,7 +301,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
-          cosign-release: "v2.6.1"
+          cosign-release: "v2.6.5"
 
       - name: Sign immutable image digest
         # docker/login-action writes the user-context registry credentials used

--- a/shared/outformat/image/chunkah-package.sh
+++ b/shared/outformat/image/chunkah-package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-CHUNKAH_IMAGE='quay.io/coreos/chunkah@sha256:fdff3175bfb41e111089392ef8a41b46a10766c7b2ec454ba1272a0c39ce3bf3'
+CHUNKAH_IMAGE='quay.io/coreos/chunkah@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708'
 
 chunk_image() { # image-ref source-date-epoch [max-layers]
     local image_ref=$1 source_date_epoch=$2 max_layers=${3:-128}


### PR DESCRIPTION
Automated update of dependencies consumed by OCI image profile builds.

These updates modify `shared/download/image-checksums.json` and/or
inline Syft, Cosign, and chunkah pins. They should trigger
`build-images.yml`, not the sysext publishing workflow.

**Please verify the image builds work before merging.**