### PR TITLE
docs: establish profile and sysext contributor funnel

### DIFF
--- a/.github/ISSUE_TEMPLATE/profile_sysext_proposal.md
+++ b/.github/ISSUE_TEMPLATE/profile_sysext_proposal.md
@@ -1,0 +1,58 @@
+---
+name: Profile or sysext proposal
+about: Propose a supported image profile or system extension
+title: "[profile/sysext] "
+labels: "enhancement"
+assignees: ""
+---
+
+## Contribution type
+
+- [ ] Profile (a supported transport and kernel combination)
+- [ ] System extension (an optional `/usr` overlay)
+- [ ] Maintenance or deprecation of an existing profile or sysext
+
+## User need
+
+Who needs this, and what supported use case does it enable?
+
+## Proposed shape
+
+- Profile, product, or sysext name:
+- Closest existing example:
+- Upstream package/source and release channel:
+- Expected files and services:
+- Hardware or runtime requirements:
+
+For a profile, identify the existing shared composition, kernel, and transport
+fragments it will select. For a sysext, explain any `/opt` relocation, factory
+`/etc` defaults, service activation, or direct download.
+
+## Update and validation plan
+
+- How will upstream releases be detected and verified?
+- Which targeted build and fixture/static checks will prove the change?
+- Does validation require hardware, virtualization, credentials, or network
+  access not available in pull-request CI?
+
+## Stewardship
+
+- Maintenance contact (GitHub handle):
+- Expected response/update cadence:
+- Handoff plan if you can no longer maintain it:
+
+Maintainers retain final review, security-response, and removal authority.
+Stewardship is shared responsibility, not exclusive ownership.
+
+## Acceptance checklist
+
+- [ ] I read the
+  [profile and sysext contribution guide](https://github.com/frostyard/snosi/blob/main/docs/design/contributing-profiles-and-sysexts.md).
+- [ ] The contribution fits the supported profile or sysext shape.
+- [ ] Redistribution, licensing, and update sources are identified.
+- [ ] The proposal has a named maintenance contact and handoff plan.
+- [ ] No credentials, private keys, or vulnerability details are included.
+
+Report security vulnerabilities privately through the
+[security policy](https://github.com/frostyard/snosi/security/policy), not in
+this issue.


### PR DESCRIPTION
## Summary

- add an end-to-end profile and sysext contribution tutorial with supported skeletons and acceptance checks
- add proposal, stewardship, handoff, and removal expectations to contributor-facing templates and guidance
- define an on-demand quarterly external-contributor and active-sysext metric
- seed four ADR-backed `good first issue` / `help wanted` tasks: #715, #716, #717, and #718

## Validation

- `git diff --check`
- local Markdown link validation for all changed contributor documents
- `./test/bootc-secure-docs-test.sh`
- executed the documented GraphQL/`jq` quarterly metric query against `frostyard/snosi`

Closes #713
