### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -1,4 +1,4 @@
-code=1.132.0-1785860022
+code=1.132.1-1786128105
 docker-ce=5:29.7.2-1~debian.13~trixie
 1password-cli=2.38.1-1
-claude-desktop=1.26832.0
+claude-desktop=1.28929.0

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -1,6 +1,6 @@
 {
-  "code": "1.132.0-1785860022",
+  "code": "1.132.1-1786128105",
   "docker-ce": "5:29.7.2-1~debian.13~trixie",
   "1password-cli": "2.38.1-1",
-  "claude-desktop": "1.26832.0"
+  "claude-desktop": "1.28929.0"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

code: 1.132.0-1785860022 -> 1.132.1-1786128105
claude-desktop: 1.26832.0 -> 1.28929.0


**Please verify the builds work before merging.**