### PR TITLE
feat(installer): ship the product catalog, cosign, and flurry SDDM state seeding

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -707,6 +707,24 @@ jobs:
               "syft-version: ${SYFT_VERSION}"
           fi
 
+          # The installer ISO ships the same pinned cosign as a verified
+          # download (shared/firn-installer/scripts/build/cosign.chroot);
+          # refresh its checksum entry alongside the workflow pin. Not
+          # gated on WORKFLOW_UPDATES_ENABLED: checksums are repo content,
+          # not workflow files.
+          if [[ "$COSIGN_UPDATE" == "true" ]]; then
+            VERSION="${COSIGN_VERSION#v}"
+            validate_update_value "cosign-installer" "$VERSION" '^[0-9]+\.[0-9]+\.[0-9]+$'
+            URL="https://github.com/sigstore/cosign/releases/download/v${VERSION}/cosign-linux-amd64"
+            TMP=$(mktemp)
+            curl -fsSL --max-time 300 -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VERSION" \
+              '.["cosign-installer"].url=$u | .["cosign-installer"].sha256=$s | .["cosign-installer"].version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
           if [[ "$COSIGN_UPDATE" == "true" && "$WORKFLOW_UPDATES_ENABLED" == "true" ]]; then
             validate_update_value "cosign-release" "$COSIGN_VERSION" '^v2\.[0-9]+\.[0-9]+$'
             replace_exactly_once .github/workflows/build-images.yml \

--- a/docs/plans/2026-08-25-flurry-omarchy-plan.md
+++ b/docs/plans/2026-08-25-flurry-omarchy-plan.md
@@ -116,9 +116,29 @@ grep-guarded so an omarchy re-pin that changes the target fails the build):
 Test-only scaffolding (not shipped): the QEMU flow installs via
 `test/lib/vm.sh` then seeds a `flurry`/`flurry` user + SDDM
 `/var/lib/sddm/state.conf` (`Last User/Session`) — omarchy's password-only
-greeter submits `userModel.lastUser`, which is empty on a virgin install
-(omarchy's ISO normally seeds it; the snosi installer should, too, when
-flurry gets an install path).
+greeter submits `userModel.lastUser`, which is empty on a virgin install.
+SHIPPED FIX (2026-08-25): `flurry-sddm-state-seed.service` (flurry tree,
+static wants, `Before=display-manager.service`,
+`ConditionPathExists=!/var/lib/sddm/state.conf`) seeds the state for the
+machine's sole uid>=1000 account on first boot, covering every install
+method; SDDM owns the file from the first real login.
+
+## Installer integration (firn, 2026-08-25)
+
+Firn is the installer (single TUI binary; ISO built by snosi's
+`firn-installer` profile). Flurry appears in the picker via
+`shared/firn-installer/catalog.json`, shipped to `/etc/firn/catalog.json`
+— firn's documented wholesale-override seam (firn ADR-0010 puts the
+catalog on the media side; firn's compiled-in list stays as fallback).
+The same change fixed a pre-existing ISO gap: the medium shipped neither
+the `cosign` CLI nor `/usr/lib/snosi/cosign.pub`, which firn's preflight
+requires for every bootc catalog entry (`scripts/build/cosign.chroot`,
+pinned in image-checksums and refreshed by the check-dependencies cosign
+check). Remaining firn-side item: on composefs installs firn defers the
+/etc/skel copy to a first-boot tmpfiles `C` rule, and a wizard-pasted SSH
+key pre-creates the home dir, silently skipping skel — fatal for flurry
+(all omarchy dotfiles are skel); fix belongs in firn's
+`internal/sysconfig` (tracked as a firn PR).
 
 ## Later / ideas
 

--- a/shared/download/image-checksums.json
+++ b/shared/download/image-checksums.json
@@ -38,5 +38,10 @@
     "url": "https://github.com/jdx/mise/releases/download/v2026.8.12/mise-v2026.8.12-linux-x64",
     "sha256": "f2092b1e67f0abc8803d3be120dd2bc5b656dd99680ba3159f710e149da10d05",
     "version": "2026.8.12"
+  },
+  "cosign-installer": {
+    "url": "https://github.com/sigstore/cosign/releases/download/v2.6.5/cosign-linux-amd64",
+    "sha256": "c3b4f5410e608af03a5eb0aaac84a4313d8da131248e08ff1759ac70c79d1644",
+    "version": "2.6.5"
   }
 }

--- a/shared/firn-installer/README.md
+++ b/shared/firn-installer/README.md
@@ -7,11 +7,16 @@ installer ISO for all snosi image families, with
 a package payload satisfying firn's step-declared tool preflight for
 both the bootc and native A/B install families.
 
-## The firn binary is NOT committed
+## The firn binary comes from the frostyard apt repo
 
-`tree/usr/bin/firn` is gitignored and provisioned at build time: the
-`just firn-installer` / `just firn-installer-iso` recipes run
-`_firn-binary` first, which builds it from a sibling firn checkout:
+`mkosi.conf` installs `Packages=frostyard-firn` (published by firn's
+release via repogen), so CI needs no sibling firn checkout. The image
+postinst still fails the build loudly if `/usr/bin/firn` is missing.
+
+For dev testing of *unreleased* firn, the `just firn-installer` /
+`just firn-installer-iso` recipes still run `_firn-binary` first, which
+builds from a sibling checkout into the gitignored `tree/usr/bin/firn`
+(ExtraTrees then overrides the packaged binary):
 
 ```sh
 # FIRN_SRC defaults to ../firn relative to this repo's root;
@@ -19,17 +24,17 @@ both the bootc and native A/B install families.
 FIRN_SRC=/path/to/firn just firn-installer
 ```
 
-`_firn-binary` runs `CGO_ENABLED=0 go build ./cmd/firn-cli` with the
-same ldflags version stamping as firn's own Makefile, so the binary on
-the medium reports the source checkout's `git describe` version. The
-image postinst fails the build loudly if the binary is missing, so a
-bare `mkosi --profile firn-installer build` without the just recipe
-cannot produce an installer-less ISO.
+## The product catalog is snosi's
 
-**TODO:** switch this local-build provisioning to installing the
-`frostyard-firn` Debian package from the frostyard repository once firn
-cuts a release — at that point `_firn-binary`, the gitignore entry, and
-the postinst presence check move to a plain `Packages=` entry.
+`catalog.json` ships to `/etc/firn/catalog.json`, which firn reads as a
+**wholesale** override of its compiled-in picker list (firn ADR-0010:
+the catalog is media payload). Adding a product to the installer is
+therefore a snosi change: add the entry here — every product must be
+listed, and entries must satisfy firn's `checkCatalog` (bootc: `ref` +
+`cosign_pub_key`, no `product`; ab: `product`, no `ref`/key). The
+pinned `cosign` CLI (scripts/build/cosign.chroot) and
+`/usr/lib/snosi/cosign.pub` back the bootc entries' signature
+verification — firn's preflight requires both.
 
 ## Kiosk units
 

--- a/shared/firn-installer/catalog.json
+++ b/shared/firn-installer/catalog.json
@@ -1,0 +1,48 @@
+[
+  {
+    "family": "bootc",
+    "name": "snow",
+    "description": "GNOME desktop with backports kernel",
+    "ref": "ghcr.io/frostyard/snow:latest",
+    "cosign_pub_key": "/usr/lib/snosi/cosign.pub"
+  },
+  {
+    "family": "bootc",
+    "name": "snowfield",
+    "description": "GNOME desktop with linux-surface kernel for Surface devices",
+    "ref": "ghcr.io/frostyard/snowfield:latest",
+    "cosign_pub_key": "/usr/lib/snosi/cosign.pub"
+  },
+  {
+    "family": "bootc",
+    "name": "flurry",
+    "description": "Hyprland desktop (Omarchy replica) with backports kernel",
+    "ref": "ghcr.io/frostyard/flurry:latest",
+    "cosign_pub_key": "/usr/lib/snosi/cosign.pub"
+  },
+  {
+    "family": "bootc",
+    "name": "cayo",
+    "description": "Headless server with podman and backports kernel",
+    "ref": "ghcr.io/frostyard/cayo:latest",
+    "cosign_pub_key": "/usr/lib/snosi/cosign.pub"
+  },
+  {
+    "family": "ab",
+    "name": "snow-ab",
+    "description": "Native A/B GNOME desktop with backports kernel",
+    "product": "snow-ab"
+  },
+  {
+    "family": "ab",
+    "name": "snowfield-ab",
+    "description": "Native A/B GNOME desktop with linux-surface kernel",
+    "product": "snowfield-ab"
+  },
+  {
+    "family": "ab",
+    "name": "cayo-ab",
+    "description": "Native A/B headless server with podman",
+    "product": "cayo-ab"
+  }
+]

--- a/shared/firn-installer/mkosi.conf
+++ b/shared/firn-installer/mkosi.conf
@@ -317,5 +317,29 @@ ExtraTrees=%D/shared/firn-installer/tree
 ExtraTrees=%D/shared/firn-installer/core.json:/usr/share/firn/core-flatpaks.json
 ExtraTrees=%D/shared/native-ab/keys/import-pubring.gpg:/usr/lib/snosi/os-update-pubring.gpg
 ExtraTrees=%D/shared/native-ab/keys/mok-2026.crt:/usr/lib/snosi/mok.crt
+# The installable-product catalog. Firn ADR-0010 puts the catalog on the
+# media side (snosi), and firn reads /etc/firn/catalog.json as a wholesale
+# override of its compiled-in list -- shipping it here means adding a
+# product to the picker is a snosi change, not a firn release. Must list
+# EVERY product (override replaces, never merges) and must satisfy firn's
+# checkCatalog rules: bootc entries carry ref + cosign_pub_key and no
+# product; ab entries carry product and no ref/key.
+ExtraTrees=%D/shared/firn-installer/catalog.json:/etc/firn/catalog.json
+# The snosi image-signing public key at the path every bootc catalog entry
+# names as cosign_pub_key (same canonical-copy provisioning as
+# shared/bootc-secure/mkosi.conf).
+ExtraTrees=%D/cosign.pub:/usr/lib/snosi/cosign.pub
+
+# Pinned cosign CLI: firn's preflight requires the `cosign` tool for every
+# catalog entry with a cosign_pub_key (see the script header). jq is
+# build-only: verified_download() parses the checksum metadata with it,
+# and nothing on the shipped medium needs it.
+BuildScripts=%D/shared/firn-installer/scripts/build/cosign.chroot
+# Build-only: verified_download() needs jq (checksum metadata) and
+# curl + CA trust (the download itself); nothing on the shipped medium
+# needs any of them.
+BuildPackages=jq
+              curl
+              ca-certificates
 
 PostInstallationScripts=%D/shared/firn-installer/postinst/mkosi.postinst.chroot

--- a/shared/firn-installer/scripts/build/cosign.chroot
+++ b/shared/firn-installer/scripts/build/cosign.chroot
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ships the pinned cosign CLI on the installer ISO. Firn's bootc preflight
+# declares the `cosign` tool for every catalog entry that carries a
+# cosign_pub_key (internal/steps/assemble.go appends it to bootcTools), and
+# every bootc entry in the shipped catalog does -- without this binary,
+# every bootc install from the ISO fails preflight before touching the
+# disk. Pinned in shared/download/image-checksums.json and refreshed by the
+# same check-dependencies cosign check that tracks build-images.yml's
+# cosign-release (v2-only: v3 cannot verify these key-signed images when
+# GitHub provenance attestations are present). Writes to $DESTDIR only
+# (frostyard/snosi#293).
+
+source "$SRCDIR/shared/download/verified-download.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+verified_download "cosign-installer" "$TMP/cosign"
+install -D -m 0755 "$TMP/cosign" "$DESTDIR/usr/bin/cosign"
+echo "cosign installed to /usr/bin/cosign"

--- a/shared/flurry/tree/usr/lib/systemd/system/flurry-sddm-state-seed.service
+++ b/shared/flurry/tree/usr/lib/systemd/system/flurry-sddm-state-seed.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Seed SDDM last-user state for the Omarchy greeter
+# Omarchy's SDDM theme has no username field: it submits
+# userModel.lastUser, which SDDM populates from /var/lib/sddm/state.conf --
+# a file that does not exist on a virgin install, making the greeter
+# unusable (login submits user ""). Seed it once, for the machine's single
+# human account, before the greeter first paints; SDDM owns the file from
+# the first real login on. Runs (and no-ops) each boot until either this
+# unit or SDDM has written the file, so an install path that creates the
+# user without seeding state still converges on the next boot.
+# Static /usr wants activation, no [Install] -- snosi infra-unit pattern
+# (see AGENTS.md "Enablement lives in presets"): preset-based enablement of
+# a new unit cannot reach installs whose first boot predates it.
+Before=display-manager.service
+RequiresMountsFor=/var/lib/sddm
+ConditionPathExists=!/var/lib/sddm/state.conf
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/flurry-sddm-state-seed

--- a/shared/flurry/tree/usr/lib/systemd/system/multi-user.target.wants/flurry-sddm-state-seed.service
+++ b/shared/flurry/tree/usr/lib/systemd/system/multi-user.target.wants/flurry-sddm-state-seed.service
@@ -1,0 +1,1 @@
+../flurry-sddm-state-seed.service

--- a/shared/flurry/tree/usr/libexec/flurry-sddm-state-seed
+++ b/shared/flurry/tree/usr/libexec/flurry-sddm-state-seed
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# Writes SDDM's last-user state for the machine's sole human account so the
+# Omarchy password-only greeter is usable on first boot. See the unit for
+# the full rationale. Exits quietly (retrying next boot via the unit's
+# ConditionPathExists) when there is not exactly one human account yet.
+
+state=/var/lib/sddm/state.conf
+[[ -e "$state" ]] && exit 0
+
+mapfile -t users < <(awk -F: '$3 >= 1000 && $3 < 60000 && $7 !~ /(nologin|false)$/ {print $1}' /etc/passwd)
+if (( ${#users[@]} != 1 )); then
+    echo "flurry-sddm-state-seed: ${#users[@]} human accounts found; leaving state unseeded"
+    exit 0
+fi
+
+install -d -m 0750 -o sddm -g sddm /var/lib/sddm
+tmp=$(mktemp /var/lib/sddm/.state.conf.XXXXXX)
+printf '[Last]\nUser=%s\nSession=/usr/share/wayland-sessions/omarchy.desktop\n' "${users[0]}" >"$tmp"
+chown sddm:sddm "$tmp"
+chmod 0600 "$tmp"
+mv "$tmp" "$state"
+echo "flurry-sddm-state-seed: seeded last user '${users[0]}'"


### PR DESCRIPTION
Gives flurry a working firn install path and fixes a pre-existing gap that broke every bootc install from the ISO:

- **`/etc/firn/catalog.json` shipped by snosi** (firn ADR-0010's media boundary; firn reads it as a wholesale override of its compiled-in picker). All seven products listed including flurry; validated through firn's own `loadCatalogFrom`. New products no longer need a firn release.
- **cosign v2.6.5 + `/usr/lib/snosi/cosign.pub` on the medium** — firn's preflight requires both for every bootc catalog entry, and the ISO shipped neither. Pinned via verified_download; the existing check-dependencies cosign check refreshes it alongside the workflow pin. `jq`/`curl`/`ca-certificates` are BuildPackages only (verified absent from the built medium).
- **`flurry-sddm-state-seed.service`** — first-boot oneshot seeding SDDM's last-user/session state for the sole human account; omarchy's password-only greeter is unusable without it on a virgin install (verified live during flurry bring-up). Covers firn, bcvk, and manual installs alike.

Verified: `mkosi --profile firn-installer build` green with cosign/catalog/pubkey present on the medium; catalog accepted by firn's checkCatalog (in-package test against this file); guards + workflow path-filter all green.

Companion firn PR (composefs skel-skip on SSH-key installs, fatal for flurry): frostyard/firn#81

🤖 Generated with [Claude Code](https://claude.com/claude-code)