### PR TITLE
test(sysext): enforce authoring inventory

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -204,6 +204,12 @@ jobs:
         # systemd vendor-keyring names carry the canonical combined trust ring.
         run: ./test/sysext-signature-verification-test.sh
 
+      - name: Validate sysext authoring inventory
+        # Discover every tracked Overlay=yes image and reject missing manifests,
+        # package identity, finalizers, update metadata, or orphan metadata.
+        # Fixture-only and repository-static: no root, network, or image build.
+        run: ./test/sysext-authoring-contract-test.sh
+
       - name: Validate sysext required paths finalizer
         # Fixture regression test for whitespace-preserving parsing of sysext
         # required-paths.txt entries. No root, network, or image build.

--- a/docs/design/sysexts.md
+++ b/docs/design/sysexts.md
@@ -476,4 +476,14 @@ succeeds the moment the cache is stale or absent.
 9. Add the sysext name to root `mkosi.conf` Dependencies list
 10. Add a corresponding update check to `.github/workflows/check-dependencies.yml` if it has external downloads
 
+`test/sysext-authoring-contract-test.sh`, run by `validate.yml`, derives the
+repository inventory from tracked `mkosi.images/*/mkosi.conf` files containing
+`Overlay=yes`; do not add a separate component list. It fails closed unless
+every discovered sysext has a nonempty tracked `required-paths.txt`, exactly one
+nonempty `KEYPACKAGE`, both shared finalizers, and one same-named
+component-scoped `.transfer`/`.feature` pair whose transfer selects the
+component and sets `Verify=true`. It also rejects component-scoped sysupdate
+metadata that has no matching tracked sysext config. The test uses synthetic
+git fixtures and does not build images.
+
 For runtime setup scripts and units shipped inside `mkosi.extra/`, do not call `systemctl enable`, `systemctl disable`, `systemctl preset`, or remove shipped paths under `/etc` from the running guest. These mutate the live `/etc` overlay and can break bootc's `/etc` merge when a staged deployment finalizes. Express service state through presets/drop-ins at build time, and use `/var` marker files for run-once behavior.

--- a/test/sysext-authoring-contract-test.sh
+++ b/test/sysext-authoring-contract-test.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Repository-wide structural contract for tracked mkosi sysext definitions.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+validation_failures=0
+test_failures=0
+
+validation_error() {
+    echo "FAIL: $*" >&2
+    validation_failures=$((validation_failures + 1))
+}
+
+validate_inventory() {
+    local root=$1
+    local config config_path name required_paths metadata_dir
+    local expected_transfer expected_feature file remainder component
+    local -a configs key_packages transfers features metadata_files
+    local -A components=() orphan_reported=()
+
+    validation_failures=0
+    mapfile -t configs < <(
+        git -C "$root" ls-files -- 'mkosi.images/*/mkosi.conf' |
+            while IFS= read -r config; do
+                grep -Eq '^[[:space:]]*Overlay[[:space:]]*=[[:space:]]*yes[[:space:]]*$' \
+                    "$root/$config" && printf '%s\n' "$config"
+            done
+    )
+
+    if ((${#configs[@]} == 0)); then
+        validation_error "no tracked Overlay=yes sysext configs found"
+    fi
+
+    for config in "${configs[@]}"; do
+        name=${config#mkosi.images/}
+        name=${name%/mkosi.conf}
+        config_path="$root/$config"
+        components["$name"]=1
+
+        required_paths="mkosi.images/$name/required-paths.txt"
+        if ! git -C "$root" ls-files --error-unmatch -- "$required_paths" >/dev/null 2>&1; then
+            validation_error "$name: missing tracked required-paths.txt"
+        elif ! awk '!/^[[:space:]]*(#|$)/ { found=1 } END { exit !found }' \
+            "$root/$required_paths"; then
+            validation_error "$name: required-paths.txt has no path entries"
+        fi
+
+        mapfile -t key_packages < <(
+            grep -E '^[[:space:]]*Environment=' "$config_path" |
+                grep -Eo 'KEYPACKAGE=[^[:space:],]+' || true
+        )
+        if ((${#key_packages[@]} != 1)) || [[ ${key_packages[0]:-} == "KEYPACKAGE=" ]]; then
+            validation_error "$name: mkosi.conf must define exactly one nonempty KEYPACKAGE"
+        fi
+
+        for file in \
+            '%D/shared/sysext/finalize/sysext-required-paths.sh' \
+            '%D/shared/sysext/finalize/sysext-strip-icon-cache.sh'; do
+            grep -E '^[[:space:]]*FinalizeScripts=' "$config_path" |
+                grep -Fq "$file" ||
+                validation_error "$name: mkosi.conf is missing finalizer $file"
+        done
+
+        metadata_dir="mkosi.images/base/mkosi.extra/usr/lib/sysupdate.$name.d"
+        expected_transfer="$metadata_dir/$name.transfer"
+        expected_feature="$metadata_dir/$name.feature"
+        mapfile -t transfers < <(git -C "$root" ls-files -- "$metadata_dir/*.transfer")
+        mapfile -t features < <(git -C "$root" ls-files -- "$metadata_dir/*.feature")
+
+        if ((${#transfers[@]} != 1)) || [[ ${transfers[0]:-} != "$expected_transfer" ]]; then
+            validation_error "$name: expected exactly one matching $expected_transfer"
+        else
+            grep -qx "Features=$name" "$root/$expected_transfer" ||
+                validation_error "$name: transfer must select Features=$name"
+            grep -qx 'Verify=true' "$root/$expected_transfer" ||
+                validation_error "$name: transfer must set Verify=true"
+        fi
+
+        if ((${#features[@]} != 1)) || [[ ${features[0]:-} != "$expected_feature" ]]; then
+            validation_error "$name: expected exactly one matching $expected_feature"
+        fi
+    done
+
+    mapfile -t metadata_files < <(
+        git -C "$root" ls-files -- \
+            'mkosi.images/base/mkosi.extra/usr/lib/sysupdate.*.d/*'
+    )
+    for file in "${metadata_files[@]}"; do
+        remainder=${file#mkosi.images/base/mkosi.extra/usr/lib/sysupdate.}
+        component=${remainder%%.d/*}
+        if [[ -z ${components["$component"]+x} && -z ${orphan_reported["$component"]+x} ]]; then
+            validation_error "$component: orphan component-scoped sysext metadata"
+            orphan_reported["$component"]=1
+        fi
+    done
+
+    if ((validation_failures > 0)); then
+        return 1
+    fi
+
+    echo "ok - ${#configs[@]} tracked sysext authoring contracts"
+}
+
+write_valid_fixture() {
+    local root=$1
+    local metadata_dir="$root/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.fixture.d"
+
+    mkdir -p "$root/mkosi.images/fixture" "$metadata_dir"
+    cat >"$root/mkosi.images/fixture/mkosi.conf" <<'EOF'
+[Output]
+Overlay=yes
+
+[Content]
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+
+[Build]
+Environment=KEYPACKAGE=fixture-package
+EOF
+    printf '/usr/bin/fixture\n' >"$root/mkosi.images/fixture/required-paths.txt"
+    cat >"$metadata_dir/fixture.transfer" <<'EOF'
+[Transfer]
+Features=fixture
+Verify=true
+EOF
+    cat >"$metadata_dir/fixture.feature" <<'EOF'
+[Feature]
+Description=Fixture sysext
+Enabled=false
+EOF
+
+    git -C "$root" init -q
+    git -C "$root" add .
+}
+
+fixture_pass() {
+    echo "PASS: $*"
+}
+
+fixture_fail() {
+    echo "FAIL: $*" >&2
+    test_failures=$((test_failures + 1))
+}
+
+run_negative_fixture() {
+    local case_name=$1
+    local expected=$2
+    local root="$work_dir/$case_name"
+    local metadata_dir="$root/mkosi.images/base/mkosi.extra/usr/lib"
+    local output
+
+    write_valid_fixture "$root"
+    case "$case_name" in
+        missing-required-paths)
+            rm "$root/mkosi.images/fixture/required-paths.txt"
+            git -C "$root" add -A
+            ;;
+        empty-required-paths)
+            : >"$root/mkosi.images/fixture/required-paths.txt"
+            git -C "$root" add mkosi.images/fixture/required-paths.txt
+            ;;
+        missing-keypackage)
+            sed -i '/KEYPACKAGE=/d' "$root/mkosi.images/fixture/mkosi.conf"
+            git -C "$root" add mkosi.images/fixture/mkosi.conf
+            ;;
+        missing-finalizer)
+            sed -i 's#,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh##' \
+                "$root/mkosi.images/fixture/mkosi.conf"
+            git -C "$root" add mkosi.images/fixture/mkosi.conf
+            ;;
+        mismatched-feature)
+            sed -i 's/Features=fixture/Features=other/' \
+                "$metadata_dir/sysupdate.fixture.d/fixture.transfer"
+            git -C "$root" add "$metadata_dir/sysupdate.fixture.d/fixture.transfer"
+            ;;
+        unsigned-transfer)
+            sed -i 's/Verify=true/Verify=false/' \
+                "$metadata_dir/sysupdate.fixture.d/fixture.transfer"
+            git -C "$root" add "$metadata_dir/sysupdate.fixture.d/fixture.transfer"
+            ;;
+        orphan-metadata)
+            mkdir -p "$metadata_dir/sysupdate.orphan.d"
+            printf '[Feature]\nDescription=Orphan\n' \
+                >"$metadata_dir/sysupdate.orphan.d/orphan.feature"
+            git -C "$root" add "$metadata_dir/sysupdate.orphan.d/orphan.feature"
+            ;;
+        *)
+            fixture_fail "unknown fixture case $case_name"
+            return
+            ;;
+    esac
+
+    if output=$(validate_inventory "$root" 2>&1); then
+        fixture_fail "$case_name was accepted"
+    elif [[ $output == *"$expected"* ]]; then
+        fixture_pass "$case_name is rejected"
+    else
+        fixture_fail "$case_name produced the wrong diagnostic: $output"
+    fi
+}
+
+if [[ ${1:-} == --validate ]]; then
+    [[ $# -eq 2 ]] || {
+        echo "Usage: $0 --validate <repository-root>" >&2
+        exit 2
+    }
+    validate_inventory "$2"
+    exit
+elif (($# != 0)); then
+    echo "Usage: $0 [--validate <repository-root>]" >&2
+    exit 2
+fi
+
+valid_fixture="$work_dir/valid"
+write_valid_fixture "$valid_fixture"
+if output=$(validate_inventory "$valid_fixture" 2>&1); then
+    fixture_pass "valid component is accepted"
+else
+    fixture_fail "valid component was rejected: $output"
+fi
+
+run_negative_fixture missing-required-paths "missing tracked required-paths.txt"
+run_negative_fixture empty-required-paths "required-paths.txt has no path entries"
+run_negative_fixture missing-keypackage "exactly one nonempty KEYPACKAGE"
+run_negative_fixture missing-finalizer "sysext-strip-icon-cache.sh"
+run_negative_fixture mismatched-feature "transfer must select Features=fixture"
+run_negative_fixture unsigned-transfer "transfer must set Verify=true"
+run_negative_fixture orphan-metadata "orphan component-scoped sysext metadata"
+
+if ! validate_inventory "$repo_root"; then
+    test_failures=$((test_failures + 1))
+fi
+
+if ((test_failures > 0)); then
+    exit 1
+fi
+
+echo "sysext-authoring-contract-test: PASSED"


### PR DESCRIPTION
# Summary

Adds a fail-closed repository inventory test derived from tracked `Overlay=yes` mkosi configs. It requires each sysext to carry a nonempty required-path manifest, one `KEYPACKAGE`, both shared finalizers, and a same-named signed component metadata pair; it also rejects orphan metadata. Synthetic git fixtures cover the valid shape and representative missing/mismatched fields.

Closes #717

## Type of change

- [ ] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [x] Sysext change
- [x] Build pipeline / CI change
- [ ] Documentation only
- [ ] Other

## Validation

- [x] `shellcheck` / `validate.yml` static checks pass for touched scripts
- [x] Relevant tests in `test/` were run
- [x] No image build required: this is a tracked-configuration and fixture-only test

Commands run:

```
./test/sysext-authoring-contract-test.sh
./test/sysext-required-paths-test.sh
./test/sysext-signature-verification-test.sh
./test/workflow-path-filter-test.sh
shellcheck -S warning -x test/sysext-authoring-contract-test.sh
actionlint .github/workflows/validate.yml
```

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] No external downloads were added
- [x] Documentation updated in `docs/design/sysexts.md`