### PR TITLE
test(profile): discover dependency contracts

### DIFF
--- a/check-profile-dependencies.sh
+++ b/check-profile-dependencies.sh
@@ -8,47 +8,113 @@ if [[ -x .mkosi/bin/mkosi ]]; then
     mkosi=.mkosi/bin/mkosi
 fi
 
-profiles=(cayo snow snowfield)
-sysexts=(
-    1password
-    1password-cli
-    azurevpn
-    bitwarden
-    claude-desktop
-    code-server
-    coder
-    debdev
-    dev
-    docker
-    edge
-    github-copilot
-    incus
-    k3s
-    lemonade
-    nix
-    paseo
-    pilothouse
-    podman
-    sunshine
-    tailscale
-    vscode
+read_root_dependencies() {
+    awk '
+        function emit(line, fields, count, i) {
+            sub(/#.*/, "", line)
+            gsub(/,/, " ", line)
+            count = split(line, fields, /[[:space:]]+/)
+            for (i = 1; i <= count; i++)
+                if (fields[i] != "")
+                    print fields[i]
+        }
+        /^\[Config\][[:space:]]*$/ {
+            in_config = 1
+            next
+        }
+        /^\[/ {
+            if (in_config)
+                exit
+        }
+        in_config && /^[[:space:]]*Dependencies=/ {
+            line = $0
+            sub(/^[[:space:]]*Dependencies=[[:space:]]*/, "", line)
+            emit(line)
+            collecting = 1
+            next
+        }
+        in_config && collecting && /^[[:space:]]+/ {
+            emit($0)
+            next
+        }
+        in_config && collecting {
+            collecting = 0
+        }
+    ' mkosi.conf
+}
+
+mapfile -t profile_configs < <(git ls-files -- 'mkosi.profiles/*/mkosi.conf' | sort)
+((${#profile_configs[@]} > 0)) || {
+    echo "No tracked profiles found." >&2
+    exit 1
+}
+
+mapfile -t root_dependencies < <(read_root_dependencies)
+declare -A sysexts=()
+base_count=0
+for dependency in "${root_dependencies[@]}"; do
+    if [[ $dependency == base ]]; then
+        base_count=$((base_count + 1))
+    else
+        sysexts["$dependency"]=1
+    fi
+done
+
+((base_count == 1)) || {
+    echo "Root mkosi.conf must list base exactly once in Dependencies=." >&2
+    exit 1
+}
+((${#sysexts[@]} > 0)) || {
+    echo "Root mkosi.conf has no sysext dependencies to guard." >&2
+    exit 1
+}
+
+installer_profiles=(
+    firn-installer
+    native-installer
 )
 
 failed=0
 
-for profile in "${profiles[@]}"; do
-    summary=$("$mkosi" -f --profile "$profile" summary)
+for profile_config in "${profile_configs[@]}"; do
+    profile=${profile_config#mkosi.profiles/}
+    profile=${profile%/mkosi.conf}
 
-    for sysext in "${sysexts[@]}"; do
-        if grep -q "^IMAGE: ${sysext}$" <<<"$summary"; then
-            echo "Profile ${profile} unexpectedly includes sysext dependency ${sysext}." >&2
+    if ! summary=$("$mkosi" -f --profile "$profile" summary); then
+        echo "Failed to resolve profile ${profile}." >&2
+        failed=1
+        continue
+    fi
+    mapfile -t image_dependencies < <(sed -n 's/^IMAGE: //p' <<<"$summary")
+
+    for dependency in "${image_dependencies[@]}"; do
+        if [[ -n ${sysexts["$dependency"]+x} ]]; then
+            echo "Profile ${profile} unexpectedly includes sysext dependency ${dependency}." >&2
             failed=1
         fi
     done
+
+    is_installer=0
+    for installer_profile in "${installer_profiles[@]}"; do
+        if [[ $profile == "$installer_profile" ]]; then
+            is_installer=1
+            break
+        fi
+    done
+
+    if ((is_installer)); then
+        if ((${#image_dependencies[@]} != 0)); then
+            echo "Installer profile ${profile} must have no image dependencies." >&2
+            failed=1
+        fi
+    elif ((${#image_dependencies[@]} != 1)) || [[ ${image_dependencies[0]:-} != base ]]; then
+        echo "Product profile ${profile} must depend only on base." >&2
+        failed=1
+    fi
 done
 
 if (( failed )); then
     exit 1
 fi
 
-echo "Profile builds depend only on base."
+echo "Checked ${#profile_configs[@]} profiles against ${#sysexts[@]} sysext dependencies."

--- a/docs/adr/0005-profiles-as-transport-kernel-selectors.md
+++ b/docs/adr/0005-profiles-as-transport-kernel-selectors.md
@@ -79,7 +79,8 @@ and greps for any forbidden `IMAGE: <sysext>` line.
 ## References
 
 - Shapes: [design/overview.md](../design/overview.md) (Configuration
-  Composition), [design/build-pipeline.md](../design/build-pipeline.md)
+  Composition), current enforcement in
+  [design/build-pipeline.md](../design/build-pipeline.md#check-profile-dependenciessh)
 - Implemented by: `mkosi.conf`, `mkosi.profiles/*/mkosi.conf`,
   `shared/composition/*/mkosi.conf`
 - Guarded by: `check-profile-dependencies.sh`

--- a/docs/design/build-pipeline.md
+++ b/docs/design/build-pipeline.md
@@ -368,7 +368,15 @@ Run after the image directory/file is created. Handle manifest processing and pa
 
 After `mkosi build` completes, the output directory contains all images, sysexts, and manifests flat in `output/`. Two root scripts organize them for publishing:
 
-Root `mkosi.conf` intentionally lists `base` plus all sysexts in `Dependencies=` so plain `mkosi build` and `just sysexts` produce the sysext publishing set. Profile configs clear that inherited collection with an empty `Dependencies=` assignment and then add `Dependencies=base`; without the reset, mkosi appends list settings and profile builds would rebuild every sysext. CI enforces this with `check-profile-dependencies.sh`.
+Root `mkosi.conf` intentionally lists `base` plus all sysexts in
+`Dependencies=` so plain `mkosi build` and `just sysexts` produce the sysext
+publishing set. Product profile configs clear that inherited collection with
+an empty `Dependencies=` assignment and then add `Dependencies=base`; without
+the reset, mkosi appends list settings and profile builds would rebuild every
+sysext. The dedicated `native-installer` and `firn-installer` profiles instead
+leave `Dependencies=` empty and also reset `BaseTrees=` because their rootfs
+must inherit neither the product base nor the sysext build set. CI enforces
+both outcomes with `check-profile-dependencies.sh`.
 
 Root `mkosi.conf` also configures mkosi's build tooling bootstrap with `ToolsTree=default` and `ToolsTreeSandboxTrees=mkosi.tools.sandbox`. Keep package-manager settings for that tools tree in `mkosi.tools.sandbox/`; the regular `mkosi.sandbox/` tree only affects target-image APT operations. Network hardening that should protect both surfaces, such as APT retries/timeouts, needs matching files in both trees.
 
@@ -386,7 +394,16 @@ Pre-build validation script (run in CI before `mkosi build`). Checks for duplica
 
 ### check-profile-dependencies.sh
 
-Config sanity check used by `validate.yml`. It runs `mkosi -f --profile <profile> summary` for every profile and fails if any profile summary includes one of the sysext image dependencies from root `mkosi.conf`. This protects the required `Dependencies=` reset pattern in profile configs.
+Config sanity check used by `validate.yml`. It discovers every tracked
+`mkosi.profiles/*/mkosi.conf` and derives the forbidden sysext inventory from
+the root `mkosi.conf` `Dependencies=` collection. It runs
+`mkosi -f --profile <profile> summary` for each profile: product profiles must
+resolve to exactly the `base` image dependency, while the dedicated
+`native-installer` and `firn-installer` profiles must resolve to no image
+dependencies. Every profile is also checked for accidental inheritance of any
+root sysext. `test/check-profile-dependencies-local-mkosi-test.sh` covers
+dynamic profile/sysext discovery, both contracts, and repository-local mkosi
+precedence without building an image.
 
 ### check-runtime-etc-guard.sh
 

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -1093,7 +1093,16 @@ Justfile                    # Build targets (just sysexts, just snow, etc.)
 
 mkosi configs compose via `Include=` directives. Each profile pulls in reusable fragments:
 
-Root `mkosi.conf` lists `base` plus all in-repo sysexts for the sysext publishing build. It also sets `ToolsTree=default` and `ToolsTreeSandboxTrees=mkosi.tools.sandbox`; files needed by the tools-tree package manager must go in `mkosi.tools.sandbox/`, while `mkosi.sandbox/` applies to the target image package manager. Both sandbox trees currently carry the same APT retry/timeout hardening. Each `mkosi.profiles/*/mkosi.conf` starts with `Dependencies=` and then `Dependencies=base` to reset mkosi's append-only collection semantics; profile image builds must not inherit the sysext list.
+Root `mkosi.conf` lists `base` plus all in-repo sysexts for the sysext
+publishing build. It also sets `ToolsTree=default` and
+`ToolsTreeSandboxTrees=mkosi.tools.sandbox`; files needed by the tools-tree
+package manager must go in `mkosi.tools.sandbox/`, while `mkosi.sandbox/`
+applies to the target image package manager. Both sandbox trees currently
+carry the same APT retry/timeout hardening. Product profile configs start with
+`Dependencies=` and then `Dependencies=base` to reset mkosi's append-only
+collection semantics. The dedicated `native-installer` and `firn-installer`
+profiles reset both `Dependencies=` and `BaseTrees=` to empty. No profile may
+inherit the root sysext list.
 
 ```
 Profile (e.g., snow/mkosi.conf)                     # transport+kernel selector only

--- a/test/check-profile-dependencies-local-mkosi-test.sh
+++ b/test/check-profile-dependencies-local-mkosi-test.sh
@@ -6,12 +6,53 @@ scratch=$(mktemp -d "${TMPDIR:-/tmp}/check-profile-dependencies-test.XXXXXX")
 trap 'rm -rf "$scratch"' EXIT
 
 cp "$repo_root/check-profile-dependencies.sh" "$scratch/"
-mkdir -p "$scratch/.mkosi/bin" "$scratch/path"
+mkdir -p \
+    "$scratch/.mkosi/bin" \
+    "$scratch/path" \
+    "$scratch/mkosi.profiles/cayo-ab" \
+    "$scratch/mkosi.profiles/firn-installer" \
+    "$scratch/mkosi.profiles/future-product" \
+    "$scratch/mkosi.profiles/native-installer"
+
+cat >"$scratch/mkosi.conf" <<'EOF'
+[Config]
+Dependencies=base
+             fixture-sysext
+
+[Output]
+Format=none
+EOF
+
+for profile in cayo-ab firn-installer future-product native-installer; do
+    printf '[Config]\n' >"$scratch/mkosi.profiles/$profile/mkosi.conf"
+done
 
 cat >"$scratch/.mkosi/bin/mkosi" <<'EOF'
 #!/bin/bash
-if [[ "$*" == *"summary"* ]]; then
+set -euo pipefail
+
+profile=
+while (($# > 0)); do
+    if [[ $1 == --profile ]]; then
+        profile=$2
+        shift 2
+    else
+        shift
+    fi
+done
+
+[[ -n $profile ]] || {
+    echo "missing --profile" >&2
+    exit 1
+}
+printf '%s\n' "$profile" >>"$MKOSI_CALL_LOG"
+
+if [[ $profile != firn-installer && $profile != native-installer &&
+    $profile != "${MKOSI_EMPTY_PROFILE:-}" ]]; then
     printf 'IMAGE: base\n'
+fi
+if [[ $profile == "${MKOSI_EXTRA_PROFILE:-}" ]]; then
+    printf 'IMAGE: %s\n' "$MKOSI_EXTRA_DEPENDENCY"
 fi
 EOF
 chmod +x "$scratch/.mkosi/bin/mkosi"
@@ -23,7 +64,85 @@ exit 1
 EOF
 chmod +x "$scratch/path/mkosi"
 
-PATH="$scratch/path:$PATH" "$scratch/check-profile-dependencies.sh" \
-    | grep -qx 'Profile builds depend only on base.'
+git -C "$scratch" init -q
+git -C "$scratch" add mkosi.conf mkosi.profiles
+
+call_log="$scratch/mkosi-calls"
+run_guard() {
+    (
+        cd "$scratch"
+        PATH="$scratch/path:$PATH" MKOSI_CALL_LOG="$call_log" \
+            ./check-profile-dependencies.sh
+    )
+}
+
+expect_failure() {
+    local description=$1
+    local expected=$2
+    local output
+    shift 2
+
+    if output=$("$@" 2>&1); then
+        echo "FAIL: $description was accepted" >&2
+        exit 1
+    elif [[ $output != *"$expected"* ]]; then
+        echo "FAIL: $description produced the wrong diagnostic: $output" >&2
+        exit 1
+    fi
+    echo "PASS: $description"
+}
+
+run_with_new_sysext() {
+    MKOSI_EXTRA_PROFILE=future-product \
+        MKOSI_EXTRA_DEPENDENCY=newly-listed-sysext \
+        run_guard
+}
+
+run_without_product_base() {
+    MKOSI_EMPTY_PROFILE=cayo-ab run_guard
+}
+
+run_with_installer_sysext() {
+    MKOSI_EXTRA_PROFILE=native-installer \
+        MKOSI_EXTRA_DEPENDENCY=fixture-sysext \
+        run_guard
+}
+
+run_with_installer_base() {
+    MKOSI_EXTRA_PROFILE=firn-installer \
+        MKOSI_EXTRA_DEPENDENCY=base \
+        run_guard
+}
+
+: >"$call_log"
+run_guard | grep -qx 'Checked 4 profiles against 1 sysext dependencies.'
+for profile in cayo-ab firn-installer future-product native-installer; do
+    grep -qx "$profile" "$call_log" || {
+        echo "FAIL: tracked profile $profile was not evaluated" >&2
+        exit 1
+    }
+done
+echo "PASS: tracked product and installer profiles use repository-local mkosi"
+
+sed -i '/fixture-sysext/a\             newly-listed-sysext' "$scratch/mkosi.conf"
+expect_failure \
+    "new root sysext dependency is rejected without changing the guard" \
+    "unexpectedly includes sysext dependency newly-listed-sysext" \
+    run_with_new_sysext
+
+expect_failure \
+    "native product profile without base is rejected" \
+    "Product profile cayo-ab must depend only on base." \
+    run_without_product_base
+
+expect_failure \
+    "dedicated installer profile rejects inherited sysexts" \
+    "Profile native-installer unexpectedly includes sysext dependency fixture-sysext." \
+    run_with_installer_sysext
+
+expect_failure \
+    "dedicated installer profile remains dependency-free" \
+    "Installer profile firn-installer must have no image dependencies." \
+    run_with_installer_base
 
 printf 'check-profile-dependencies-local-mkosi-test: PASSED\n'


### PR DESCRIPTION
# Summary

Makes `check-profile-dependencies.sh` discover every tracked profile and derive forbidden sysext dependencies from root `mkosi.conf`. Resolved product profiles must depend only on `base`; `native-installer` and `firn-installer` must remain dependency-free. The expanded local-mkosi fixture proves dynamic profile/sysext discovery, native product coverage, installer coverage, and local checkout precedence.

Closes #716

## Type of change

- [ ] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [ ] Sysext change
- [x] Build pipeline / CI change
- [ ] Documentation only
- [x] Other: dependency guard and fixture coverage

## Validation

- [x] `shellcheck` static checks pass for touched scripts
- [x] Relevant tests in `test/` were run
- [x] No image build required: fixtures exercise resolved summary contracts through a repository-local mkosi stub

Commands run:

```
./test/check-profile-dependencies-local-mkosi-test.sh
./test/native-ab-static-test.sh
./test/workflow-path-filter-test.sh
shellcheck -S warning -x check-profile-dependencies.sh test/check-profile-dependencies-local-mkosi-test.sh
```

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] No external downloads were added
- [x] ADR-0005 links to the current enforcement documentation
- [x] Contributor-facing profile composition documentation is updated