### PR TITLE
test: tolerate chunkah digest rotations

### DIFF
--- a/test/bootc-secure-package-cleanup-test.sh
+++ b/test/bootc-secure-package-cleanup-test.sh
@@ -133,7 +133,7 @@ case $1 in
         :
         ;;
     run)
-        if [[ " $* " == *' quay.io/coreos/chunkah@sha256:fdff3175bfb41e111089392ef8a41b46a10766c7b2ec454ba1272a0c39ce3bf3 '* ]]; then
+        if [[ " $* " == *' quay.io/coreos/chunkah@sha256:'* ]]; then
             printf '%s\n' "$@" >"$BUILD_FIXTURE_STATE/chunk-args"
             for ((i = 1; i <= $#; i++)); do
                 if [[ ${!i} == SOURCE_DATE_EPOCH=* ]]; then


### PR DESCRIPTION
## Summary
- match the digest-pinned Chunkah repository in the secure cleanup fixture without duplicating its current digest
- keep production digest pin validation unchanged
- prevent dependency rotations from being misclassified as bootc digest probes

## Root cause
The automated Chunkah update in #689 changed the production image digest, while the fake Podman in `bootc-secure-package-cleanup-test.sh` still matched the previous exact digest. This caused the fixture to treat Chunkah as a bootc probe and cascade from an empty image reference.

## Testing
- `./test/bootc-secure-package-cleanup-test.sh`
- `shellcheck test/bootc-secure-package-cleanup-test.sh`
- `git diff --check origin/main...HEAD`

Fixes the failure in Actions run 31453205472.