### PR TITLE
chore: readme iso link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ A bootable container image build system using [mkosi](https://github.com/systemd
 
 ## Downloads
 
-- [Bootc live installation media](https://repository.frostyard.org/isos/snow-live-latest.iso)
 - [Firn installer — all image families, bootc and A/B (latest x86-64)](https://repository.frostyard.org/isos/native/v1/snosi-installer-latest-x86-64.iso)
 - [Installer checksums](https://repository.frostyard.org/isos/native/v1/SHA256SUMS) and [OpenPGP signature](https://repository.frostyard.org/isos/native/v1/SHA256SUMS.gpg)
-
+- Older bootc installer: [Bootc live installation media](https://repository.frostyard.org/isos/snow-live-latest.iso)
 See the [supported installation guide](docs/installing.md) to choose an image,
 verify the native installer, create boot media, install safely, and recover or
 update the installed system.


### PR DESCRIPTION
Removed duplicate link for Bootc live installation media.

# Summary

<!-- What does this change do, and why? Link the issue it closes. -->

Closes #

## Type of change

- [ ] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [ ] Sysext change
- [ ] Build pipeline / CI change
- [ ] Documentation only
- [ ] Other:

## Validation

<!-- List the commands you actually ran and their outcome. -->

- [ ] `shellcheck` / `validate.yml` static checks pass for touched scripts
- [ ] Relevant `just` build target(s) succeed
- [ ] Relevant tests in `test/` were run

Commands run:

```
```

## Checklist

- [ ] Changes are as small and focused as possible
- [ ] No secrets, keys, or credentials are committed
- [ ] New external downloads are pinned and go through `verified_download()`
- [ ] Documentation updated (`CLAUDE.md`, `README.md`, `docs/`) where relevant
