### PR TITLE
fix(firn-installer): ship sbsigntool (sbverify) for bootc Secure Boot

### DIFF
--- a/shared/firn-installer/mkosi.conf
+++ b/shared/firn-installer/mkosi.conf
@@ -96,11 +96,16 @@ Packages=libnss-myhostname/forky
 #   - mokutil: firn's A/B mok-stage step declares it (preflight contract);
 #     also used by the boot-chain proof itself (mokutil --sb-state inside
 #     the guest).
+#   - sbsigntool: provides sbverify, which firn's bootc esp-stage step
+#     declares (preflight contract) to verify the MOK-signed second stage
+#     and shim/MokManager signatures before staging them (firn ADR-0014,
+#     secure-install schema-1).
 Packages=shim-signed
          grub-efi-amd64-signed
          shim-helpers-amd64-signed
          linux-image-amd64
          mokutil
+         sbsigntool
 
 # Console/VT tooling: kbd provides chvt, which firn-kiosk.service uses to
 # bring tty1 to the foreground so the TUI renders on the visible VGA VT


### PR DESCRIPTION
firn v0.3.0's bootc `esp-stage` step declares `sbverify` (preflight contract) to verify the MOK-signed second stage and shim/MokManager signatures before staging them (secure-install schema-1, firn ADR-0014). The installer ISO shipped `mokutil` but not `sbsigntool`, so a bootc + Secure Boot install fails preflight:

```
Step preflight-tools: required tools not found on PATH: sbverify
```

Add `sbsigntool` to the firn-installer boot-chain package set. Confirmed against the lab bootc+SB cell on the v0.3.0 ISO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)