### PR TITLE
fix(images): keep frostyard-igloo out of Snow

### DIFF
--- a/shared/packages/snow/mkosi.conf
+++ b/shared/packages/snow/mkosi.conf
@@ -6,6 +6,10 @@ BaseTrees=%O/base
 Packages=frostyard-chairlift
          snow-first-setup
 
+# Igloo is an Incus-container tool, not part of Snow. Keep it out even if a
+# selected Frostyard package later gains a dependency on it.
+RemovePackages=frostyard-igloo
+
 # Plymouth
 Packages=plymouth
          plymouth-themes

--- a/test/native-ab-static-test.sh
+++ b/test/native-ab-static-test.sh
@@ -324,6 +324,15 @@ done
 # ExtraTrees land), and a SkeletonTrees copy of the plymouthd.conf conffile
 # hard-fails the build (dpkg conffile prompt + non-interactive stdin = EOF).
 comp_snow="$root/shared/composition/snow/mkosi.conf"
+snow_packages="$root/shared/packages/snow/mkosi.conf"
+
+# frostyard-igloo is not an OS package. Its exclusion belongs in the shared
+# Snow package fragment so it covers both bootc and native A/B profiles.
+if grep -qE '^(Packages=|[[:space:]]+)frostyard-igloo([[:space:]]|$)' "$snow_packages"; then
+    echo "frostyard-igloo must not be selected by the Snow package fragment" >&2
+    exit 1
+fi
+grep -qx 'RemovePackages=frostyard-igloo' "$snow_packages"
 grep -q '^KernelCommandLine=splash plymouth\.ignore-serial-consoles quiet$' "$comp_snow"
 # The splash runs from the real root only: native initrds must omit the
 # plymouth dracut module (details-forcing/DRM-race with console=ttyS0 --


### PR DESCRIPTION
## Summary

- explicitly remove `frostyard-igloo` from the shared Snow package composition
- prevent a future transitive dependency from restoring it to Snow or Snowfield images
- add a static regression assertion covering both bootc and native A/B profiles

## Testing

- `./test/native-ab-static-test.sh`
- `git diff --check`