### PR TITLE
docs: link org-wide conventions to frostyard/core ADRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1687,3 +1687,9 @@ The target (e.g. `gnome-session.target`) comes from the service's `WantedBy=` in
 **.memory/ directory** `.memory/` is the repository's committed agent-learning store: `.memory/README.md` documents the conventions and `.memory/corrections.jsonl` is an append-only JSON Lines log of corrections (fields: `date`, `scope`, `correction`, `evidence`, `promoted_to`). Append an entry whenever a session establishes that a previously-held belief about this codebase was wrong, with the evidence that settled it; when a correction hardens into a general rule, promote it into `CLAUDE.md` or `yeti/` and set `promoted_to`. Never record secrets or personal data there — the directory is committed.
 
 **Delivery metrics** `docs/metrics/README.md` defines the metrics snosi tracks about its own change-delivery process — PR acceptance rate (split by author, to detect drift between agent-authored and human-authored PRs), review iterations to merge, time to merge, and `validate.yml` first-pass rate — each with the exact on-demand `gh`/`jq` query that collects it. There is deliberately no scheduled collector, stored time series, or committed snapshot: the queries are the definition. Its "Acting on the numbers" table routes each adverse signal to a documentation or tooling fix (agent-PR acceptance drop → `AGENTS.md`/`CLAUDE.md`/`yeti/`; recurring corrections → `.memory/corrections.jsonl`, then promotion), never to a process reminder.
+
+## Org-wide decisions
+
+Org-level conventions this repo follows are recorded as ADRs in
+frostyard/core — see [docs/org-adrs.md](docs/org-adrs.md) for the list that
+binds this repo. Change the ADR (in core) before changing behavior it covers.

--- a/docs/org-adrs.md
+++ b/docs/org-adrs.md
@@ -1,0 +1,27 @@
+# Org-wide decisions (frostyard/core ADRs)
+
+Conventions this repository follows that are decided at the org level are
+recorded as ADRs in
+[frostyard/core](https://github.com/frostyard/core/tree/main/docs/adr).
+The ones that bind snosi:
+
+- [ADR-0003 — Record image provenance in /usr/share/frostyard](https://github.com/frostyard/core/blob/main/docs/adr/0003-image-provenance-in-usr-share-frostyard.md) — defines the packages.txt/build_date files written by common-postinst.sh
+- [ADR-0004 — Product-namespaced filesystem paths, split by lifetime tier](https://github.com/frostyard/core/blob/main/docs/adr/0004-product-namespaced-filesystem-tiers.md) — the /usr/lib|share/snosi, /var/lib/snosi, /run/snosi split
+- [ADR-0005 — Transport discrimination by marker file and /run update-state contract](https://github.com/frostyard/core/blob/main/docs/adr/0005-native-ab-marker-and-update-state-files.md) — /usr/lib/snosi/native-ab and /run/snosi/update-* are cross-repo contracts (chairlift consumes them)
+- [ADR-0006 — OS artifact versions are 14-digit UTC timestamps](https://github.com/frostyard/core/blob/main/docs/adr/0006-os-artifact-versions-are-utc-timestamps.md) — mkosi.version / GHCR tags / partition-label budget
+- [ADR-0007 — The Frostyard sysext filename pattern and derived versions](https://github.com/frostyard/core/blob/main/docs/adr/0007-frostyard-sysext-filename-pattern.md) — sysext-postoutput.sh's KEYPACKAGE/epoch/revision rules
+- [ADR-0008 — Sysext distribution layout and update contract](https://github.com/frostyard/core/blob/main/docs/adr/0008-sysext-distribution-and-update-contract.md) — the ext/<name>/ layout the shipped .transfer files consume
+- [ADR-0009 — repository.frostyard.org is the single artifact origin](https://github.com/frostyard/core/blob/main/docs/adr/0009-single-artifact-origin-repository-frostyard-org.md) — frozen os/native/v1 and isos namespaces, SHA256SUMS channel pointer
+- [ADR-0010 — Publish packages through the shared repogen action](https://github.com/frostyard/core/blob/main/docs/adr/0010-publish-packages-via-repogen-to-r2.md) — build.yml / build-images.yml publish steps
+- [ADR-0013 — Component releases trigger image rebuilds via repository_dispatch](https://github.com/frostyard/core/blob/main/docs/adr/0013-release-fanout-via-repository-dispatch.md) — snosi is the receiver of `build` dispatches
+- [ADR-0014 — One GPG repository key, baked into images](https://github.com/frostyard/core/blob/main/docs/adr/0014-single-gpg-trust-root.md) — shared/sysext/keys, import-pubring.gpg
+- [ADR-0015 — os-release is the image identity surface](https://github.com/frostyard/core/blob/main/docs/adr/0015-os-release-image-identity.md) — IMAGE_ID written into ID=; ImageId stays the product name in -ab profiles
+- [ADR-0017 — io.snosi.* OCI capability labels and the mechanics QA tier](https://github.com/frostyard/core/blob/main/docs/adr/0017-io-snosi-capability-labels-and-mechanics-tier.md) — buildah-package.sh trusted labels; build-mechanics.yml
+- [ADR-0018 — Org-wide agent instruction and knowledge surfaces](https://github.com/frostyard/core/blob/main/docs/adr/0018-org-wide-agent-instruction-and-knowledge-surfaces.md) — AGENTS.md symlinks, yeti/, .memory/, .knowledge/
+- [ADR-0019 — Repository governance as machine-readable policy with risk tiers](https://github.com/frostyard/core/blob/main/docs/adr/0019-governance-as-code-and-risk-tiers.md) — policies/agent-governance.json, risk tiers
+- [ADR-0020 — Trust boundaries for AI automation in CI](https://github.com/frostyard/core/blob/main/docs/adr/0020-ai-automation-trust-boundaries.md) — COPILOT_ASSIGNMENT_TOKEN canonical-secret rule originates here
+- [ADR-0021 — SHA-pinned actions and least-privilege CI workflows](https://github.com/frostyard/core/blob/main/docs/adr/0021-sha-pinned-actions-and-least-privilege-ci.md) — workflow pinning policy
+- [ADR-0023 — External downloads are version-pinned and checksum-verified](https://github.com/frostyard/core/blob/main/docs/adr/0023-verified-pinned-downloads.md) — shared/download/verified-download.sh and its split registries
+
+When changing behavior covered by one of these, update or supersede the ADR
+in frostyard/core first, then change this repo in the same effort.


### PR DESCRIPTION
# Summary

An org-wide sweep extracted snosi's implicit conventions (filesystem tiers, artifact versioning, sysext contracts, publication origin, CI trust boundaries, and more) into ADRs in [frostyard/core](https://github.com/frostyard/core/tree/main/docs/adr). This PR adds the back-links: a new `docs/org-adrs.md` listing the 17 ADRs that bind snosi with a relevance note for each, and a short `## Org-wide decisions` section at the end of `AGENTS.md` pointing to it. No behavior, scripts, or workflows are touched.

Closes # (no issue — documentation back-link from the org-wide ADR sweep)

## Type of change

- [ ] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [ ] Sysext change
- [ ] Build pipeline / CI change
- [x] Documentation only
- [ ] Other:

Rationale: documentation-only — lowest-risk tier; adds two Markdown docs surfaces and changes no image inputs, scripts, or CI.

## Validation

- [ ] `shellcheck` / `validate.yml` static checks pass for touched scripts (no scripts touched)
- [ ] Relevant `just` build target(s) succeed (not applicable — Markdown only)
- [ ] Relevant tests in `test/` were run (not applicable — Markdown only)

Commands run:

```
(none — Markdown-only change; build-images.yml path filters exclude Markdown)
```

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] New external downloads are pinned and go through `verified_download()` (none added)
- [x] Documentation updated (`CLAUDE.md`, `README.md`, `docs/`, `yeti/`) where relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)