### PR TITLE
docs: record repo-local architecture decisions as ADRs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,9 +14,18 @@ Docs are split by the question they answer (the shape defined by
 
 ### Decisions (ADRs)
 
-*(none yet — repo-local decisions get the next number from
-[adr/TEMPLATE.md](adr/TEMPLATE.md))*
-
+- [adr/0001-var-factory-state-outcome-maps.md](adr/0001-var-factory-state-outcome-maps.md) — every build-time `/var` path is classified in per-product outcome maps, audited fail-closed in both directions (unclassified paths and stale globs)
+- [adr/0002-ship-no-enablement-symlinks-in-etc.md](adr/0002-ship-no-enablement-symlinks-in-etc.md) — images ship zero unit-enablement symlinks in `/etc`; first-boot presets recreate them, with parity proven against a shipped manifest
+- [adr/0003-runtime-etc-mutation-ban.md](adr/0003-runtime-etc-mutation-ban.md) — shipped payload files may not mutate `/etc` at runtime; enforced by payload-directory scanning with a per-line `etc-guard-allow` escape hatch
+- [adr/0004-sysext-authoring-rules.md](adr/0004-sysext-authoring-rules.md) — sysexts are `/usr`-only overlays: `/opt` relocation, scoped factory-`/etc` capture, `Upholds=` activation, fail-closed `required-paths.txt` manifests
+- [adr/0005-profiles-as-transport-kernel-selectors.md](adr/0005-profiles-as-transport-kernel-selectors.md) — profiles reduce to transport+kernel selectors via the `Dependencies=` reset idiom and ordered `Include=` fragment layering
+- [adr/0006-name-triggered-publication-guards.md](adr/0006-name-triggered-publication-guards.md) — a profile is production purely by name; static textual guards pin secure posture on production profiles and forbid it on dev fixtures
+- [adr/0007-frozen-contract-executable-allowlist.md](adr/0007-frozen-contract-executable-allowlist.md) — frozen contract docs get an executable form and an allowlist that fails closed in both directions, so it shrinks to empty
+- [adr/0008-digest-first-release-latest-is-promotion.md](adr/0008-digest-first-release-latest-is-promotion.md) — publish by digest, sign and verify before `latest` is promoted; predecessors require the SBOM referrer or are skipped
+- [adr/0009-snosi-env-var-classes.md](adr/0009-snosi-env-var-classes.md) — `SNOSI_*` variables come in three classes; security-relevant test hooks are paired/mutually gated so one stray variable is inert
+- [adr/0010-credential-handoff-paths-not-bytes.md](adr/0010-credential-handoff-paths-not-bytes.md) — credentials cross the sudo boundary as mode-0600 file paths, never bytes; durable keys live in `.snosi-private/`, year-stamped
+- [adr/0011-mkosi-bootstrapped-and-pin-shared.md](adr/0011-mkosi-bootstrapped-and-pin-shared.md) — mkosi runs from a repo-local checkout pinned to the workflow's action commit, bootstrapped pre-sudo
+- [adr/0012-chunked-layers-cadence-xattrs-chunk-before-seal.md](adr/0012-chunked-layers-cadence-xattrs-chunk-before-seal.md) — OCI layers are chunked by changelog-derived update cadence; secure images chunk before digest sealing, never after
 - [org-adrs.md](org-adrs.md) — the frostyard/core ADRs that bind this repo
 
 ### Design

--- a/docs/adr/0001-var-factory-state-outcome-maps.md
+++ b/docs/adr/0001-var-factory-state-outcome-maps.md
@@ -1,0 +1,92 @@
+# 0001 — Classify every build-time /var path in per-product outcome maps, audited fail-closed
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+Native A/B images boot with an empty `/var` partition, while bootc images
+carry `/var` state through updates. Whatever a Debian package drops under
+`/var` at image-build time therefore has four possible fates, and getting one
+wrong is silent: a path that should have been seeded ships broken, a path
+that should have been discarded ships stale secrets or caches. Package drift
+makes this worse — upstream Debian freely adds, removes, and renames its
+`/var` state between releases, and nothing in mkosi flags the change.
+
+## Decision
+
+Every product carries an outcome map, `shared/composition/<product>/
+var-outcomes.txt` (`cayo/var-outcomes.txt` for cayo; `snow/var-outcomes.txt`
+shared by snow and snowfield), that classifies every path present under the
+buildroot's `/var` into exactly one of four outcomes:
+
+- `image-metadata` — kept in the image's factory state
+- `tmpfiles` — recreated at runtime by a tmpfiles.d entry
+- `discard` — deliberately dropped
+- `installer-seed` — written by the installer after `mkfs` (valid class,
+  currently zero entries)
+
+`shared/composition/var-audit.finalize` (a non-chroot mkosi FinalizeScript,
+wired from both products' composition `mkosi.conf`) walks `$BUILDROOT/var`
+— every file and symlink, plus empty directories — and matches each path
+against the map's bash-glob patterns, **first match wins** (the loop breaks
+and marks only that pattern used). Matching is `[[ == ]]` string globbing, so
+`*` crosses `/`; `**` in the maps is a naming convention only.
+
+The audit fails the build in **both** directions:
+
+- any `/var` path matching no pattern → unclassified, build fails;
+- any pattern matching no path → stale glob, build fails.
+
+An unknown `IMAGE_ID` and an invalid outcome token are also hard failures.
+On success the audit writes the classified inventory to
+`$BUILDROOT/usr/share/snosi/var-inventory.txt` (`LC_ALL=C` sorted), which
+`test/native-ab-components-test.sh` asserts in the booted guest.
+
+## Consequences
+
+- Upstream package drift in `/var` cannot land silently: on 2026-08-12,
+  Debian's man-db stopped pre-generating `cache/man` and replaced the
+  `lib/man-db/auto-update` marker with a directory. The audit failed twice
+  in ~2 hours — once as an unclassified path, once as stale globs on the
+  builds the first fix was not validated against — and the surviving map
+  comments (`cayo/var-outcomes.txt`, `snow/var-outcomes.txt`) record the
+  reclassification. Both failure directions earned their keep the same day.
+- The cost is symmetric: an unrelated upstream change hard-blocks every
+  image build and every open PR until the maps are updated. That is the
+  accepted trade — updating a text map is cheap; shipping a misclassified
+  `/var` path is not.
+- The fail-closed stale check shapes glob style: dual-shape bare-`*`
+  patterns (`lib/dpkg*`) are used where two separate globs would make one
+  spuriously stale depending on build output.
+- The audit script itself has no unit test; validation is the synthetic
+  scratch-buildroot recipe in
+  [design/overview.md](../design/overview.md#native-var-factory-state-phase-2)
+  plus the guest-side inventory assertions.
+
+## Alternatives considered
+
+- **Warn-only audit:** rejected — a warning on a green build is never read;
+  both halves of the man-db incident would have shipped.
+- **Allowlist only unexpected paths (no full classification):** rejected —
+  the value is the forced *decision* per path; an allowlist records
+  exceptions without recording intent for the other four hundred paths.
+- **One shared map for all products:** rejected — cayo (server) and
+  snow/snowfield (desktop) legitimately differ (e.g. cayo builds no man-db
+  index); a shared map would need per-product escapes that reintroduce
+  ambiguity.
+- **Pathname-expansion globbing (`*` stops at `/`):** rejected — maps would
+  need an entry per directory level; string globbing keeps maps short at the
+  cost of the documented "`*` crosses `/`" gotcha.
+
+## References
+
+- Shapes: [design/overview.md](../design/overview.md) (Native `/var`
+  Factory State), [design/testing.md](../design/testing.md)
+- Implemented by: `shared/composition/var-audit.finalize`,
+  `shared/composition/cayo/var-outcomes.txt`,
+  `shared/composition/snow/var-outcomes.txt`
+- Guarded by: the build itself (finalize failure);
+  `test/native-ab-components-test.sh` (guest-side inventory)
+- Builds on: [core ADR-0004 — product-namespaced filesystem tiers](https://github.com/frostyard/core/blob/main/docs/adr/0004-product-namespaced-filesystem-tiers.md)
+  (`/usr/share/snosi/var-inventory.txt` lives in the image-lifetime tier)

--- a/docs/adr/0002-ship-no-enablement-symlinks-in-etc.md
+++ b/docs/adr/0002-ship-no-enablement-symlinks-in-etc.md
@@ -1,0 +1,92 @@
+# 0002 — Ship zero unit-enablement symlinks in /etc; presets recreate them at first boot
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+Debian package postinsts enable units by creating symlinks under
+`/etc/systemd/system/*.wants/` (and `[Install]` aliases). On an immutable
+image those shipped symlinks are a liability: when an admin later runs
+`systemctl disable`, systemd deletes an *image-shipped* `/etc` path, and
+bootc's three-way `/etc` merge at update finalize breaks on the deletion —
+the staged update is discarded while the updater reports success (the
+deletion-crash needs a *symlink* counterpart in the new deployment; deleted
+shipped regular files merge fine). Independently, systemd only runs
+first-boot preset logic when the machine believes it is on first boot.
+
+## Decision
+
+Golden images ship **zero** unit-enablement symlinks under `/etc`.
+`shared/outformat/image/finalize/mkosi.finalize.chroot`:
+
+- records every `.wants`/`.requires` entry and `[Install]` alias into
+  `/usr/share/snosi/enablement-manifest.txt` (`<scope> <relpath>` lines,
+  `LC_ALL=C sort`ed — C collation because the guest-side parity test
+  `comm(1)`s against this file), then deletes the symlinks and now-empty
+  `.wants`/`.requires` directories;
+- writes `uninitialized` into `/etc/machine-id` (an *empty* file merely
+  means "generate an ID" and silently suppresses all first-boot semantics),
+  so systemd applies presets at first boot and recreates the enablement
+  state from `/usr/lib/systemd/*-preset/`.
+
+Four classes are excluded from the manifest (documented in the script):
+
+1. `ctrl-alt-del.target` — not preset-managed; `/usr` ships the same alias;
+2. `display-manager.service` — Debian display managers carry no `Alias=`;
+   desktop trees ship a static `/usr` alias instead;
+3. entries whose target unit is masked (masks in `/etc` or under
+   `/usr/lib/systemd`, as the native ab-root tree masks bootc/nbc updaters);
+4. dangling entries whose unit is no longer shipped (e.g. systemd 261
+   removed `run-lock.mount`).
+
+Masks (`-> /dev/null`) and links whose targets live outside the systemd unit
+directories are kept, not stripped. At runtime,
+`/usr/libexec/preset-reconcile` (via `preset-reconcile.service`) compares the
+shipped manifest against `/var/lib/snosi/enablement-manifest.applied` with
+`LC_ALL=C comm`, creates newly-expected enablement, and records removals to
+`/var/lib/snosi/preset-removals` without ever auto-disabling.
+
+## Consequences
+
+- `systemctl disable` on a running system touches only admin-created state;
+  bootc's `/etc` merge can no longer be broken by enablement churn.
+- Enablement becomes declarative and diffable: the manifest is the single
+  build-time truth, and `test/tests/05-firstboot-presets.sh` proves parity
+  in the booted guest.
+- New units enabled by a package update reach existing machines through
+  preset-reconcile's create-only pass; *dis*ablement never propagates
+  automatically — an operator decision by design, recorded in
+  `/var/lib/snosi/preset-removals`.
+- The exclusion classes are knowledge that lives in the finalize script's
+  comments; a new exclusion class must be added there and mirrored in the
+  parity test.
+- `machine-id=uninitialized` makes every image boot as a true first boot;
+  anything not preset- or tmpfiles-driven will not be set up.
+
+## Alternatives considered
+
+- **Ship the symlinks and forbid `systemctl disable`:** rejected —
+  unenforceable against admins, and the failure mode (silently discarded
+  update) is the worst in the repo.
+- **Empty `/etc/machine-id`:** rejected by regression — empty means
+  "generate an ID" only; first-boot semantics stayed off and presets never
+  ran (fixed 2026-07).
+- **`systemctl preset-all` in a runtime unit instead of first-boot
+  semantics:** rejected — runtime enablement mutation is exactly what
+  [ADR-0003](0003-runtime-etc-mutation-ban.md) bans; preset-reconcile's
+  narrow create-only pass carries an explicit `etc-guard-allow`.
+
+## References
+
+- Shapes: [design/build-pipeline.md](../design/build-pipeline.md)
+  (FinalizeScripts), [design/testing.md](../design/testing.md)
+  (first-boot preset parity)
+- Implemented by:
+  `shared/outformat/image/finalize/mkosi.finalize.chroot`,
+  `mkosi.images/base/mkosi.extra/usr/libexec/preset-reconcile`
+- Guarded by: `test/tests/05-firstboot-presets.sh`,
+  `test/bootc-migration-test.sh`
+- Related: [ADR-0003 — runtime /etc mutation ban](0003-runtime-etc-mutation-ban.md)
+- Builds on: [core ADR-0004 — product-namespaced filesystem tiers](https://github.com/frostyard/core/blob/main/docs/adr/0004-product-namespaced-filesystem-tiers.md)
+  (`/usr/share/snosi` and `/var/lib/snosi` tier placement)

--- a/docs/adr/0003-runtime-etc-mutation-ban.md
+++ b/docs/adr/0003-runtime-etc-mutation-ban.md
@@ -1,0 +1,78 @@
+# 0003 — Ban runtime /etc mutation, enforced by scanning payload directories
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+On 2026-07-05, `enable-incus-agent.service` — a shipped unit that disabled
+itself via `ExecStartPost=systemctl disable` — was root-caused as the trigger
+of bootc (≤ 1.16.3) failing its `/etc` merge with `error: Merging: a path led
+outside of the filesystem`: the staged update was silently discarded while
+the updater reported success. Any *shipped* code that mutates `/etc`
+enablement state or deletes `/etc` paths at runtime can reproduce this class
+of failure, and code review alone had already missed one instance.
+
+## Decision
+
+Files that ship inside images may not mutate `/etc` at runtime. The rule is
+enforced by `check-runtime-etc-guard.sh` (repo root), which scans **payload
+directories** — a classification invented for this guard: every git-tracked
+file under `*/mkosi.extra/*`, `mkosi.extra/*`, or `shared/*/tree/*`. These
+are exactly the trees copied verbatim into images; build-time scripts
+(`*.chroot`, `mkosi.postinst`, `mkosi.finalize`) are deliberately out of
+scope because build time is the correct place to set enablement state.
+
+Forbidden in payload files:
+
+- `systemctl`/`deb-systemd-helper` with `disable|enable|revert|unmask|
+  preset|preset-all` — `enable` only *creates* symlinks and is merge-safe,
+  but is banned anyway: enablement state must be image-defined;
+- `rm`/`rmdir`/`unlink`, `mv`, and `find … -delete` targeting `/etc`;
+- tmpfiles.d removal types (`r`, `R`, `D`) on `/etc` paths.
+
+Run-once behavior must use a `/var` marker instead:
+`ConditionPathExists=!/var/lib/<unit>.done` plus `ExecStartPost=touch …`.
+
+The escape hatch is `# etc-guard-allow: <reason>`, trailing on the offending
+line or on the comment line immediately above (unit files cannot carry
+trailing comments on directive lines); an above-line allowance exempts
+exactly one following line, never a block.
+
+## Consequences
+
+- The incus-agent failure class is structurally closed: the three current
+  allowances (`preset-reconcile`, `preset-global.service`,
+  `preset-migration.service`) are each a deliberate, reasoned exception
+  visible to `grep etc-guard-allow`.
+- Adding any shipped file that touches `/etc` at runtime now requires either
+  a redesign around `/var` markers and presets, or a written reason at the
+  call site — the review conversation happens in the diff.
+- The guard is textual: obfuscated invocations (variables, wrappers) evade
+  it. It is a tripwire against the common spellings, not a sandbox.
+- The "payload directory" classification must be kept in sync if new payload
+  roots are added to the repo layout.
+
+## Alternatives considered
+
+- **Review checklist only:** rejected — this exact bug shipped once already
+  under review.
+- **Runtime enforcement (read-only `/etc`, SELinux):** rejected — `/etc`
+  must stay admin-writable on these systems; the ban is on *shipped* code,
+  not on administrators.
+- **Scanning every file in the repo:** rejected — build-time scripts
+  legitimately set enablement state; scanning them would drown the signal
+  in allowances.
+
+## References
+
+- Shapes: [design/ci-cd.md](../design/ci-cd.md),
+  [design/build-pipeline.md](../design/build-pipeline.md),
+  [design/overview.md](../design/overview.md)
+- Implemented by: `check-runtime-etc-guard.sh`
+- Guarded by: `test/runtime-etc-guard-test.sh`,
+  `test/publication-guards.bats`, `.github/workflows/validate.yml`,
+  `.github/workflows/nightly-compliance.yml`
+- Related: [ADR-0002 — ship no enablement symlinks in /etc](0002-ship-no-enablement-symlinks-in-etc.md)
+- Builds on: [core ADR-0005 — marker files and /run update-state contract](https://github.com/frostyard/core/blob/main/docs/adr/0005-native-ab-marker-and-update-state-files.md)
+  (the `/var` marker idiom extends the same state-file discipline)

--- a/docs/adr/0004-sysext-authoring-rules.md
+++ b/docs/adr/0004-sysext-authoring-rules.md
@@ -1,0 +1,94 @@
+# 0004 — Sysexts are /usr-only overlays with fail-closed structural manifests
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+The 22 sysexts are EROFS overlays merged onto an immutable base at runtime
+(`Format=sysext`, `Overlay=yes`, `BaseTrees=%O/base`). Three facts constrain
+how they must be authored: sysexts can only provide files under `/usr`;
+PID 1 scans unit files *before* any sysext is merged; and the buildroot's
+`/etc` during a sysext build is the merged base view, containing secrets.
+Each constraint was violated once before being turned into a rule — most
+expensively on 2026-07-01, when the published incus sysext
+(`1+7.2-debian13-202607011055`) shipped without its entire
+incus-base/incus-client payload: no incusd, no CLI, no units, and no check
+noticed.
+
+## Decision
+
+Sysexts follow four authoring rules:
+
+1. **Payloads are `/usr`-only.** Packages that install to `/opt` are
+   relocated to `/usr/lib/<pkg>` in the image's postinst chroot script, with
+   `/usr/bin` symlinks, `patchelf --set-rpath` where libraries reference
+   `/opt` paths (patchelf purged afterward so it does not ship), and
+   SUID/capability restoration (`chmod 4755` on chrome-sandbox binaries,
+   `setcap` where needed). `/opt` itself must stay: it is the mountpoint for
+   `opt.mount`, whose bind to `/var/opt` shadows anything left there.
+2. **`/etc` defaults are captured into `/usr/share/factory/etc` only for the
+   exact paths the sysext's tmpfiles.d entries reference** — enumerated
+   per-path in each `mkosi.finalize` (e.g. incus's `FACTORY_PATHS` array).
+   Never all of `/etc`: the buildroot `/etc` is the merged base view, so a
+   full capture ships `/etc/shadow` and the SSH host keys generated during
+   the base build (frostyard/snosi#282, found in the 2026-07-01 audit).
+3. **Services activate via a shipped drop-in
+   `/usr/lib/systemd/system/multi-user.target.d/10-<name>.conf` carrying
+   `Upholds=`**, not `.wants` symlinks: PID 1 scans unit files before the
+   sysext is merged, so a `.wants` symlink into the sysext dangles at scan
+   time and is silently dropped, and merging later does not re-trigger the
+   dropped `Wants=`. `Upholds=` is re-evaluated continuously, so it fires
+   once the merge lands. (Deliberate non-adopters — pure desktop apps,
+   sunshine — are documented in design/sysexts.md.)
+4. **Every sysext declares `required-paths.txt`**, checked fail-closed by
+   `shared/sysext/finalize/sysext-required-paths.sh` (wired via
+   `FinalizeScripts=` in all 22 sysext configs): a missing manifest fails
+   the build, and any listed path missing from the output fails the build
+   ("refusing to produce a broken extension"). Because `Overlay=yes` makes
+   `$BUILDROOT` the *delta*, base-image paths must not be listed.
+
+## Consequences
+
+- The 2026-07-01 failure class is closed structurally: an empty or
+  mis-assembled payload cannot be published, because its manifest paths are
+  absent. The sibling `SYSEXT_REVISION` (+rN) mechanism exists because
+  publish-time `skip-duplicates` keyed on version meant tree-only fixes
+  never republished.
+- Relocation scripts are per-package boilerplate that must be re-derived for
+  each new `/opt`-installing vendor package; the pattern is documented in
+  design/build-pipeline.md.
+- Factory capture is deliberately verbose (one path per line) so that review
+  sees exactly which `/etc` bytes ship; scoped subtrees owned by the package
+  (e.g. `/etc/1password`, `/etc/nix`) are acceptable, whole-`/etc` capture
+  never is.
+- `/usr`-only remains convention plus mkosi's sysext format — there is no
+  separate linter rejecting stray `/var` or `/opt` payloads; the
+  required-paths manifests (all-`/usr` today) are the observable check.
+
+## Alternatives considered
+
+- **Enable services with `.wants` symlinks in the sysext:** rejected —
+  dangles at PID-1 scan time and is silently dropped (observed; recorded in
+  design/sysexts.md with the docker `-H fd://` socket-activation variant).
+- **Capture all of `/etc` to factory:** rejected — shipped `/etc/shadow`
+  and SSH host keys in a published artifact (frostyard/snosi#282).
+- **Leave packages in `/opt`:** rejected — sysexts cannot ship `/opt`, and
+  the `opt.mount` bind shadows it at runtime anyway.
+- **Content tests in QEMU instead of build-time manifests:** rejected as the
+  only line of defense — the guest tiers exist, but the manifest fails the
+  build before an artifact exists to publish, with no boot required.
+
+## References
+
+- Shapes: [design/sysexts.md](../design/sysexts.md),
+  [design/build-pipeline.md](../design/build-pipeline.md) (Package
+  Relocation)
+- Implemented by: `shared/sysext/finalize/sysext-required-paths.sh`,
+  `mkosi.images/*/required-paths.txt`, `mkosi.images/*/mkosi.finalize`,
+  `shared/packages/*/mkosi.postinst.d/*.chroot`
+- Guarded by: `test/sysext-required-paths-test.sh`
+  (`.github/workflows/validate.yml`), `test/pilothouse-sysext-test.sh`
+- Builds on:
+  [core ADR-0007 — sysext filename pattern](https://github.com/frostyard/core/blob/main/docs/adr/0007-frostyard-sysext-filename-pattern.md),
+  [core ADR-0008 — sysext distribution and update contract](https://github.com/frostyard/core/blob/main/docs/adr/0008-sysext-distribution-and-update-contract.md)

--- a/docs/adr/0005-profiles-as-transport-kernel-selectors.md
+++ b/docs/adr/0005-profiles-as-transport-kernel-selectors.md
@@ -1,0 +1,91 @@
+# 0005 — Profiles select transport and kernel posture; composition stays shared
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+Each product (cayo, snow, snowfield) ships over two transports — bootc OCI
+and native A/B — and the two variants must have identical package
+composition or every guest test proves the wrong thing. mkosi has two
+properties that make naive profile configs wrong: list settings
+*accumulate* (a profile's `Dependencies=` appends to the root
+`mkosi.conf`'s), and `Include=` fragments merge list settings in encounter
+order.
+
+## Decision
+
+The root `mkosi.conf` declares `Dependencies=base` plus all 22 sysexts, so
+the default build produces everything. Every profile then reduces itself to
+a transport+kernel selector using the reset idiom — an empty assignment
+followed by the single wanted dependency:
+
+```ini
+[Config]
+Dependencies=
+Dependencies=base
+```
+
+(the empty assignment is required because mkosi appends collection settings;
+without it every profile would rebuild every sysext). All nine profiles
+carry the idiom verbatim. Product composition lives in shared fragments
+(`shared/composition/<product>/mkosi.conf`) included by both the bootc and
+the native profile of a product, so the pair differs only in transport
+fragments (`shared/packages/bootc` + `shared/outformat/image` vs
+`shared/outformat/ab-root` + `shared/native-ab/channels/<product>`).
+
+`Include=` order inside a profile is load-bearing: the secure posture
+fragment comes before the composition fragment so its FinalizeScripts
+(disable-nvpcr) resolve before the composition's image finalize — mkosi
+accumulates list settings in `Include=` encounter order. The three
+production native profiles state this in an identical comment; the arbiter
+for any ordering question is a byte-level diff of `mkosi cat-config`/
+`mkosi summary` output, not a read of the source files.
+
+`check-profile-dependencies.sh` enforces the reset idiom's outcome for the
+bootc profiles (cayo, snow, snowfield): it runs `mkosi summary` per profile
+and greps for any forbidden `IMAGE: <sysext>` line.
+
+## Consequences
+
+- One composition fragment per product keeps bootc and native builds
+  provably identical in package terms; a package added to a product lands on
+  both transports by construction.
+- The reset idiom is boilerplate every new profile must copy exactly;
+  forgetting the empty assignment silently rebuilds all sysexts (caught by
+  the guard for bootc profiles).
+- Known enforcement gaps, accepted for now: the guard covers only the three
+  bootc profiles, not the six native/installer profiles carrying the same
+  idiom; its sysext list is a hand-maintained duplicate of the root
+  `mkosi.conf`; and no test asserts the secure-before-composition `Include=`
+  order — that ordering is held by the in-profile comments and by
+  "verified via `mkosi summary`" review discipline.
+- Profile behavior can only be judged from resolved output (`summary` /
+  `cat-config`), never from reading fragment files in isolation.
+
+## Alternatives considered
+
+- **Per-profile Dependencies lists (no root list):** rejected — the default
+  build is the sysext-publishing build and must stay complete; profiles are
+  the exception, not the rule.
+- **Duplicating composition per transport profile:** rejected — the two
+  transports of a product would drift, and the native test matrix would
+  validate a different package set than what bootc ships.
+- **A real Include= resolver as the guard:** rejected — `mkosi summary` *is*
+  the resolver; the guard greps its output rather than reimplementing mkosi
+  config semantics ([ADR-0006](0006-name-triggered-publication-guards.md)
+  makes the same choice for the same reason).
+
+## References
+
+- Shapes: [design/overview.md](../design/overview.md) (Configuration
+  Composition), [design/build-pipeline.md](../design/build-pipeline.md)
+- Implemented by: `mkosi.conf`, `mkosi.profiles/*/mkosi.conf`,
+  `shared/composition/*/mkosi.conf`
+- Guarded by: `check-profile-dependencies.sh`
+  (`.github/workflows/validate.yml`),
+  `test/check-profile-dependencies-local-mkosi-test.sh`,
+  `test/native-ab-static-test.sh` (Include= presence)
+- Builds on: [core ADR-0015 — os-release image identity](https://github.com/frostyard/core/blob/main/docs/adr/0015-os-release-image-identity.md)
+  (`ImageId` stays the product name across transports, which is what lets
+  composition fragments key off `IMAGE_ID`)

--- a/docs/adr/0006-name-triggered-publication-guards.md
+++ b/docs/adr/0006-name-triggered-publication-guards.md
@@ -1,0 +1,89 @@
+# 0006 — Profile names trigger publication guards; reachability is textual, not resolved
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+Production and development profiles live in the same tree and share
+fragments. The dangerous failure is categorical: a dev fixture drifting into
+publishability (acquiring signing markers), or a production profile silently
+losing its secure posture. Any guard keyed on profile *content* can be
+argued around; any guard keyed on a registry file can fall out of date.
+What cannot drift is the name a publish workflow builds.
+
+## Decision
+
+A profile is production purely by being named `cayo-ab`, `snow-ab`, or
+`snowfield-ab` — the rule is normative in
+[native-ab-contracts.md §1](../native-ab-contracts.md): a profile literally
+so named is production-facing, must satisfy the publication guard, and must
+never mean "raw prototype". Two guards enforce the postures:
+
+- `check-native-publication-guard.sh` requires, in each production-named
+  profile's reachable config text: `ShimBootloader=signed`,
+  `SecureBoot=yes`, `SignExpectedPcr=yes`, the `disable-nvpcr.chroot`
+  reference, the `shared/outformat/ab-root` include, and the committed
+  pubring `shared/native-ab/keys/import-pubring.gpg` — and forbids a
+  profile-local `KernelModules=` filter. It also hard-fails the inverse:
+  the dev fixture `cayo-ab-raw` must never carry any of the three signing
+  markers. Beyond profiles, it pins the workflow shape itself (PR builds
+  must not reference `secrets.NATIVE_*`, publish/promote scripts, `rclone:`
+  or artifact uploads; publish jobs must use `environment: native-build`).
+- `check-bootc-publication-guard.sh` requires each bootc production profile
+  (`cayo`, `snow`, `snowfield`) to include
+  `shared/bootc-secure/mkosi.conf` plus its file set (cosign.pub, MOK/PCR
+  certs, policy.json, bootc-secure.json), and forbids any `*-ab*` profile
+  from including the bootc secure fragment.
+
+Reachability is a **plain textual check, deliberately not an `Include=`
+resolver**: a profile's config plus the one documented fragment directory
+(`shared/native-ab-secure/**`) if and only if the profile's `mkosi.conf`
+textually references it. The guard does not walk arbitrary `Include=`
+chains — the comment in the script states this, and
+`test/native-ab-contracts-test.sh` restates the same rule at its mirror
+check.
+
+## Consequences
+
+- Publishing posture cannot be weakened by renaming or refactoring
+  fragments without the guard noticing — the check follows the same
+  contract-frozen names the publish workflows use.
+- Symmetric protection: production profiles cannot lose markers, and dev
+  fixtures cannot gain them; `test/publication-guards.bats` mutation cases
+  cover both directions, using the `SNOSI_*_GUARD_ROOT` fixture overrides
+  ([ADR-0009](0009-snosi-env-var-classes.md)).
+- The textual reachability rule means a marker moved into a *new* fragment
+  directory is invisible to the guard until the guard learns the directory;
+  that is the accepted cost of not reimplementing mkosi's config resolution
+  (the tie-breaker for resolution questions stays `mkosi summary`, per
+  [ADR-0005](0005-profiles-as-transport-kernel-selectors.md)).
+- Creating a profile named like production *is* a publication decision —
+  there is no separate "register it for publishing" step to forget.
+
+## Alternatives considered
+
+- **A real Include= resolver:** rejected in the script's own comments — it
+  would reimplement mkosi config semantics and drift from them; the
+  contract instead freezes the one fragment directory the check must know.
+- **A publishable-profiles registry file:** rejected — a second source of
+  truth that can disagree with what workflows actually build; names are the
+  single shared key.
+- **Content-based detection (any profile with SecureBoot=yes is
+  production):** rejected — inverts the failure mode: a dev profile gaining
+  a marker would become production instead of failing the build.
+
+## References
+
+- Shapes: [native-ab-contracts.md](../native-ab-contracts.md) (§1, §15),
+  [design/ci-cd.md](../design/ci-cd.md),
+  [design/testing.md](../design/testing.md)
+- Implemented by: `check-native-publication-guard.sh`,
+  `check-bootc-publication-guard.sh`
+- Guarded by: `test/publication-guards.bats`,
+  `test/bootc-publication-guard-test.sh`, `.github/workflows/validate.yml`,
+  `.github/workflows/nightly-compliance.yml`
+- Related: [ADR-0007 — frozen contract with executable form](0007-frozen-contract-executable-allowlist.md)
+- Builds on: [core ADR-0014 — single GPG trust root](https://github.com/frostyard/core/blob/main/docs/adr/0014-single-gpg-trust-root.md)
+  (the committed pubring the guard requires),
+  [core ADR-0015 — os-release image identity](https://github.com/frostyard/core/blob/main/docs/adr/0015-os-release-image-identity.md)

--- a/docs/adr/0007-frozen-contract-executable-allowlist.md
+++ b/docs/adr/0007-frozen-contract-executable-allowlist.md
@@ -1,0 +1,80 @@
+# 0007 — Freeze contracts in a doc with an executable form and a shrinking allowlist
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+The native A/B rollout froze names, paths, version grammar, and policy
+(Phase 0) before most implementing code existed. A frozen prose document
+alone drifts; a test alone encodes values nobody can read as a contract; and
+a prototype that predates the freeze needs a way to deviate *visibly*
+without blocking every build until each phase lands.
+
+## Decision
+
+[native-ab-contracts.md](../native-ab-contracts.md) is the normative source
+of truth for native A/B naming, paths, and policy — it defines values and
+carries no rationale. `test/native-ab-contracts-test.sh` validates every
+value statically, and the doc states the tie-breaker in its own header:
+*"That test is the executable form of this document. If the two disagree,
+the test is currently wrong (fix it) unless a value here was deliberately
+changed (update both in the same commit)."*
+
+Known deviations are tracked in `test/native-ab-contracts-allow.txt`, which
+fails closed in **both** directions:
+
+- an unallowlisted contract violation fails the test;
+- a stale allowlist entry fails the test — both modes: the referenced file
+  no longer exists, or it no longer violates.
+
+Every entry names the phase that removes it, so the allowlist can only
+shrink. It has since reached its terminal state: the file is now comments
+only, stating "No tracked deviations remain… the stale-entry check keeps it
+that way." A missing allowlist file is itself a test failure.
+
+## Consequences
+
+- The contract stayed enforceable across a multi-phase rollout: the
+  prototype's known deviations (e.g. the pre-rename `cayo-ab` under tag
+  `pending-rename`) were visible, phase-bound, and mechanically expired as
+  each phase landed.
+- The two-direction fail-closed allowlist prevents both failure modes of
+  exception lists: silent accumulation (stale entries fail) and silent
+  bypass (unlisted violations fail).
+- Editing the frozen doc is constrained: value changes require the paired
+  test change in the same commit; the doc cannot grow rationale (that now
+  belongs in ADRs and design docs).
+- This is a governance *pattern*, but it currently has exactly one
+  instance. The bootc install contract pair
+  ([bootc-secure-install-contract.md](../bootc-secure-install-contract.md)
+  + `test/bootc-secure-install-contract-test.sh`) is a different mechanism:
+  its authoritative artifact is the shipped
+  `/usr/lib/snosi/bootc-secure.json`, asserted by a hardcoded exact-dict
+  test, with no allowlist and no tie-breaker clause. A second frozen-doc
+  contract should copy the native-ab mechanism deliberately, not assume it
+  is already generic.
+
+## Alternatives considered
+
+- **Doc only, review-enforced:** rejected — a freeze that review must
+  remember is not a freeze; the version grammar and label budgets are
+  exactly the values that erode one "harmless" exception at a time.
+- **Test only, no prose contract:** rejected — downstream repos (chairlift,
+  installer repos) consume the *names*; they need a citable document, not a
+  shell script.
+- **Warn-listed deviations (non-failing):** rejected — deviations must
+  block anything that is not explicitly tracked with a removal phase, or
+  the prototype would have quietly redefined the contract.
+
+## References
+
+- Shapes: [native-ab-contracts.md](../native-ab-contracts.md),
+  [design/testing.md](../design/testing.md)
+- Implemented by: `test/native-ab-contracts-test.sh`,
+  `test/native-ab-contracts-allow.txt`
+- Guarded by: `.github/workflows/validate.yml` (contracts test step)
+- Related: [ADR-0006 — name-triggered publication guards](0006-name-triggered-publication-guards.md)
+  (§15 of the contract is its normative home)
+- Builds on: [core ADR-0006 — OS artifact versions are UTC timestamps](https://github.com/frostyard/core/blob/main/docs/adr/0006-os-artifact-versions-are-utc-timestamps.md)
+  (the frozen version grammar), [core ADR-0005 — marker and update-state files](https://github.com/frostyard/core/blob/main/docs/adr/0005-native-ab-marker-and-update-state-files.md)

--- a/docs/adr/0008-digest-first-release-latest-is-promotion.md
+++ b/docs/adr/0008-digest-first-release-latest-is-promotion.md
@@ -1,0 +1,87 @@
+# 0008 — Publish by digest; `latest` is a promotion, never a push
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+A mutable `latest` tag pushed alongside the version tag means consumers can
+pull an image that was never verified: signing or verification failing
+*after* the push leaves `latest` pointing at unvetted bytes. Separately, the
+release job must resolve a predecessor image to describe updates against —
+and guessing one produced a real incident: GitHub Actions run 30627996880's
+fallback selected failed-build tag `20260731030941`, which had no SBOM.
+
+## Decision
+
+The secure publish path in `.github/workflows/build-images.yml` is
+digest-first, in a statically enforced order:
+
+1. push the immutable 14-digit version tag only, capturing the digest
+   (`--digestfile`, shape-validated `^sha256:`);
+2. `cosign sign` **the digest**, never a tag;
+3. verify remotely (`shared/bootc-secure/ci/verify-published-image.sh`:
+   capability labels, tag→digest agreement, `cosign verify` against the
+   committed `cosign.pub`, policy-gated `skopeo copy`) and re-validate the
+   policy-copied bytes with `test/bootc-secure-artifact-test.sh`;
+4. only then promote: `shared/bootc-secure/ci/promote-published-image.sh`
+   does a registry-to-registry `skopeo copy --all "$IMAGE@$DIGEST"
+   "$IMAGE:latest"` and re-inspects `latest`, failing unless it resolves to
+   the expected digest. No local bytes are ever pushed under `latest`.
+
+After promotion, the SBOM is attached as an ORAS referrer
+(`--artifact-type application/vnd.syft+json`), rediscovered to prove it is
+findable, and itself cosign-signed. `check-bootc-publication-guard.sh` pins
+the step order (Push → Sign → Verify → Validate → Promote, monotonically
+increasing line numbers).
+
+Release notes embed a machine-readable `<!-- snow-tag: <version> -->`
+marker. Predecessor resolution
+(`shared/bootc-secure/ci/resolve-snow-release-predecessor.sh`) walks release
+markers, requires the candidate's digest to resolve, its referrer discovery
+to parse, **and a `application/vnd.syft+json` referrer to exist** — any
+candidate failing any check is skipped, and if none qualifies the release
+steps are skipped (`skip=true`) rather than guessing. Listing registry tags
+as a fallback is forbidden by the guard (`oras repo tags` must not appear in
+the release job).
+
+## Consequences
+
+- `latest` can only ever point at a digest that was signed, remotely
+  verified, and policy-copy revalidated; a failure anywhere leaves the
+  version tag published but `latest` untouched — an intentionally visible
+  half-state.
+- A release with no SBOM-complete predecessor produces no changelog rather
+  than a wrong one (the run-30627996880 class); the trade-off is that a
+  gap in SBOM attachment mutes release notes until repaired.
+- The SBOM referrer is attached *after* promotion, so there is a window in
+  which `latest` exists without its SBOM; the predecessor resolver treats
+  such images as ineligible, which is the designed behavior for incomplete
+  publishes.
+- The step ordering is contract, not convention: reordering the workflow
+  fails `check-bootc-publication-guard.sh` before it can ship.
+
+## Alternatives considered
+
+- **Push version + latest together, then sign:** rejected — the window
+  where `latest` is unsigned/unverified is exactly the failure this flow
+  removes.
+- **Tag-based signing:** rejected — tags are mutable; the signature must
+  bind bytes, so it binds the digest.
+- **Predecessor by registry tag listing:** rejected by incident — tag
+  listings include failed and incomplete builds; the SBOM referrer is the
+  proof of a completed publish, so it is the eligibility criterion.
+
+## References
+
+- Shapes: [design/ci-cd.md](../design/ci-cd.md) (secure-build and release
+  jobs), [bootc-secure-operations.md](../bootc-secure-operations.md)
+- Implemented by: `.github/workflows/build-images.yml`,
+  `shared/bootc-secure/ci/verify-published-image.sh`,
+  `shared/bootc-secure/ci/promote-published-image.sh`,
+  `shared/bootc-secure/ci/resolve-snow-release-predecessor.sh`
+- Guarded by: `check-bootc-publication-guard.sh` (step-order pinning),
+  `test/bootc-release-predecessor-test.sh`
+- Builds on: [core ADR-0006 — OS artifact versions are UTC timestamps](https://github.com/frostyard/core/blob/main/docs/adr/0006-os-artifact-versions-are-utc-timestamps.md)
+  (the version-tag grammar), [core ADR-0017 — io.snosi.* capability labels](https://github.com/frostyard/core/blob/main/docs/adr/0017-io-snosi-capability-labels-and-mechanics-tier.md)
+  (the labels the remote verify asserts)

--- a/docs/adr/0009-snosi-env-var-classes.md
+++ b/docs/adr/0009-snosi-env-var-classes.md
@@ -1,0 +1,88 @@
+# 0009 — SNOSI_* variables come in three classes; security-relevant test hooks are mutually gated
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+Roughly 75 `SNOSI_*` environment variables have accumulated across build
+scripts, guards, and shipped binaries. Many exist only so tests can inject
+fixtures — and an env var is the easiest thing in a CI system to set by
+accident or leave exported. A single stray variable must never be able to
+weaken a production build or a shipped binary's security posture. This ADR
+is the first written statement of the classification, which previously
+existed only as scattered per-script comments.
+
+## Decision
+
+`SNOSI_*` variables fall into three classes, with different rules:
+
+1. **Build inputs** — production-meaningful settings (`SNOSI_BOOTC_SECURE`,
+   `SNOSI_BOOTC_MOK_KEY/_CERT`, `SNOSI_BOOTC_PCR_KEY/_CERT`,
+   `SNOSI_NATIVE_AUTOSTAGE`, `SNOSI_REQUIRE_GPT_AUTO_VALIDATION`, …). These
+   are documented where consumed, validated at the consumer (unset or
+   malformed is fatal on secure paths), and explicitly forwarded across the
+   sudo boundary by name
+   ([ADR-0010](0010-credential-handoff-paths-not-bytes.md)).
+2. **Guard-root overrides** — exactly the `SNOSI_*_GUARD_ROOT` family
+   (bootc/native publication, runtime-etc, duplicate-packages). They
+   redirect *what a guard inspects* so mutation-fixture tests are possible;
+   they cannot weaken production because pointing a guard at a fixture repo
+   changes the check's subject, not the shipped artifact.
+3. **Test hooks** — undocumented by design (absent from `--help`), never
+   present on a real target machine, and where a hook can weaken a security
+   property it must be **paired or mutually gated** so one stray variable
+   is inert:
+   - `snosi-etc-diff` relaxes its `EUID==0` requirement only when **both**
+     `SNOSI_ETC_DIFF_LIVE_ETC` and `SNOSI_ETC_DIFF_PRISTINE_ETC` are set;
+     either alone changes nothing.
+   - `buildah-package.sh` rejects `SNOSI_BOOTC_SECURE_TEST_ASSEMBLER`
+     unless `SNOSI_BOOTC_SECURE_TEST_HOOKS=1`, rejects hooks=1 without an
+     assembler, and rejects any hooks value other than 0/1 (no
+     truthy-string bypass).
+
+   Hooks that only substitute inert inputs (fixture paths such as
+   `SNOSI_INSTALL_LSBLK_JSON`, `SNOSI_TEST_*` tool paths) may stand alone;
+   the pairing requirement applies where a hook alone would relax a check.
+
+## Consequences
+
+- The threat model "one exported variable left over from a test run" is
+  addressed at the two places where it could bypass a security property;
+  new hooks with that power must copy the pairing pattern.
+- Class-2 overrides are what make the guards testable at all
+  ([ADR-0006](0006-name-triggered-publication-guards.md)'s mutation
+  fixtures); keeping them read-target-only preserves that safety argument.
+- Known gap, accepted: no test currently exercises the assembler/hooks
+  rejection branches themselves — the suites always set the pair together.
+  A regression that dropped the mutual gate would not be caught by CI
+  today.
+- Undocumented-by-design means test hooks impose no compatibility
+  obligation; anything documented in `--help` graduates to class 1 and
+  acquires one.
+
+## Alternatives considered
+
+- **A single `SNOSI_TEST_MODE=1` master switch:** rejected — one variable
+  that relaxes everything is exactly the stray-variable hazard, and its
+  blast radius grows with every hook added under it.
+- **Documenting all hooks:** rejected — documentation implies support;
+  hooks exist to be reshaped freely by the tests that own them.
+- **Config files instead of env vars for hooks:** rejected — the hooks must
+  work inside QEMU guests and fixture chroots where placing files is the
+  expensive operation and env is the cheap one.
+
+## References
+
+- Shapes: [design/build-pipeline.md](../design/build-pipeline.md)
+  (snosi-etc-diff hooks), [design/overview.md](../design/overview.md)
+  (installer test hooks), [design/testing.md](../design/testing.md)
+- Implemented by:
+  `mkosi.images/base/mkosi.extra/usr/bin/snosi-etc-diff`,
+  `shared/outformat/image/buildah-package.sh`,
+  `check-*-guard.sh` / `check-duplicate-packages.sh` (guard roots)
+- Guarded by: `test/snosi-etc-diff-test.sh`,
+  `test/publication-guards.bats` (guard-root usage)
+- Related: [ADR-0006](0006-name-triggered-publication-guards.md),
+  [ADR-0010](0010-credential-handoff-paths-not-bytes.md)
+- Builds on: [core ADR-0019 — governance as code and risk tiers](https://github.com/frostyard/core/blob/main/docs/adr/0019-governance-as-code-and-risk-tiers.md)

--- a/docs/adr/0010-credential-handoff-paths-not-bytes.md
+++ b/docs/adr/0010-credential-handoff-paths-not-bytes.md
@@ -1,0 +1,81 @@
+# 0010 — Credentials cross the sudo boundary as paths, never as bytes
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+The secure image build needs signing material (MOK key/cert, PCR signing
+key/cert, cosign key) inside a `sudo`-elevated mkosi invocation in CI.
+Secret bytes in command arguments or a broadly preserved environment leak
+into process listings, logs, and every child process; and key files that
+outlive the job are a rotation liability. Locally, developers need durable
+keys that survive `mkosi clean -ff` — which deletes the `.mkosi-private`
+directory, because mkosi owns it.
+
+## Decision
+
+- **Bytes land once, before elevation:** the workflow writes each secret to
+  a file under `/var/tmp/bootc-secure-credentials` with `umask 077` +
+  `chmod 600`. Everything after that point handles *paths*: the sudo
+  invocation forwards each `SNOSI_BOOTC_*` variable as an explicit
+  `VAR="$VAR"` assignment (never `--preserve-env`), and the values are file
+  paths. Only credential paths cross the boundary; secret bytes remain in
+  the mode-0600 files.
+- **Committed public identities are byte-checked before use:** the
+  delivered MOK cert and derived PCR public key must `cmp` equal to the
+  committed `shared/native-ab/keys/mok-2026.crt` and
+  `pcr-signing-2026.pub`, so a wrong or rotated secret fails loudly before
+  any signing happens.
+- **Credentials are deleted before any registry write:** the removal step
+  (`if: always()`) precedes the first push in the workflow.
+- **Durable local keys live in the gitignored `.snosi-private/`** — never
+  `.mkosi-private`, which mkosi owns and `mkosi clean -ff` removes.
+  Key filenames are year-stamped (`mok-2026.crt`, `pcr-signing-2026.pub`)
+  so rotation is visible in every reference, with history retained under
+  `.snosi-private/history/`.
+
+The native A/B workflows use the same shape (umask 077, chmod 600 files,
+explicit forwarding, `rm -rf` of `/var/tmp/native-promote-secrets`).
+
+## Consequences
+
+- Secrets never appear in `ps`, workflow logs, or the environment of
+  arbitrary build children; compromise of a build script reads files it was
+  already trusted with, no more.
+- The byte-check turns "wrong key configured in repo secrets" from a
+  silently mis-signed artifact into an immediate, attributable failure.
+- Deleting credentials before the first registry write bounds their
+  lifetime to the build phase; nothing that talks to the network still has
+  them. (The publication guard requires the cleanup step to exist with
+  `if: always()`, but does not yet pin its position before the push — the
+  ordering is held by the workflow itself.)
+- Year-stamped names force every consumer to be updated at rotation —
+  deliberate friction that makes stale-key use impossible to miss.
+
+## Alternatives considered
+
+- **`sudo --preserve-env`:** rejected — forwards the entire environment,
+  including anything a previous step exported; explicit per-variable
+  assignments are the allowlist form.
+- **Secret bytes in env vars/arguments:** rejected — visible to process
+  listings and inherited by every child of the elevated build.
+- **Durable keys in `.mkosi-private/`:** rejected by mechanism — mkosi owns
+  that directory and `mkosi clean -ff` deletes it; a routine clean would
+  destroy signing keys.
+- **Unversioned key names (`mok.crt`):** rejected — rotation becomes
+  invisible; a year-stamp makes the active generation explicit at every
+  call site.
+
+## References
+
+- Shapes: [bootc-secure-operations.md](../bootc-secure-operations.md),
+  [design/ci-cd.md](../design/ci-cd.md)
+- Implemented by: `.github/workflows/build-images.yml` (credential
+  materialization, identity `cmp`, cleanup),
+  `.github/workflows/build-native-images.yml`, `.gitignore`
+  (`.snosi-private/`, `.mkosi-private/`), `shared/native-ab/keys/`
+- Guarded by: `check-bootc-publication-guard.sh` (explicit sudo
+  forwarding, cleanup-step presence), `test/bootc-publication-guard-test.sh`
+- Related: [ADR-0009 — SNOSI_* variable classes](0009-snosi-env-var-classes.md)
+- Builds on: [core ADR-0014 — single GPG trust root](https://github.com/frostyard/core/blob/main/docs/adr/0014-single-gpg-trust-root.md)

--- a/docs/adr/0011-mkosi-bootstrapped-and-pin-shared.md
+++ b/docs/adr/0011-mkosi-bootstrapped-and-pin-shared.md
@@ -1,0 +1,78 @@
+# 0011 — Bootstrap mkosi from a repo-local checkout pinned to the workflow's commit
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+Image output depends on the exact mkosi commit: a local build on a distro
+mkosi and a CI build on the pinned `systemd/mkosi` action can produce
+different images from the same tree, and the mkosi commit is effectively
+part of the published image contract. Maintaining the pin in two places
+(workflow and local tooling) invites the copy-paste defect where one is
+bumped and the other is not.
+
+## Decision
+
+mkosi runs from a repo-local, gitignored `.mkosi/` checkout, bootstrapped by
+the single implementation `shared/native-ab/ci/bootstrap-mkosi.sh` — used by
+both the Justfile and CI. The pin has one source of truth: the script greps
+`systemd/mkosi@<sha>` out of `.github/workflows/build.yml` and checks out
+that commit; there is no second recorded pin to drift.
+
+`shared/native-ab/ci/check-mkosi-pin.sh` enforces the scheme: the pin must
+be a full 40-character SHA (short SHAs, branches, and tags are rejected —
+the commit is part of the published image contract);
+`build-native-images.yml` must not carry a *conflicting* `systemd/mkosi@`
+pin; and an existing `.mkosi/` checkout's HEAD must equal the pin (absent
+checkout is a skip, not a failure). CI runs bootstrap+check pairs in every
+build job plus a standalone pin-check job.
+
+In the Justfile, every public target depends on `ensure-mkosi` *before* its
+`sudo` line — the bootstrap runs as the invoking user so the checkout is not
+root-owned. Scripts prefer `.mkosi/bin/mkosi` over any `mkosi` on `PATH`
+(`check-profile-dependencies.sh`), and
+`test/check-profile-dependencies-local-mkosi-test.sh` proves the local
+checkout wins by planting a poisoned `PATH` mkosi.
+
+## Consequences
+
+- Local and CI builds are bit-for-bit on the same mkosi by construction;
+  "works locally, differs in CI" ceases to be a config-resolution suspect.
+- Bumping mkosi is one edit (the `build.yml` action pin); everything else
+  follows, and the pin-check fails any workflow that reintroduces a second
+  divergent pin.
+- The full-SHA requirement trades convenience for reproducibility: no
+  tracking a branch, ever.
+- Pre-sudo bootstrap keeps `.mkosi/` user-owned, so `git` operations and
+  re-bootstraps never need elevation and never litter root-owned files in
+  the tree.
+- Developers pay a one-time clone of the mkosi repo per checkout; the
+  bootstrap is idempotent and short-circuits when HEAD already matches.
+
+## Alternatives considered
+
+- **Distro/pip-installed mkosi:** rejected — version skew against CI is
+  invisible until an image differs.
+- **Recording the pin in its own file (e.g. `.mkosi-version`):** rejected —
+  a second source of truth that the workflow could disagree with; the
+  workflow's action pin is the one CI actually executes, so it is the
+  truth.
+- **Git submodule:** rejected — submodules require every clone and CI job
+  to manage init/update state, and root-invoked builds would still need the
+  ownership care the pre-sudo bootstrap gives for free.
+
+## References
+
+- Shapes: [design/ci-cd.md](../design/ci-cd.md),
+  [design/overview.md](../design/overview.md),
+  [plans/2026-07-14-bootc-native-ab-coexistence-plan.md](../plans/2026-07-14-bootc-native-ab-coexistence-plan.md)
+  (Mkosi Pin Governance)
+- Implemented by: `shared/native-ab/ci/bootstrap-mkosi.sh`, `Justfile`
+  (`ensure-mkosi`), `.github/workflows/build.yml` (the authoritative pin)
+- Guarded by: `shared/native-ab/ci/check-mkosi-pin.sh`
+  (`.github/workflows/build-native-images.yml`,
+  `.github/workflows/native-nightly.yml`),
+  `test/check-profile-dependencies-local-mkosi-test.sh`
+- Builds on: [core ADR-0021 — SHA-pinned actions and least-privilege CI](https://github.com/frostyard/core/blob/main/docs/adr/0021-sha-pinned-actions-and-least-privilege-ci.md),
+  [core ADR-0023 — verified pinned downloads](https://github.com/frostyard/core/blob/main/docs/adr/0023-verified-pinned-downloads.md)

--- a/docs/adr/0012-chunked-layers-cadence-xattrs-chunk-before-seal.md
+++ b/docs/adr/0012-chunked-layers-cadence-xattrs-chunk-before-seal.md
@@ -1,0 +1,91 @@
+# 0012 — Chunk OCI layers by update cadence; chunk before sealing, never after
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+A monolithic OCI rootfs layer forces clients to re-download the whole image
+for any change. Chunking tools group files into layers, but grouping is only
+useful if files that change together share layers — and for secure images
+there is a harder constraint: the UKI binds a `composefs=` digest of the
+image's storage identity into the signed kernel command line, and chunking
+rewrites the OCI layer layout, changing that digest. Chunking a sealed image
+invalidates its own seal.
+
+## Decision
+
+- **Chunking:** `shared/outformat/image/chunkah-package.sh` runs a
+  digest-pinned chunkah (`quay.io/coreos/chunkah@sha256:…`, auto-bumped by
+  `check-dependencies.yml`) with `--max-layers` defaulting to 128
+  (`MAX_LAYERS: 128` in the workflow, pinned by the publication guard).
+- **Cadence metadata:** before packaging,
+  `shared/outformat/image/finalize/mkosi.finalize.chroot` tags every
+  packaged file with two xattrs chunkah groups by: `user.component` (the
+  owning dpkg package) and `user.update-interval`, computed per package from
+  its Debian changelog — the last 10 `changelog.Debian.gz` entries, pairwise
+  day-deltas, true median, bucketed into six classes: ≤3 daily, ≤10 weekly,
+  ≤21 biweekly, ≤52 monthly, ≤180 quarterly, else yearly. Missing changelogs
+  fail soft (xattr skipped, build continues); the Homebrew tarball is
+  hardcoded `biweekly`. This tagging runs only for directory-image (OCI)
+  outputs, not native A/B.
+- **Chunk before seal:** on the secure path
+  (`shared/outformat/image/buildah-package.sh`), the pristine candidate is
+  packaged, **then chunked, and the authoritative composefs digest is
+  computed from the chunked candidate**; only then does ukify bind
+  `composefs=?<digest>` into the UKI, and the final image derives from the
+  chunked candidate with only `/boot` overlaid — followed by a hard equality
+  check that the overlay did not change the digest. `SOURCE_DATE_EPOCH` is
+  required (fail-closed) for secure chunking. Protected images are never
+  re-chunked after assembly: `check-bootc-publication-guard.sh` fails any
+  secure-build workflow that invokes `chunkah-package.sh` directly.
+
+## Consequences
+
+- Update downloads scale with what changed: fast-moving packages share
+  layers with each other, not with the yearly-cadence base, so a browser
+  update does not invalidate the glibc layer.
+- The chunked candidate — not the unchunked rootfs — is the storage-digest
+  authority; the digest the UKI enforces is the digest clients actually
+  pull. Re-chunking after sealing is structurally impossible in CI, not
+  just discouraged.
+- The cadence heuristic is deliberately cheap and wrong-tolerant: a
+  mis-bucketed package costs bandwidth, never correctness, and fail-soft
+  means chunking never blocks a build over a missing changelog.
+- Currently chunkah's only call site is the secure branch; the non-secure
+  buildah path packages without chunking (older doc text saying non-secure
+  images are chunked is stale).
+- Known fragility (recorded in the fable audit): `chunkah-package.sh`
+  parses `podman load`'s English output, so an upstream wording change
+  aborts packaging.
+
+## Alternatives considered
+
+- **One layer per package (no cap):** rejected — registries and clients
+  degrade with thousands of layers; `MAX_LAYERS=128` forces grouping, and
+  cadence is the grouping key that minimizes expected re-download.
+- **Static hand-maintained layer groups:** rejected — a curated map of
+  ~2000 packages drifts immediately; changelog history is already shipped
+  ground truth for how often a package changes.
+- **Chunk after sealing (chunk the final image):** rejected by mechanism —
+  chunking rewrites the layer layout and thus the composefs digest the UKI
+  already signed; the seal must bind the post-chunk identity.
+- **ostree-container chunking:** not adopted — these images are
+  bootc/composefs from mkosi output, not ostree commits; chunkah operates
+  on the rootfs directly.
+
+## References
+
+- Shapes: [design/build-pipeline.md](../design/build-pipeline.md),
+  [design/ci-cd.md](../design/ci-cd.md),
+  [bootc-secure-assembly-compatibility.md](../bootc-secure-assembly-compatibility.md)
+- Implemented by: `shared/outformat/image/chunkah-package.sh`,
+  `shared/outformat/image/buildah-package.sh`,
+  `shared/outformat/image/finalize/mkosi.finalize.chroot` (xattr tagging)
+- Guarded by: `check-bootc-publication-guard.sh` (MAX_LAYERS pin, no
+  direct chunkah invocation in secure builds),
+  `test/bootc-publication-guard-test.sh`
+- Related: [ADR-0008 — digest-first release](0008-digest-first-release-latest-is-promotion.md)
+- Builds on: [core ADR-0017 — io.snosi.* capability labels](https://github.com/frostyard/core/blob/main/docs/adr/0017-io-snosi-capability-labels-and-mechanics-tier.md),
+  [core ADR-0023 — verified pinned downloads](https://github.com/frostyard/core/blob/main/docs/adr/0023-verified-pinned-downloads.md)
+  (the digest-pinned chunkah image)

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -4,6 +4,9 @@
 for the Frostyard `bootc` package at upstream version `1.16.7`. It is not an
 upstream-stable bootc interface.
 
+The chunk-before-seal ordering this contract pins is decided in
+[ADR-0012](adr/0012-chunked-layers-cadence-xattrs-chunk-before-seal.md).
+
 ## Pinned behavior
 
 The adapter relies on all of the following observed behavior:

--- a/docs/bootc-secure-operations.md
+++ b/docs/bootc-secure-operations.md
@@ -14,6 +14,10 @@ installer contract is [docs/bootc-secure-install-contract.md](bootc-secure-insta
 the assembly compatibility contract is [docs/bootc-secure-assembly-compatibility.md](bootc-secure-assembly-compatibility.md),
 and the image schema source is
 [shared/bootc-secure/tree/usr/lib/snosi/bootc-secure.json](../shared/bootc-secure/tree/usr/lib/snosi/bootc-secure.json).
+Decision records: [ADR-0008](adr/0008-digest-first-release-latest-is-promotion.md)
+(digest-first publication) and
+[ADR-0010](adr/0010-credential-handoff-paths-not-bytes.md) (credential
+handoff).
 
 ## Support Status
 

--- a/docs/design/build-pipeline.md
+++ b/docs/design/build-pipeline.md
@@ -1,5 +1,18 @@
 # Build Pipeline
 
+Decision records shaping this document:
+[ADR-0002](../adr/0002-ship-no-enablement-symlinks-in-etc.md) (enablement
+symlinks stripped from `/etc`),
+[ADR-0003](../adr/0003-runtime-etc-mutation-ban.md) (runtime `/etc` guard),
+[ADR-0004](../adr/0004-sysext-authoring-rules.md) (package relocation,
+factory-`/etc` capture),
+[ADR-0005](../adr/0005-profiles-as-transport-kernel-selectors.md)
+(`Dependencies=` reset, profile checks),
+[ADR-0006](../adr/0006-name-triggered-publication-guards.md) (publication
+guards), [ADR-0009](../adr/0009-snosi-env-var-classes.md) (test-hook
+gating), [ADR-0012](../adr/0012-chunked-layers-cadence-xattrs-chunk-before-seal.md)
+(chunkah xattrs).
+
 ## Script Execution Order
 
 Each image build runs four phases of scripts sequentially:

--- a/docs/design/ci-cd.md
+++ b/docs/design/ci-cd.md
@@ -1,5 +1,16 @@
 # CI/CD Pipeline
 
+Decision records shaping this document:
+[ADR-0003](../adr/0003-runtime-etc-mutation-ban.md) (runtime `/etc` guard),
+[ADR-0006](../adr/0006-name-triggered-publication-guards.md) (publication
+guards), [ADR-0008](../adr/0008-digest-first-release-latest-is-promotion.md)
+(digest-first publish, SBOM-gated predecessors),
+[ADR-0010](../adr/0010-credential-handoff-paths-not-bytes.md) (credential
+handoff), [ADR-0011](../adr/0011-mkosi-bootstrapped-and-pin-shared.md)
+(mkosi pin governance),
+[ADR-0012](../adr/0012-chunked-layers-cadence-xattrs-chunk-before-seal.md)
+(chunk-before-seal).
+
 ## Workflows
 
 ### build.yml — Sysext Build and Publish

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -1,5 +1,11 @@
 # snosi Overview
 
+Decision records shaping this document: [ADR-0001](../adr/0001-var-factory-state-outcome-maps.md)
+(`/var` outcome maps), [ADR-0005](../adr/0005-profiles-as-transport-kernel-selectors.md)
+(profile composition), [ADR-0009](../adr/0009-snosi-env-var-classes.md)
+(`SNOSI_*` variable classes), [ADR-0011](../adr/0011-mkosi-bootstrapped-and-pin-shared.md)
+(mkosi pin governance).
+
 ## Purpose
 
 snosi is a bootable container image build system that uses [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). It outputs OCI desktop/server images deployed via bootc/systemd-boot with atomic updates, plus EROFS sysext overlays distributed through systemd-sysupdate.

--- a/docs/design/sysexts.md
+++ b/docs/design/sysexts.md
@@ -1,5 +1,10 @@
 # System Extensions (Sysexts)
 
+Decision record shaping this document:
+[ADR-0004](../adr/0004-sysext-authoring-rules.md) (authoring rules:
+`/usr`-only payloads, `/opt` relocation, scoped factory-`/etc` capture,
+`Upholds=` activation, `required-paths.txt` manifests).
+
 ## Overview
 
 Sysexts are overlay images that extend the immutable base OS by adding files under `/usr`. They are distributed as EROFS images and managed by systemd-sysext at runtime and systemd-sysupdate for downloads.

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -1,5 +1,15 @@
 # Testing Framework
 
+Decision records shaping this document:
+[ADR-0001](../adr/0001-var-factory-state-outcome-maps.md) (`/var` inventory
+assertions), [ADR-0002](../adr/0002-ship-no-enablement-symlinks-in-etc.md)
+(first-boot preset parity),
+[ADR-0006](../adr/0006-name-triggered-publication-guards.md) (guard mutation
+fixtures), [ADR-0007](../adr/0007-frozen-contract-executable-allowlist.md)
+(executable contract),
+[ADR-0009](../adr/0009-snosi-env-var-classes.md) (test hooks and guard-root
+overrides).
+
 ## Overview
 
 The `test/` directory contains bootc lifecycle tests and the experimental native

--- a/docs/native-ab-contracts.md
+++ b/docs/native-ab-contracts.md
@@ -14,6 +14,11 @@ Known deviations between the current prototype and this contract are tracked,
 not silently tolerated, via `test/native-ab-contracts-allow.txt`. Every
 allowlist entry names the phase that removes it.
 
+The doc+test+allowlist governance mechanism itself is decided in
+[ADR-0007](adr/0007-frozen-contract-executable-allowlist.md); the
+name-triggered publication-guard rule (§1, §15) is decided in
+[ADR-0006](adr/0006-name-triggered-publication-guards.md).
+
 ## 1. Products, profiles, channels
 
 | Kind | Names |

--- a/docs/plans/2026-07-14-bootc-native-ab-coexistence-plan.md
+++ b/docs/plans/2026-07-14-bootc-native-ab-coexistence-plan.md
@@ -6,6 +6,9 @@
 native A/B variants of Cayo, Snow, and Snowfield, an R2 publication pipeline,
 and a network installer ISO.
 
+The mkosi pin governance this plan introduced is recorded as
+[ADR-0011](../adr/0011-mkosi-bootstrapped-and-pin-shared.md).
+
 ## Summary
 
 Snosi will support two deployment formats in parallel:


### PR DESCRIPTION
# Summary

Records the repository's load-bearing architecture decisions as repo-local ADRs — the final Phase 3 repo of frostyard/core `docs/plans/0001-docs-shape-rollout.md`. Twelve decisions, each verified against current code (guards, tests, workflows) before writing; each ADR names its implementing files, enforcing guards/tests, and the frostyard/core ADRs it builds on. Adds the ADR index to `docs/README.md` and bidirectional links from the design docs, `native-ab-contracts.md`, and the secure-bootc contract docs.

- **ADR-0001** — per-product `/var` factory-state outcome maps, audited fail-closed both directions (unclassified paths and stale globs; the 2026-08-12 man-db drift fired both)
- **ADR-0002** — ship zero unit-enablement symlinks in `/etc`; first-boot presets recreate them against a shipped `LC_ALL=C`-sorted manifest
- **ADR-0003** — runtime `/etc` mutation ban enforced by payload-directory scanning with the `# etc-guard-allow:` escape hatch
- **ADR-0004** — sysext authoring rules: `/usr`-only, `/opt` relocation, scoped factory-`/etc` capture, `Upholds=` activation, fail-closed `required-paths.txt`
- **ADR-0005** — profiles are transport+kernel selectors: `Dependencies=` reset idiom, shared composition fragments, load-bearing `Include=` order
- **ADR-0006** — name-triggered publication guards; textual reachability by design, not an `Include=` resolver
- **ADR-0007** — frozen contract doc + executable test + allowlist that fails closed both directions (now empty)
- **ADR-0008** — digest-first GHCR publish; `latest` is a promotion; predecessor resolution requires the SBOM referrer or skips
- **ADR-0009** — `SNOSI_*` variables in three classes; security-relevant test hooks paired/mutually gated
- **ADR-0010** — credentials cross the sudo boundary as mode-0600 file paths, never bytes; durable keys in `.snosi-private/`, year-stamped
- **ADR-0011** — mkosi bootstrapped pre-sudo from a repo-local checkout pinned to the workflow's action commit
- **ADR-0012** — chunked layers with changelog-derived update-cadence xattrs; secure images chunk before digest sealing, never after

This repo has required-review branch protection: the owner merges this PR.

## Type of change

- [x] Documentation only

## Validation

- [x] Relevant tests in `test/` were run

Commands run:

```
bash test/workflow-path-filter-test.sh      # PASS (docs-only path filter smoke check)
bash test/native-ab-contracts-test.sh       # PASS (pins docs/native-ab-contracts.md, edited here)
bash test/bootc-secure-docs-test.sh         # PASS (pins docs/bootc-secure-operations.md, edited here)
# plus a relative-link resolution check over all new/edited docs (all resolve)
```

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] Documentation updated (`CLAUDE.md`, `README.md`, `docs/`) where relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
