### PR TITLE
feat(iso): publish the firn installer ISO, retiring native-installer

### DIFF
--- a/.github/workflows/build-native-images.yml
+++ b/.github/workflows/build-native-images.yml
@@ -1257,15 +1257,15 @@ jobs:
             dracut-core binutils file python3-cryptography xorriso mtools dosfstools zstd
 
       - name: Build installer rootfs
-        run: sudo TMPDIR="$TMPDIR" .mkosi/bin/mkosi --profile native-installer build
+        run: sudo TMPDIR="$TMPDIR" .mkosi/bin/mkosi --profile firn-installer build
 
       - name: Assemble ISO
-        run: sudo PATH="$PATH" ./shared/native-installer/tools/build-iso.sh output/native-installer output "$VERSION"
+        run: sudo PATH="$PATH" ./shared/firn-installer/tools/build-iso.sh output/firn-installer output "$VERSION"
 
       - name: Prepare ISO publication
         run: |
           ./shared/native-ab/publish/prepare-iso-publication.sh \
-            "output/snosi-native-installer_${VERSION}_x86-64.iso" "$VERSION" \
+            "output/snosi-installer_${VERSION}_x86-64.iso" "$VERSION" \
             /var/tmp/native-publish/iso
 
       - name: Publish candidate objects to R2
@@ -1487,7 +1487,7 @@ jobs:
           set -euo pipefail
           ver="$(jq -r .version /var/tmp/native-publish/iso/publication-info.json)"
           ./shared/native-ab/publish/verify-installer-redirect.sh \
-            https://repository.frostyard.org/isos/native/v1/snosi-native-installer-latest-x86-64.iso \
+            https://repository.frostyard.org/isos/native/v1/snosi-installer-latest-x86-64.iso \
             "$ver"
 
       - name: Remove OpenPGP update-signing key

--- a/.github/workflows/deploy-native-installer-redirect.yml
+++ b/.github/workflows/deploy-native-installer-redirect.yml
@@ -67,11 +67,11 @@ jobs:
       - name: Confirm route is active
         run: |
           set -euo pipefail
-          url=https://repository.frostyard.org/isos/native/v1/snosi-native-installer-latest-x86-64.iso
+          url=https://repository.frostyard.org/isos/native/v1/snosi-installer-latest-x86-64.iso
           base=https://repository.frostyard.org/isos/native/v1
           version=""
           if sums="$(curl -fsS --max-time 15 "$base/SHA256SUMS")"; then
-            version="$(awk '$2 ~ /^snosi-native-installer_[0-9]{14}_x86-64\.iso$/ {name=$2} END {sub(/^snosi-native-installer_/, "", name); sub(/_x86-64\.iso$/, "", name); print name}' <<<"$sums")"
+            version="$(awk '$2 ~ /^snosi-installer_[0-9]{14}_x86-64\.iso$/ {name=$2} END {sub(/^snosi-installer_/, "", name); sub(/_x86-64\.iso$/, "", name); print name}' <<<"$sums")"
           fi
           for attempt in 1 2 3 4 5 6; do
             if [[ -n "$version" ]]; then

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A bootable container image build system using [mkosi](https://github.com/systemd
 ## Downloads
 
 - [Bootc live installation media](https://repository.frostyard.org/isos/snow-live-latest.iso)
-- [Native A/B network installer (latest x86-64)](https://repository.frostyard.org/isos/native/v1/snosi-native-installer-latest-x86-64.iso)
-- [Native installer checksums](https://repository.frostyard.org/isos/native/v1/SHA256SUMS) and [OpenPGP signature](https://repository.frostyard.org/isos/native/v1/SHA256SUMS.gpg)
+- [Firn installer — all image families, bootc and A/B (latest x86-64)](https://repository.frostyard.org/isos/native/v1/snosi-installer-latest-x86-64.iso)
+- [Installer checksums](https://repository.frostyard.org/isos/native/v1/SHA256SUMS) and [OpenPGP signature](https://repository.frostyard.org/isos/native/v1/SHA256SUMS.gpg)
 
 See the [supported installation guide](docs/installing.md) to choose an image,
 verify the native installer, create boot media, install safely, and recover or

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -52,8 +52,8 @@ curl -fL https://repository.frostyard.org/isos/snow-live-latest.iso \
 
 # Native A/B installer
 curl -fL \
-  https://repository.frostyard.org/isos/native/v1/snosi-native-installer-latest-x86-64.iso \
-  -o snosi-native-installer.iso
+  https://repository.frostyard.org/isos/native/v1/snosi-installer-latest-x86-64.iso \
+  -o snosi-installer.iso
 ```
 
 The native installer's `latest` URL redirects without caching to the immutable,
@@ -78,13 +78,13 @@ test "$fingerprint" = F37282A35CB6BDFEBFC8FE775A2EAC5C8216FD68
 gpgv --keyring ./snosi-native-update-pubring.gpg \
   SHA256SUMS.gpg SHA256SUMS
 expected="$(
-  awk '$2 ~ /^snosi-native-installer_[0-9]{14}_x86-64\.iso$/ {
+  awk '$2 ~ /^snosi-installer_[0-9]{14}_x86-64\.iso$/ {
     print $1
     exit
   }' SHA256SUMS
 )"
 test -n "$expected"
-printf '%s  %s\n' "$expected" snosi-native-installer.iso |
+printf '%s  %s\n' "$expected" snosi-installer.iso |
   sha256sum -c -
 ```
 
@@ -112,7 +112,7 @@ device, such as `/dev/sdb`, not a partition such as `/dev/sdb1`.
 3. Set `ISO` and `DISK`, inspect them again, and write the image:
 
    ```bash
-   ISO=snosi-native-installer.iso  # or snow-live.iso
+   ISO=snosi-installer.iso  # or snow-live.iso
    DISK=/dev/sdX                   # replace with the whole USB device
 
    test -f "$ISO"

--- a/shared/firn-installer/mkosi.conf
+++ b/shared/firn-installer/mkosi.conf
@@ -184,6 +184,14 @@ Packages=gpgv
 # curl/jq are gone: they were snosi-install's (bash) HTTP/JSON tools; firn
 # does both natively in Go.
 Packages=ca-certificates
+# The firn installer binary itself, from the frostyard apt repo
+# (mkosi.sandbox/.../frostyard.sources -> repository.frostyard.org,
+# published by firn's release via repogen). This is the CI source of firn
+# per firn ADR-0010/0027/0028: no sibling firn checkout is needed at build
+# time (the old `just _firn-binary` local build still overrides it via the
+# tree ExtraTrees below, for dev testing of unreleased firn). Installs to
+# /usr/bin/firn, which the postinst guard checks for.
+Packages=frostyard-firn
 # mount/umount live in the 'mount' package (separate from util-linux, whose
 # agetty/lsblk/etc. ARE present). firn's mount-target/tpm-enroll/seed-var
 # steps declare mount/umount (mounting the target root, the ESP to read the
@@ -296,6 +304,12 @@ Packages=flatpak
 # duplicated into this tree. /usr/lib/snosi/os-update-pubring.gpg is the
 # first entry in firn's pubring search order (firn internal/trust).
 ExtraTrees=%D/shared/firn-installer/tree
+# The core flatpak list firn reads for core_flatpaks on composefs images,
+# whose /usr is not readable at install time (firn's fallback,
+# InstallerCoreJSONPath). The frostyard-firn package does not ship it, so
+# provision the vendored copy here at build time — the CI equivalent of
+# what `just _firn-binary` copies into the tree for local builds.
+ExtraTrees=%D/shared/firn-installer/core.json:/usr/share/firn/core-flatpaks.json
 ExtraTrees=%D/shared/native-ab/keys/import-pubring.gpg:/usr/lib/snosi/os-update-pubring.gpg
 ExtraTrees=%D/shared/native-ab/keys/mok-2026.crt:/usr/lib/snosi/mok.crt
 

--- a/shared/firn-installer/postinst/mkosi.postinst.chroot
+++ b/shared/firn-installer/postinst/mkosi.postinst.chroot
@@ -16,15 +16,15 @@ set -euo pipefail
 # install, not a dracut initrd), so systemd boots straight to normal targets.
 ln -sf usr/lib/systemd/systemd /init
 
-# The firn installer binary ships via this profile's own ExtraTrees=
-# (shared/firn-installer/tree/usr/bin/firn), but it is NOT committed: `just
-# _firn-binary` builds it from a sibling firn checkout right before the
-# mkosi build (see shared/firn-installer/README.md). Fail the image build
-# loudly if that step was skipped -- an installer ISO without its installer
-# would otherwise only be discovered at first boot. The chmod fixes up the
-# mode defensively (ExtraTrees= preserves the source tree's file mode).
+# The firn installer binary comes from the frostyard-firn apt package
+# (Packages=frostyard-firn in this profile's mkosi.conf, published by
+# firn's release to repository.frostyard.org). A local `just _firn-binary`
+# build still overrides it via the tree ExtraTrees= for dev. Either way,
+# fail the image build loudly if firn is missing -- an installer ISO
+# without its installer would otherwise only be discovered at first boot.
+# The chmod fixes up the mode defensively.
 [[ -f /usr/bin/firn ]] || {
-    echo "ERROR: /usr/bin/firn missing -- run \`just firn-installer\` (which builds it via _firn-binary), not bare mkosi (see shared/firn-installer/README.md)" >&2
+    echo "ERROR: /usr/bin/firn missing -- Packages=frostyard-firn should have installed it (see shared/firn-installer/mkosi.conf)" >&2
     exit 1
 }
 chmod 0755 /usr/bin/firn

--- a/shared/native-ab/publish/prepare-iso-publication.sh
+++ b/shared/native-ab/publish/prepare-iso-publication.sh
@@ -52,7 +52,7 @@ done
 [[ -f "$ISO_PATH" ]] || { echo "Error: ISO not found: $ISO_PATH" >&2; exit 1; }
 [[ "$VERSION" =~ ^[0-9]{14}$ ]] || { echo "Error: version must be exactly 14 digits: $VERSION" >&2; exit 1; }
 
-expected_name="snosi-native-installer_${VERSION}_x86-64.iso"
+expected_name="snosi-installer_${VERSION}_x86-64.iso"
 actual_name="$(basename "$ISO_PATH")"
 [[ "$actual_name" == "$expected_name" ]] || {
     echo "Error: ISO filename '$actual_name' does not match the frozen public name '$expected_name' for version $VERSION (docs/native-ab-contracts.md \"Installer ISO\")" >&2
@@ -98,12 +98,13 @@ sums_tmp="$NEW_TMPFILE"
 commit_tmpfile "$sums_tmp" "$sums_file"
 echo "Writing $sums_file (unsigned; signing is the Phase 7 promotion step)"
 
-# product == channel == "snosi-native-installer" here (unlike the OS
-# artifact pipeline, where product/channel differ, e.g. "cayo"/"cayo-ab"):
-# there is exactly one installer, not one per product, and this value must
-# equal the literal prefix of the frozen object name itself
-# (snosi-native-installer_<version>_x86-64.iso) so promote.sh's outgoing-
-# index archival step (which greps SHA256SUMS for "<channel>_<14-digit
+# product == channel == "snosi-installer" here (unlike the OS artifact
+# pipeline, where product/channel differ, e.g. "cayo"/"cayo-ab"): there is
+# exactly one installer (firn, the successor to native-installer; core
+# ADR-0027/0028), not one per product, and this value must equal the
+# literal prefix of the frozen object name itself
+# (snosi-installer_<version>_x86-64.iso) so promote.sh's outgoing-index
+# archival step (which greps SHA256SUMS for "<channel>_<14-digit
 # version>") can find this publication type's own entries.
 source_commit="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse HEAD 2>/dev/null || echo unknown)"
 generated_at="$(date -u +%FT%TZ)"
@@ -114,8 +115,8 @@ new_tmpfile "$info_file"
 info_tmp="$NEW_TMPFILE"
 cat >"$info_tmp" <<EOF
 {
-  "product": "snosi-native-installer",
-  "channel": "snosi-native-installer",
+  "product": "snosi-installer",
+  "channel": "snosi-installer",
   "version": "$VERSION",
   "dest_path": "isos/native/v1",
   "artifacts": {

--- a/shared/native-ab/publish/verify-installer-redirect.sh
+++ b/shared/native-ab/publish/verify-installer-redirect.sh
@@ -20,7 +20,7 @@ command -v curl >/dev/null || { echo "Error: curl is required" >&2; exit 1; }
 WORK="$(mktemp -d /var/tmp/verify-installer-redirect.XXXXXX)"
 trap 'rm -rf "$WORK"' EXIT
 
-expected_name="snosi-native-installer_${EXPECTED_VERSION}_x86-64.iso"
+expected_name="snosi-installer_${EXPECTED_VERSION}_x86-64.iso"
 base_url="${STABLE_URL%/*}"
 expected_location="$base_url/$expected_name"
 

--- a/test/native-publication-pipeline-test.sh
+++ b/test/native-publication-pipeline-test.sh
@@ -360,8 +360,8 @@ echo "=== ISO-shaped fixture leg (isos/native/v1) ==="
 
 ISO_VERSION1=20260301000000
 ISO_VERSION2=20260302000000
-ISO_FIXTURE1="$WORK_DIR/snosi-native-installer_${ISO_VERSION1}_x86-64.iso"
-ISO_FIXTURE2="$WORK_DIR/snosi-native-installer_${ISO_VERSION2}_x86-64.iso"
+ISO_FIXTURE1="$WORK_DIR/snosi-installer_${ISO_VERSION1}_x86-64.iso"
+ISO_FIXTURE2="$WORK_DIR/snosi-installer_${ISO_VERSION2}_x86-64.iso"
 printf 'fixture ISO bytes v1\n' >"$ISO_FIXTURE1"
 printf 'fixture ISO bytes v2, slightly different length\n' >"$ISO_FIXTURE2"
 
@@ -379,7 +379,7 @@ ISO_BASE_URL="http://127.0.0.1:${PORT}/isos/native/v1"
 
 "$PUBLISH_DIR/publish-candidate.sh" "$ISO_PREPARED1" "$DEST"
 assert_true "ISO candidate object landed under isos/native/v1/.candidate/$ISO_VERSION1/" \
-    test -f "$DEST/isos/native/v1/.candidate/$ISO_VERSION1/snosi-native-installer_${ISO_VERSION1}_x86-64.iso"
+    test -f "$DEST/isos/native/v1/.candidate/$ISO_VERSION1/snosi-installer_${ISO_VERSION1}_x86-64.iso"
 
 assert_true "verify-remote.sh clean pass for the ISO candidate" \
     "$PUBLISH_DIR/verify-remote.sh" "$ISO_PREPARED1" "$ISO_BASE_URL"
@@ -390,7 +390,7 @@ assert_true "ISO final SHA256SUMS.gpg exists (no product/x86-64 subpath)" test -
 assert_true "gpgv accepts the promoted ISO index" \
     gpgv --keyring "$PUBRING" "$iso_product_dir/SHA256SUMS.gpg" "$iso_product_dir/SHA256SUMS"
 assert_contains "promoted ISO index lists the version-stamped name" \
-    "$(cat "$iso_product_dir/SHA256SUMS")" "snosi-native-installer_${ISO_VERSION1}_x86-64.iso"
+    "$(cat "$iso_product_dir/SHA256SUMS")" "snosi-installer_${ISO_VERSION1}_x86-64.iso"
 
 "$PUBLISH_DIR/publish-candidate.sh" "$ISO_PREPARED2" "$DEST" >/dev/null
 "$PUBLISH_DIR/verify-remote.sh" "$ISO_PREPARED2" "$ISO_BASE_URL" >/dev/null
@@ -398,9 +398,9 @@ assert_contains "promoted ISO index lists the version-stamped name" \
 assert_true "ISO v1's signed index was archived to .history/$ISO_VERSION1/" \
     test -f "$iso_product_dir/.history/$ISO_VERSION1/SHA256SUMS.gpg"
 
-"$PUBLISH_DIR/withdraw.sh" --pubring "$PUBRING" --dest-path isos/native/v1 snosi-native-installer "$ISO_VERSION1" "$DEST"
+"$PUBLISH_DIR/withdraw.sh" --pubring "$PUBRING" --dest-path isos/native/v1 snosi-installer "$ISO_VERSION1" "$DEST"
 assert_contains "ISO index advertises v1 again after withdrawal via --dest-path" \
-    "$(cat "$iso_product_dir/SHA256SUMS")" "snosi-native-installer_${ISO_VERSION1}_x86-64.iso"
+    "$(cat "$iso_product_dir/SHA256SUMS")" "snosi-installer_${ISO_VERSION1}_x86-64.iso"
 assert_true "gpgv accepts the withdrawn (restored) ISO index" \
     gpgv --keyring "$PUBRING" "$iso_product_dir/SHA256SUMS.gpg" "$iso_product_dir/SHA256SUMS"
 

--- a/workers/native-installer-redirect/src/index.ts
+++ b/workers/native-installer-redirect/src/index.ts
@@ -1,4 +1,4 @@
-const STABLE_PATH = "/isos/native/v1/snosi-native-installer-latest-x86-64.iso";
+const STABLE_PATH = "/isos/native/v1/snosi-installer-latest-x86-64.iso";
 const INDEX_KEY = "isos/native/v1/SHA256SUMS";
 const ISO_KEY_PREFIX = "isos/native/v1/";
 const PUBLIC_BASE = "https://repository.frostyard.org/isos/native/v1/";
@@ -10,7 +10,7 @@ const NO_STORE_HEADERS = {
 };
 
 const INDEX_LINE = /^([0-9a-f]{64})  (\S+)$/;
-const INSTALLER_NAME = /^snosi-native-installer_[0-9]{14}_x86-64\.iso$/;
+const INSTALLER_NAME = /^snosi-installer_[0-9]{14}_x86-64\.iso$/;
 
 class ResolutionError extends Error {
   constructor(readonly code: string) {

--- a/workers/native-installer-redirect/test/index.test.ts
+++ b/workers/native-installer-redirect/test/index.test.ts
@@ -3,10 +3,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { installerNameFromIndex } from "../src/index";
 
 const STABLE_URL =
-  "https://repository.frostyard.org/isos/native/v1/snosi-native-installer-latest-x86-64.iso";
+  "https://repository.frostyard.org/isos/native/v1/snosi-installer-latest-x86-64.iso";
 const INDEX_KEY = "isos/native/v1/SHA256SUMS";
 const VERSION = "20260717123456";
-const ISO_NAME = `snosi-native-installer_${VERSION}_x86-64.iso`;
+const ISO_NAME = `snosi-installer_${VERSION}_x86-64.iso`;
 const ISO_KEY = `isos/native/v1/${ISO_NAME}`;
 const HASH = "a".repeat(64);
 
@@ -48,7 +48,7 @@ describe("installerNameFromIndex", () => {
     ["non-canonical spacing", `${HASH} ${ISO_NAME}\n`],
     ["a carriage return", `${HASH}  ${ISO_NAME}\r\n`],
     ["no installer", `${HASH}  release-notes.txt\n`],
-    ["multiple installers", `${HASH}  ${ISO_NAME}\n${"b".repeat(64)}  snosi-native-installer_20260718123456_x86-64.iso\n`],
+    ["multiple installers", `${HASH}  ${ISO_NAME}\n${"b".repeat(64)}  snosi-installer_20260718123456_x86-64.iso\n`],
   ])("rejects %s", (_description, index) => {
     expect(() => installerNameFromIndex(index)).toThrow();
   });


### PR DESCRIPTION
Switches the **published installer ISO** from the old `native-installer` profile to **firn** (the single installer; firn ADR-0010, core ADR-0027/0028). firn now comes from the `frostyard-firn` apt package, so CI needs no firn source checkout.

Load-bearing:
- `shared/firn-installer/mkosi.conf`: `Packages=frostyard-firn` + core-list ExtraTree.
- `build-native-images.yml` build-iso: `--profile firn-installer` + firn's `build-iso.sh` → object `snosi-installer_<ver>_x86-64.iso`.
- publish scripts + redirect worker (regex + `STABLE_PATH`) + worker tests + deploy-redirect: new object name and `snosi-installer-latest` alias; `isos/native/v1` namespace reused.
- README/installing docs.

**Validated locally**: bare `mkosi --profile firn-installer build` installs `firn 0.2.0` from the package (core list + pubring present); redirect worker's 16 tests pass. build-iso does not run on PRs, so this was validated by hand before merge.

Follow-up: retire the `native-installer` profile + its E2E tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)