### PR TITLE
fix: bump secure bootc contract to 1.16.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ dracut or the Forky systemd family changes.
 
 **Bootc UKI assembly (Task 5, 2026-07-28):**
 `shared/bootc-secure/assemble-uki.sh` and the secure branch of
-`shared/outformat/image/buildah-package.sh` formalize the observed bootc 1.16.7
+`shared/outformat/image/buildah-package.sh` formalize the observed bootc 1.16.8
 hidden storage-digest plus direct two-pass ukify behavior as a maintained,
 fail-closed compatibility contract. This is NOT upstream-stable. Secure builds
 must set `SNOSI_BOOTC_SECURE=1` and caller-owned MOK/PCR credentials; Buildah
@@ -123,7 +123,7 @@ Every storage-digest probe runs through the ONE shared helper
 sourced by `buildah-package.sh`, `assemble-uki.sh`, and
 `test/bootc-secure-spike-test.sh`); never re-inline the `podman run` shape. The
 helper binds a host scratch dir over the container's `/var/tmp` because bootc
-1.16.7 hardcodes its temp composefs repo there (`TMPDIR` ignored) and composefs
+1.16.8 hardcodes its temp composefs repo there (`TMPDIR` ignored) and composefs
 object writes use `O_TMPFILE`, which fuse-overlayfs lacks — GitHub runner image
 ubuntu24/20260810.271 (podman 5.8.4) forces `mount_program = fuse-overlayfs`,
 which broke every secure "Package image" step with `os error 95` (root-caused

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ already-mounted read-only ESP. The real cayo proof validates immutable-source
 assembly only; FAT-ESP reconciler execution is deferred to Task 9 secure-install
 runtime coverage. Secure and insecure images carry explicit
 `io.snosi.bootc.secureboot-capable=true|false` labels. This is a maintained,
-fail-closed compatibility contract for Frostyard bootc 1.16.7, including its
+fail-closed compatibility contract for Frostyard bootc 1.16.8, including its
 hidden storage-digest command and direct two-pass ukify behavior, not an
 upstream-stable API. See `docs/bootc-secure-assembly-compatibility.md`.
 The protected packager checks its pinned bootc through the built rootfs with a

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -369,7 +369,7 @@ if [[ ! -f $verifier ]]; then
 else
     verifier_text=$(<"$verifier")
     require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-capable"] == "true" and'
-    require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.7-storage-digest-v1"'
+    require_text "$verifier" "$verifier_text" '    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.8-storage-digest-v1"'
     # shellcheck disable=SC1003,SC2016 # Match the literal verifier shell source.
     require_text "$verifier" "$verifier_text" \
         'inspection=$(skopeo inspect --authfile "$AUTH_FILE" \'

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ when next rewritten.
 - [native-ab-contracts.md](native-ab-contracts.md) — **frozen normative source of truth** for native A/B naming, paths, and policy (spec-natured; candidate for `specs/`)
 - [integration-contracts.md](integration-contracts.md) — cross-tool producer→consumer contract map with fragility ratings
 - [bootc-secure-install-contract.md](bootc-secure-install-contract.md) — contract between secure OCI images and the external installer repos
-- [bootc-secure-assembly-compatibility.md](bootc-secure-assembly-compatibility.md) — assemble-uki.sh compatibility contract with bootc 1.16.7
+- [bootc-secure-assembly-compatibility.md](bootc-secure-assembly-compatibility.md) — assemble-uki.sh compatibility contract with bootc 1.16.8
 - [bootc-secure-operations.md](bootc-secure-operations.md) — normative secure-bootc operations runbook (pinned by `test/bootc-secure-docs-test.sh`)
 - [native-ab-publication.md](native-ab-publication.md) — native A/B production publication runbook
 - [native-ab-capacities.md](native-ab-capacities.md) — measurements behind per-product channel partition sizes

--- a/docs/bootc-secure-assembly-compatibility.md
+++ b/docs/bootc-secure-assembly-compatibility.md
@@ -1,7 +1,7 @@
 # Bootc Secure Assembly Compatibility Contract
 
 `shared/bootc-secure/assemble-uki.sh` is a maintained compatibility adapter
-for the Frostyard `bootc` package at upstream version `1.16.7`. It is not an
+for the Frostyard `bootc` package at upstream version `1.16.8`. It is not an
 upstream-stable bootc interface.
 
 The chunk-before-seal ordering this contract pins is decided in
@@ -54,7 +54,7 @@ through the single shared helper `shared/bootc-secure/storage-digest-probe.sh`
 (`snosi_storage_composefs_digest`, sourced by `buildah-package.sh`,
 `assemble-uki.sh`, and `test/bootc-secure-spike-test.sh` — never re-inline the
 `podman run` shape). The helper binds a host-filesystem scratch directory over
-the container's `/var/tmp`: bootc 1.16.7 hardcodes its temporary composefs
+the container's `/var/tmp`: bootc 1.16.8 hardcodes its temporary composefs
 repository at `/var/tmp` inside the container (`TMPDIR` is ignored) and
 composefs object writes use `O_TMPFILE`, which fuse-overlayfs does not support
 — GitHub runner image ubuntu24/20260810.271 (podman 5.8.4) forces

--- a/docs/bootc-secure-install-contract.md
+++ b/docs/bootc-secure-install-contract.md
@@ -15,7 +15,7 @@ authoritative. The `installer` object defines the requirements below.
 
 ## Prerequisites
 
-- The installer medium must provide bootc `1.16.7` exactly, and at minimum
+- The installer medium must provide bootc `1.16.8` exactly, and at minimum
   Cosign `2.6.1` and the coherent Forky systemd `261.1-3` family. The two
   policies are deliberately different:
 

--- a/docs/bootc-secure-operations.md
+++ b/docs/bootc-secure-operations.md
@@ -27,7 +27,7 @@ remains blocked until authorized signed secure N/N+1/N+2 and transition OCI
 artifacts, prepared Dakota/bootc-installer/Fisherman runners, and representative
 Snowfield hardware results exist. Do not use an image unless inspection confirms
 `io.snosi.bootc.secureboot-capable=true` and
-`io.snosi.bootc.secureboot-assembly=bootc-1.16.7-storage-digest-v1`.
+`io.snosi.bootc.secureboot-assembly=bootc-1.16.8-storage-digest-v1`.
 
 ## Trust Boundaries
 

--- a/docs/design/build-pipeline.md
+++ b/docs/design/build-pipeline.md
@@ -61,7 +61,7 @@ mixes in systemd-boot, cryptsetup, and TPM tooling. It adds
 `lockdown=integrity` through
 `/usr/lib/bootc/kargs.d/10-lockdown.toml`, not mkosi `KernelCommandLine=`:
 these directory-format profiles do not have an mkosi-built UKI for that setting
-to affect. Pinned bootc 1.16.7 loads sorted `*.toml` files from that directory;
+to affect. Pinned bootc 1.16.8 loads sorted `*.toml` files from that directory;
 the strict schema is `kargs = ["..."]` with optional
 `match-architectures = ["x86_64"]`. The fragment also carries explicit
 MOK/recovery/TPM/UKI tools and the public-only native MOK certificate plus
@@ -69,7 +69,7 @@ RSA-2048 PCR signing public key. The image contract is
 `/usr/lib/snosi/bootc-secure.json` (schema 1). Task 5 adds
 `shared/bootc-secure/assemble-uki.sh`, called only through
 `buildah-package.sh` when `SNOSI_BOOTC_SECURE=1`: the pristine first OCI package
-is chunked before its candidate bootc obtains bootc 1.16.7's hidden storage
+is chunked before its candidate bootc obtains bootc 1.16.8's hidden storage
 digest. That chunked candidate is digest authority; the adapter injects a
 MOK-signed UKI plus the ESP copy of systemd-boot under `/boot`. Before that first package, it
 places the same signed systemd-boot source at

--- a/docs/design/ci-cd.md
+++ b/docs/design/ci-cd.md
@@ -87,7 +87,7 @@ the cayo, snow, and snowfield package access needed by secure publication.
    sudo. Do not replace this with implicit preservation or pass secret bytes in
    arguments.
    Local validation requires host Podman, not host bootc: the validator runs the
-   candidate image's pinned bootc 1.16.7 to recompute its storage composefs digest.
+   candidate image's pinned bootc 1.16.8 to recompute its storage composefs digest.
    The same boundary applies to the policy-copied validation after registry pull.
 2. Chunk, smoke test, and generate the SBOM, then use root Buildah's stdin login with the job-scoped `GITHUB_TOKEN` to push only the immutable timestamp tag and capture its digest.
 3. Use the Docker credential context to sign `IMAGE@DIGEST`, verify its remote digest/secure labels and Cosign signature, and copy it through the restrictive repository policy before validating the copied UKI/composefs artifact.

--- a/shared/bootc-secure/assemble-uki.sh
+++ b/shared/bootc-secure/assemble-uki.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# Assemble the pinned bootc-1.16.7 compatibility UKI. This is deliberately not
+# Assemble the pinned bootc-1.16.8 compatibility UKI. This is deliberately not
 # an upstream-stable interface: buildah-package.sh supplies the OCI digest.
 set -euo pipefail
 umask 077
 
-readonly EXPECTED_BOOTC_VERSION="1.16.7"
+readonly EXPECTED_BOOTC_VERSION="1.16.8"
 readonly CANDIDATE_UKIFY_MOK_KEY=/run/snosi-ukify-mok.key
 readonly CANDIDATE_UKIFY_MOK_CERT=/run/snosi-ukify-mok.crt
 readonly CANDIDATE_UKIFY_PCR_KEY=/run/snosi-ukify-pcr.key
@@ -66,7 +66,7 @@ validate_root_contract() { # rootfs
     local root=$1 contract
     contract="$root/usr/lib/snosi/bootc-secure.json"
     [[ -f "$contract" ]] || die "missing bootc secure rootfs contract"
-    jq -e '.schema == 1 and .mok_certificate == "/usr/lib/snosi/mok.crt" and .pcr_public_key == "/usr/lib/snosi/pcr-signing.pub" and .encrypted_root_mapper == "root" and .systemd_suite == "forky" and ((has("assembly") | not) or .assembly == {compatibility: "bootc-1.16.7-storage-digest-v1", bootc_version: "1.16.7", storage_digest_command: "bootc container compute-composefs-digest-from-storage", ukify: "direct-two-pass"})' "$contract" >/dev/null || die "unexpected bootc secure rootfs contract"
+    jq -e '.schema == 1 and .mok_certificate == "/usr/lib/snosi/mok.crt" and .pcr_public_key == "/usr/lib/snosi/pcr-signing.pub" and .encrypted_root_mapper == "root" and .systemd_suite == "forky" and ((has("assembly") | not) or .assembly == {compatibility: "bootc-1.16.8-storage-digest-v1", bootc_version: "1.16.8", storage_digest_command: "bootc container compute-composefs-digest-from-storage", ukify: "direct-two-pass"})' "$contract" >/dev/null || die "unexpected bootc secure rootfs contract"
 }
 
 # The gate tracks only caller-owned private keys. Generic PEM scans reject

--- a/shared/bootc-secure/ci/verify-published-image.sh
+++ b/shared/bootc-secure/ci/verify-published-image.sh
@@ -49,7 +49,7 @@ inspection=$(skopeo inspect --authfile "$AUTH_FILE" \
 jq -e --arg digest "$EXPECTED_DIGEST" '
     .Digest == $digest and
     .Labels["io.snosi.bootc.secureboot-capable"] == "true" and
-    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.7-storage-digest-v1"
+    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.8-storage-digest-v1"
 ' <<<"$inspection" >/dev/null
 
 tag_digest=$(skopeo inspect --authfile "$AUTH_FILE" --format '{{.Digest}}' \

--- a/shared/bootc-secure/storage-digest-probe.sh
+++ b/shared/bootc-secure/storage-digest-probe.sh
@@ -6,7 +6,7 @@
 # ONE place (sibling copies of this shape have drifted before; see CLAUDE.md
 # "move the behaviour rather than copying the fix").
 #
-# The /var/tmp bind mount is load-bearing: bootc 1.16.7 hardcodes its
+# The /var/tmp bind mount is load-bearing: bootc 1.16.8 hardcodes its
 # temporary composefs repository at /var/tmp INSIDE the container
 # (tempfile::tempdir_in("/var/tmp") in bootc_composefs/digest.rs; TMPDIR is
 # ignored), and composefs object writes open temp files with O_TMPFILE, which

--- a/shared/bootc-secure/tree/usr/lib/snosi/bootc-secure.json
+++ b/shared/bootc-secure/tree/usr/lib/snosi/bootc-secure.json
@@ -5,14 +5,14 @@
   "encrypted_root_mapper": "root",
   "systemd_suite": "forky",
   "assembly": {
-    "compatibility": "bootc-1.16.7-storage-digest-v1",
-    "bootc_version": "1.16.7",
+    "compatibility": "bootc-1.16.8-storage-digest-v1",
+    "bootc_version": "1.16.8",
     "storage_digest_command": "bootc container compute-composefs-digest-from-storage",
     "ukify": "direct-two-pass"
   },
   "installer": {
     "minimum_versions": {
-      "bootc": "1.16.7",
+      "bootc": "1.16.8",
       "cosign": "2.6.1",
       "systemd": "261.1-3"
     },

--- a/shared/outformat/image/buildah-package.sh
+++ b/shared/outformat/image/buildah-package.sh
@@ -59,15 +59,15 @@ probe_rootfs_bootc_version() ( # rootfs
         printf 'Error: rootfs bootc execution failed:\n%s\n' "$output" >&2
         exit 1
     fi
-    [[ $output == 'bootc 1.16.7' ]] || {
-        printf 'Error: expected bootc 1.16.7, observed %s\n' "$output" >&2
+    [[ $output == 'bootc 1.16.8' ]] || {
+        printf 'Error: expected bootc 1.16.8, observed %s\n' "$output" >&2
         exit 1
     }
 )
 
 readonly SECURE_CAPABLE_LABEL="io.snosi.bootc.secureboot-capable=true"
 readonly SECURE_INCAPABLE_LABEL="io.snosi.bootc.secureboot-capable=false"
-readonly SECURE_ASSEMBLY_LABEL="io.snosi.bootc.secureboot-assembly=bootc-1.16.7-storage-digest-v1"
+readonly SECURE_ASSEMBLY_LABEL="io.snosi.bootc.secureboot-assembly=bootc-1.16.8-storage-digest-v1"
 first_image=""
 final_container=""
 final_mount=""
@@ -129,7 +129,7 @@ if [[ ${SNOSI_BOOTC_SECURE:-0} == 1 ]]; then
     }
     digest=$(snosi_storage_composefs_digest "$first_image")
     [[ $digest =~ ^[[:xdigit:]]{128}$ ]] || { echo "Error: unsupported bootc storage-digest interface" >&2; exit 1; }
-    SNOSI_BOOTC_SECURE_COMPOSEFS_DIGEST="$digest" SNOSI_BOOTC_SECURE_BOOTC_VERSION=1.16.7 \
+    SNOSI_BOOTC_SECURE_COMPOSEFS_DIGEST="$digest" SNOSI_BOOTC_SECURE_BOOTC_VERSION=1.16.8 \
         SNOSI_BOOTC_SECURE_UKIFY_IMAGE="$first_image" \
         SNOSI_BOOTC_PREVIOUS_PCR_KEY="${SNOSI_BOOTC_PREVIOUS_PCR_KEY:-}" \
         "$ASSEMBLER" "$ROOTFS_DIR" \

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -57,7 +57,7 @@ sudo skopeo copy --src-authfile "$AUTH_FILE" \
 jq -e --arg digest "$EXPECTED_DIGEST" '
     .Digest == $digest and
     .Labels["io.snosi.bootc.secureboot-capable"] == "true" and
-    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.7-storage-digest-v1"
+    .Labels["io.snosi.bootc.secureboot-assembly"] == "bootc-1.16.8-storage-digest-v1"
 ' <<<"$inspection" >/dev/null
 EOF
 

--- a/test/bootc-secure-docs-test.sh
+++ b/test/bootc-secure-docs-test.sh
@@ -27,7 +27,7 @@ required_headings=(
 
 required_strings=(
     'io.snosi.bootc.secureboot-capable=true'
-    'io.snosi.bootc.secureboot-assembly=bootc-1.16.7-storage-digest-v1'
+    'io.snosi.bootc.secureboot-assembly=bootc-1.16.8-storage-digest-v1'
     '/dev/mapper/root'
     "ROOT_BACKING_DEVICE=\$(cryptsetup status root | awk '/^[[:space:]]*device:/{print \$2; exit}')"
     "ROOT_BACKING_DEVICE_COUNT=\$(cryptsetup status root | awk '/^[[:space:]]*device:/{print \$2}' | grep -Ec '^/dev/')"

--- a/test/bootc-secure-install-contract-test.sh
+++ b/test/bootc-secure-install-contract-test.sh
@@ -19,7 +19,7 @@ assert contract["schema"] == 1
 assert contract["encrypted_root_mapper"] == "root"
 assert contract["installer"] == {
     "minimum_versions": {
-        "bootc": "1.16.7",
+        "bootc": "1.16.8",
         "cosign": "2.6.1",
         "systemd": "261.1-3",
     },

--- a/test/bootc-secure-package-cleanup-test.sh
+++ b/test/bootc-secure-package-cleanup-test.sh
@@ -47,7 +47,7 @@ if [[ ${BUILD_FIXTURE_CHROOT_FAIL:-0} == 1 ]]; then
     echo 'fixture rootfs loader failure' >&2
     exit 86
 fi
-printf '%s\n' "${BUILD_FIXTURE_BOOTC_VERSION:-bootc 1.16.7}"
+printf '%s\n' "${BUILD_FIXTURE_BOOTC_VERSION:-bootc 1.16.8}"
 EOF
     cat >"$state/bin/umount" <<'EOF'
 #!/bin/bash
@@ -309,7 +309,7 @@ remove_proc_dir() { rmdir "$2/proc"; }
 run_probe_failure_case proc-missing 'rootfs proc directory is missing' remove_proc_dir UNUSED 0
 run_probe_failure_case proc-pre-mounted 'rootfs proc is already mounted' mark_proc_mounted UNUSED 0
 run_probe_failure_case chroot-fails 'fixture rootfs loader failure' none BUILD_FIXTURE_CHROOT_FAIL 1
-run_probe_failure_case wrong-version 'expected bootc 1.16.7, observed bootc 1.16.2' none BUILD_FIXTURE_BOOTC_VERSION 'bootc 1.16.2'
+run_probe_failure_case wrong-version 'expected bootc 1.16.8, observed bootc 1.16.2' none BUILD_FIXTURE_BOOTC_VERSION 'bootc 1.16.2'
 run_probe_failure_case umount-fails 'failed to unmount rootfs proc' none BUILD_FIXTURE_UMOUNT_FAIL 1
 
 run_case assembler-fails
@@ -356,7 +356,7 @@ run_success_case() {
     ! grep -Fxq 'io.snosi.bootc.secureboot-capable=true' "$state/container-1-labels" || fail "first candidate gained the secure capability label"
     ! grep -Fq 'io.snosi.bootc.secureboot-assembly=' "$state/container-1-labels" || fail "first candidate gained the assembly label"
     grep -Fxq 'io.snosi.bootc.secureboot-capable=true' "$state/container-2-labels" || fail "final container lost the secure label"
-    grep -Fxq 'io.snosi.bootc.secureboot-assembly=bootc-1.16.7-storage-digest-v1' "$state/container-2-labels" || fail "final container lost the assembly label"
+    grep -Fxq 'io.snosi.bootc.secureboot-assembly=bootc-1.16.8-storage-digest-v1' "$state/container-2-labels" || fail "final container lost the assembly label"
     "$state/assembler" --remove-injected "$root"
 }
 

--- a/test/bootc-secure-publication-test.sh
+++ b/test/bootc-secure-publication-test.sh
@@ -104,7 +104,7 @@ EOF
 chmod +x "$WORK/bin/skopeo" "$WORK/bin/cosign" "$WORK/bin/sudo"
 
 export INSPECTION
-INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.8-storage-digest-v1"}}')
 
 run_case "accepted immutable secure image is copied" success "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 grep -Fqx "skopeo inspect --authfile $AUTH_FILE docker://$IMAGE@$DIGEST" "$WORK/commands" && pass "Skopeo inspects immutable metadata with explicit auth" || fail "Skopeo inspects immutable metadata with explicit auth"
@@ -147,16 +147,16 @@ TAG_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     run_case "version tag digest mismatch is rejected" failure \
     "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
-INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "false", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "false", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.8-storage-digest-v1"}}')
 run_case "false secure capability is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
-INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-assembly": "bootc-1.16.8-storage-digest-v1"}}')
 run_case "missing secure capability is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "wrong"}}')
 run_case "wrong secure assembly is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
-INSPECTION=$(jq -nc --arg digest "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.8-storage-digest-v1"}}')
 run_case "remote digest mismatch is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 
-INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.7-storage-digest-v1"}}')
+INSPECTION=$(jq -nc --arg digest "$DIGEST" '{Digest: $digest, Labels: {"io.snosi.bootc.secureboot-capable": "true", "io.snosi.bootc.secureboot-assembly": "bootc-1.16.8-storage-digest-v1"}}')
 COSIGN_VERIFY_FAIL=1 run_case "failed Cosign verification is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 SKOPEO_COPY_FAIL=1 run_case "failed policy copy is rejected" failure "$IMAGE" "$VERSION" "$DIGEST" "$LOCAL_REF" "$AUTH_FILE"
 

--- a/test/bootc-secure-spike-test.sh
+++ b/test/bootc-secure-spike-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Feasibility gate for bootc 1.16.7 UKIs sealed to a composefs rootfs.
+# Feasibility gate for bootc 1.16.8 UKIs sealed to a composefs rootfs.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -138,7 +138,7 @@ for package in mokutil cryptsetup cryptsetup-bin tpm2-tools \
 done
 
 # Directory-format bootc profiles do not build a UKI through mkosi, so
-# KernelCommandLine= is inert. Pinned bootc 1.16.7 reads sorted *.toml files
+# KernelCommandLine= is inert. Pinned bootc 1.16.8 reads sorted *.toml files
 # from /usr/lib/bootc/kargs.d; its strict schema requires a kargs array.
 if grep -q '^KernelCommandLine=' "$secure"; then
     echo "bootc secure fragment must use bootc kargs.d, not mkosi KernelCommandLine=" >&2
@@ -172,8 +172,8 @@ assert {key: contract[key] for key in (
     "encrypted_root_mapper": "root",
     "systemd_suite": "forky",
     "assembly": {
-        "compatibility": "bootc-1.16.7-storage-digest-v1",
-        "bootc_version": "1.16.7",
+        "compatibility": "bootc-1.16.8-storage-digest-v1",
+        "bootc_version": "1.16.8",
         "storage_digest_command": "bootc container compute-composefs-digest-from-storage",
         "ukify": "direct-two-pass",
     },


### PR DESCRIPTION
## Summary
- bump the secure rootfs bootc version gate from 1.16.7 to 1.16.8
- update the assembly compatibility label and shipped rootfs/install contract
- keep publication verification, fixtures, and current documentation in sync

## Validation
- bash test/bootc-secure-package-cleanup-test.sh
- bash test/bootc-secure-static-test.sh
- bash test/bootc-secure-publication-test.sh
- bash test/bootc-publication-guard-test.sh
- bash test/bootc-secure-install-contract-test.sh
- bash test/bootc-secure-docs-test.sh
- git diff --check