### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -1,5 +1,5 @@
 code=1.133.0-1786487972
 docker-ce=5:29.7.2-1~debian.13~trixie
 1password-cli=2.39.0-1
-claude-desktop=1.32352.1
-chatgpt=26.814.41407
+claude-desktop=1.32885.1
+chatgpt=26.814.41957

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -2,6 +2,6 @@
   "code": "1.133.0-1786487972",
   "docker-ce": "5:29.7.2-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
-  "claude-desktop": "1.32352.1",
-  "chatgpt": "26.814.41407"
+  "claude-desktop": "1.32885.1",
+  "chatgpt": "26.814.41957"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

claude-desktop: 1.32352.1 -> 1.32885.1
chatgpt: 26.814.41407 -> 26.814.41957


**Please verify the builds work before merging.**