### PR TITLE
ci: add flurry to the OCI publication matrix

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -133,6 +133,8 @@ jobs:
             description: "Snow Linux OS Image"
           - profile: snowfield
             description: "Snowfield Linux OS Image"
+          - profile: flurry
+            description: "Flurry Linux OS Image"
 
     steps:
       - name: Show disk space (before)
@@ -496,6 +498,8 @@ jobs:
             description: "Snow Linux OS Image"
           - profile: snowfield
             description: "Snowfield Linux OS Image"
+          - profile: flurry
+            description: "Flurry Linux OS Image"
     steps:
       - name: Show disk space (before)
         run: sudo df -h

--- a/.github/workflows/build-mechanics.yml
+++ b/.github/workflows/build-mechanics.yml
@@ -60,6 +60,8 @@ jobs:
             description: "Snow Linux OS Image"
           - profile: snowfield
             description: "Snowfield Linux OS Image"
+          - profile: flurry
+            description: "Flurry Linux OS Image"
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/check-bootc-publication-guard.sh
+++ b/check-bootc-publication-guard.sh
@@ -36,7 +36,7 @@ if [[ ! -d $guard_root ]]; then
     exit "$fail"
 fi
 
-profiles=(cayo snow snowfield)
+profiles=(cayo snow snowfield flurry)
 secure_include='Include=%D/shared/bootc-secure/mkosi.conf'
 for profile in "${profiles[@]}"; do
     conf="$guard_root/mkosi.profiles/$profile/mkosi.conf"

--- a/docs/plans/2026-08-25-flurry-omarchy-plan.md
+++ b/docs/plans/2026-08-25-flurry-omarchy-plan.md
@@ -122,11 +122,14 @@ flurry gets an install path).
 
 ## Later / ideas
 
-- CI publication: add flurry to `build-images.yml` matrices AND a
-  `ghcr.io/frostyard/flurry` `sigstoreSigned` scope in
-  `shared/bootc-secure/tree/etc/containers/policy.json` +
-  `test/bootc-container-policy-test.sh` expectations (a published flurry
-  cannot registry-pull its own updates without the policy scope).
+- ~~CI publication~~ DONE (alpha matrix, 2026-08-25): flurry is in the
+  `build-images.yml` secure-build + PR matrices and `build-mechanics.yml`;
+  policy.json carries the `ghcr.io/frostyard/flurry` `sigstoreSigned` scope
+  (test updated); the publication guard, verify/promote scripts, and static
+  test all include flurry. Still deferred: the live secure-harness rotations
+  (`bootc-secure-nightly.yml`, `test-bootc-secure.yml` dispatch options,
+  `stage-state-root.sh`/`run-full-window.sh`) — those need flurry secure
+  install fixtures that do not exist yet.
 - Native A/B `flurry-ab` (channel fragment, repart, sysupdate transfers, CI).
 - Vendor gpu-screen-recorder (screen recording is stubbed), tensaku
   (screenshot editing falls back), voxtype, localsend, moonlight-qt,

--- a/shared/bootc-secure/ci/promote-published-image.sh
+++ b/shared/bootc-secure/ci/promote-published-image.sh
@@ -11,7 +11,7 @@ IMAGE=$1
 EXPECTED_DIGEST=$2
 AUTH_FILE=$3
 
-if [[ ! $IMAGE =~ ^ghcr\.io/frostyard/(cayo|snow|snowfield)$ ]] ||
+if [[ ! $IMAGE =~ ^ghcr\.io/frostyard/(cayo|snow|snowfield|flurry)$ ]] ||
         [[ ! $EXPECTED_DIGEST =~ ^sha256:[a-f0-9]{64}$ ]]; then
     printf 'invalid secure image reference\n' >&2
     exit 2

--- a/shared/bootc-secure/ci/verify-published-image.sh
+++ b/shared/bootc-secure/ci/verify-published-image.sh
@@ -27,7 +27,7 @@ if [[ ${AUTH_FILE##*/} != config.json ]]; then
     exit 2
 fi
 
-if [[ ! $IMAGE =~ ^ghcr\.io/frostyard/(cayo|snow|snowfield)$ ]]; then
+if [[ ! $IMAGE =~ ^ghcr\.io/frostyard/(cayo|snow|snowfield|flurry)$ ]]; then
     printf 'invalid secure image reference\n' >&2
     exit 2
 fi

--- a/shared/bootc-secure/tree/etc/containers/policy.json
+++ b/shared/bootc-secure/tree/etc/containers/policy.json
@@ -32,6 +32,15 @@
             "type": "matchRepository"
           }
         }
+      ],
+      "ghcr.io/frostyard/flurry": [
+        {
+          "type": "sigstoreSigned",
+          "keyPath": "/usr/lib/snosi/cosign.pub",
+          "signedIdentity": {
+            "type": "matchRepository"
+          }
+        }
       ]
     },
     "containers-storage": {

--- a/test/bootc-container-policy-test.sh
+++ b/test/bootc-container-policy-test.sh
@@ -41,7 +41,7 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
         fail "unlisted images are rejected"
     fi
 
-    for image in cayo snow snowfield; do
+    for image in cayo snow snowfield flurry; do
         scope="ghcr.io/frostyard/$image"
         if jq -e --arg scope "$scope" '
             .transports.docker[$scope] == [{
@@ -62,7 +62,7 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
         fail "previously policy-verified local storage images are accepted"
     fi
 
-    for image in cayo snow snowfield; do
+    for image in cayo snow snowfield flurry; do
         scope="ghcr.io/frostyard/${image}-wrong-repository"
         if jq -e --arg scope "$scope" '.transports.docker[$scope] == null' "$POLICY" >/dev/null; then
             pass "wrong repository $scope is rejected"
@@ -71,10 +71,10 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
         fi
     done
 
-    if jq -e '[.transports.docker | keys[] | select(startswith("ghcr.io/frostyard/"))] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"]' "$POLICY" >/dev/null; then
-        pass "only the three supported GHCR repositories are trusted"
+    if jq -e '[.transports.docker | keys[] | select(startswith("ghcr.io/frostyard/"))] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/flurry", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"]' "$POLICY" >/dev/null; then
+        pass "only the four supported GHCR repositories are trusted"
     else
-        fail "only the three supported GHCR repositories are trusted"
+        fail "only the four supported GHCR repositories are trusted"
     fi
 
     # LOCAL file transports are accepted so an operator can actually do image
@@ -345,7 +345,7 @@ run_live_policy_proof() {
     IFS=, read -r -a live_images <<<"${LIVE_IMAGES:-cayo}"
     for image in "${live_images[@]}"; do
         case "$image" in
-            cayo|snow|snowfield) ;;
+            cayo|snow|snowfield|flurry) ;;
             *) printf 'BLOCKED: LIVE_IMAGES contains unsupported product %s\n' "$image" >&2; return 2 ;;
         esac
         if HOME="$live_home" podman pull "ghcr.io/frostyard/$image:latest" >/dev/null 2>&1; then

--- a/test/bootc-publication-guard-test.sh
+++ b/test/bootc-publication-guard-test.sh
@@ -27,7 +27,7 @@ make_fixture() {
         "$fixture/shared/bootc-secure/ci" \
         "$fixture/.github/workflows"
 
-    for profile in cayo snow snowfield; do
+    for profile in cayo snow snowfield flurry; do
         mkdir -p "$fixture/mkosi.profiles/$profile"
         printf 'Include=%%D/shared/bootc-secure/mkosi.conf\n' >"$fixture/mkosi.profiles/$profile/mkosi.conf"
     done

--- a/test/bootc-secure-publication-test.sh
+++ b/test/bootc-secure-publication-test.sh
@@ -113,13 +113,14 @@ grep -Fqx "DOCKER_CONFIG=$(dirname -- "$AUTH_FILE") cosign verify --key $ROOT_DI
 grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" && grep -Fq -- "--registries.d " "$WORK/commands" && grep -Fq "docker://$IMAGE@$DIGEST containers-storage:$LOCAL_REF" "$WORK/commands" && pass "policy copy uses immutable source and root containers storage" || fail "policy copy uses immutable source and root containers storage"
 if jq -e '.default == [{"type":"reject"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains global reject"; else fail "copied policy retains global reject"; fi
 if jq -e --arg key "$ROOT_DIR/cosign.pub" '
-    [.transports.docker | keys[]] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"] and
+    [.transports.docker | keys[]] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/flurry", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"] and
     [.transports.docker[][]] == [
+        {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}},
         {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}},
         {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}},
         {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}}
     ]
-' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains exactly the three scoped Cosign rules"; else fail "copied policy retains exactly the three scoped Cosign rules"; fi
+' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains exactly the four scoped Cosign rules"; else fail "copied policy retains exactly the four scoped Cosign rules"; fi
 if jq -e '.transports["containers-storage"][""] == [{"type":"insecureAcceptAnything"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains the containers-storage exception"; else fail "copied policy retains the containers-storage exception"; fi
 if [[ $(sed -n '1p' "$WORK/commands") == "skopeo inspect --authfile $AUTH_FILE docker://$IMAGE@$DIGEST" ]] && [[ $(sed -n '2p' "$WORK/commands") == "skopeo inspect --authfile $AUTH_FILE --format {{.Digest}} docker://$IMAGE:$VERSION" ]] && [[ $(sed -n '3p' "$WORK/commands") == "DOCKER_CONFIG=$(dirname -- "$AUTH_FILE") cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" ]] && [[ $(sed -n '5p' "$WORK/commands") == "skopeo copy --src-authfile $AUTH_FILE "* ]]; then pass "verification orders explicit metadata reads before Cosign before policy copy"; else fail "verification orders explicit metadata reads before Cosign before policy copy"; fi
 grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" &&

--- a/test/bootc-secure-static-test.sh
+++ b/test/bootc-secure-static-test.sh
@@ -198,7 +198,7 @@ grep -Fq '/usr/lib/snosi/esp.sh' "$reconciler"
 
 # Only OCI bootc profiles consume the fragment. Native A/B, including the raw
 # fixture, must remain entirely independent of its packages and trust files.
-for profile in cayo snow snowfield; do
+for profile in cayo snow snowfield flurry; do
     grep -q '^Include=%D/shared/bootc-secure/mkosi.conf$' \
         "$root/mkosi.profiles/$profile/mkosi.conf"
 done


### PR DESCRIPTION
Completes the flurry alpha by wiring publication CI: secure-build + PR matrices in `build-images.yml`, `build-mechanics.yml`, the `ghcr.io/frostyard/flurry` sigstoreSigned policy scope (+policy-test expectations, now four pinned repositories), the bootc publication guard, the verify/promote CI scripts, and the secure static test.

Live secure-harness rotations (nightlies, stage-state-root/run-full-window) stay deferred until flurry secure install fixtures exist — noted in the plan doc.

All local checks green: policy test 33/33, publication-guard fixtures 63/63, static test, workflow path-filter 227/227, bootc-secure-ci 19/19, actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)