### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -1,5 +1,5 @@
 code=1.133.0-1786487972
 docker-ce=5:29.7.2-1~debian.13~trixie
-1password-cli=2.38.1-1
+1password-cli=2.39.0-1
 claude-desktop=1.30096.1
-chatgpt=26.810.41047
+chatgpt=26.810.52044

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -1,7 +1,7 @@
 {
   "code": "1.133.0-1786487972",
   "docker-ce": "5:29.7.2-1~debian.13~trixie",
-  "1password-cli": "2.38.1-1",
+  "1password-cli": "2.39.0-1",
   "claude-desktop": "1.30096.1",
-  "chatgpt": "26.810.41047"
+  "chatgpt": "26.810.52044"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

1password-cli: 2.38.1-1 -> 2.39.0-1
chatgpt: 26.810.41047 -> 26.810.52044


**Please verify the builds work before merging.**