### PR TITLE
fix(worker): route the snosi-installer-latest alias to the redirect worker

### DIFF
--- a/workers/native-installer-redirect/wrangler.jsonc
+++ b/workers/native-installer-redirect/wrangler.jsonc
@@ -5,7 +5,7 @@
   "compatibility_date": "2026-07-17",
   "routes": [
     {
-      "pattern": "https://repository.frostyard.org/isos/native/v1/snosi-native-installer-latest-x86-64.iso*",
+      "pattern": "https://repository.frostyard.org/isos/native/v1/snosi-installer-latest-x86-64.iso*",
       "zone_name": "frostyard.org"
     }
   ],


### PR DESCRIPTION
The redirect worker's route pattern in `wrangler.jsonc` still matched the old `snosi-native-installer-latest` path, so the new firn alias never reached the worker and R2 returned a plain 404. The firn ISO **is published** (`snosi-installer_20260812052439` is in the index), but the stable `snosi-installer-latest` URL doesn't resolve. Point the route at the new alias; `STABLE_PATH`/regex already track it. Unblocks the stable download URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)