### PR TITLE
chore: update sysext dependency checksums

### DIFF
--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -5,9 +5,9 @@
     "version": "8.12.32"
   },
   "bitwarden": {
-    "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2026.7.0/Bitwarden-2026.7.0-amd64.deb",
-    "sha256": "17523257c367f299a76d3670c7e329941fdaf14a4f9321cf38b347e35453ae64",
-    "version": "2026.7.0"
+    "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2026.8.0/Bitwarden-2026.8.0-amd64.deb",
+    "sha256": "720ecc392eef1992780af2aaabd4733916807155c8ee217ed67f3f93287bb415",
+    "version": "2026.8.0"
   },
   "microsoft-azurevpnclient": {
     "url": "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/microsoft-azurevpnclient_3.1.0_amd64.deb",
@@ -15,24 +15,24 @@
     "version": "3.1.0"
   },
   "microsoft-edge-stable": {
-    "url": "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_151.0.4129.86-1_amd64.deb",
-    "sha256": "26b02cb1c6465756df94b9ef34191b614f3df627ba21b7b00b641f44cc1d8343",
-    "version": "151.0.4129.86-1"
+    "url": "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_151.0.4129.107-1_amd64.deb",
+    "sha256": "1193e2de1588c14aff86704cb479f512955cfd6c5f2d5c2bb54ff536a77f624c",
+    "version": "151.0.4129.107-1"
   },
   "code-server": {
-    "url": "https://github.com/coder/code-server/releases/download/v4.132.0/code-server_4.132.0_amd64.deb",
-    "sha256": "18e0e69920ab23b725cb219fb42bc045a908421448cf496a3124314e1a02bcf1",
-    "version": "4.132.0"
+    "url": "https://github.com/coder/code-server/releases/download/v4.133.0/code-server_4.133.0_amd64.deb",
+    "sha256": "241feb9fcbd96b1e2caa2e16ecafa67a70d6f7f60659058ddc9a8ba51d366d7e",
+    "version": "4.133.0"
   },
   "coder": {
-    "url": "https://github.com/coder/coder/releases/download/v2.35.3/coder_2.35.3_linux_amd64.deb",
-    "sha256": "8fbeef52bd7b2c795501cfa357b8389867f882b9a9b363ddda3c7c544f103a5d",
-    "version": "2.35.3"
+    "url": "https://github.com/coder/coder/releases/download/v2.35.4/coder_2.35.4_linux_amd64.deb",
+    "sha256": "d3f50f9aad0373d68aefd55341fb55cf750ba959fbd912ea55511e466765ec57",
+    "version": "2.35.4"
   },
   "github-copilot": {
-    "url": "https://github.com/github/app/releases/download/v1.1.10/GitHub-Copilot-linux-x64.deb",
-    "sha256": "70305eaa3e79f278c5ba5b91a056c2dfa079ec5322371fd681a08f383e9aca79",
-    "version": "1.1.10"
+    "url": "https://github.com/github/app/releases/download/v1.1.12/GitHub-Copilot-linux-x64.deb",
+    "sha256": "813f02cca6a8c8d872903b4d197403a98734c8146f368b63c044f123d5673e80",
+    "version": "1.1.12"
   },
   "k3s": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.3%2Bk3s1/k3s",
@@ -40,14 +40,14 @@
     "version": "1.36.3+k3s1"
   },
   "lemonade": {
-    "url": "https://github.com/lemonade-sdk/lemonade/releases/download/v11.6.0/lemonade-server_11.6.0-debian13_amd64.deb",
-    "sha256": "29acb18cc87491f45b9478ea7c5e6e17b751f85bcb4a09dc4b37b2881774155d",
-    "version": "11.6.0"
+    "url": "https://github.com/lemonade-sdk/lemonade/releases/download/v11.7.0/lemonade-server_11.7.0-debian13_amd64.deb",
+    "sha256": "68bbb117c4f6a87aa9b21dabadb553423baae3175c2daeed0bfd3985f1440857",
+    "version": "11.7.0"
   },
   "paseo": {
-    "url": "https://github.com/getpaseo/paseo/releases/download/v0.4.0/Paseo-0.4.0-amd64.deb",
-    "sha256": "422b6b15e07698c3f706e6662b08c73993a19943d2d4c8a9cb71e22bf50ce626",
-    "version": "0.4.0"
+    "url": "https://github.com/getpaseo/paseo/releases/download/v0.5.1/Paseo-0.5.1-amd64.deb",
+    "sha256": "eed54db0bfd3f3ac6fc47ebdd04de2430ac1e7ccafd43b49644ef23bfb00821e",
+    "version": "0.5.1"
   },
   "pilothouse": {
     "url": "https://github.com/frostyard/pilothouse/releases/download/v0.9.0/frostyard-pilothouse_0.9.0_amd64.deb",


### PR DESCRIPTION
Automated update of pinned direct-download dependencies consumed by sysext builds.

These updates modify `shared/download/sysext-checksums.json` and should trigger `build.yml`, not the OCI image matrix.

**Please verify the sysext build works before merging.**