### PR TITLE
fix(flurry): brew on PATH, gtk-launch, and pactl — first live-session gaps

### DIFF
--- a/shared/flurry/scripts/build/omarchy.chroot
+++ b/shared/flurry/scripts/build/omarchy.chroot
@@ -209,6 +209,38 @@ compat_patch "$OMARCHY/shell/plugins/notifications/Service.qml" \
     'var transient = false' \
     's/\btransient\b/xTransient/g; s/xTransient` hint/transient` hint/; s/hints\["xTransient"\]/hints["transient"]/' \
     'Qt 6.8 reserved word transient'
+# Homebrew on PATH (frostyard/snosi#777): omarchy's env-bootstrap is the
+# single PATH authority for every shell entry point (skel .bashrc, uwsm
+# session env, profile.d login shells, the bash rc chain), and it knows
+# nothing of snosi's /home/linuxbrew tree (unpacked by brew-setup.service)
+# -- yet the omarchy-pkg-* overrides point users at `brew install`. Append
+# a dedup-guarded brew bin dir before the final `export PATH`, same
+# append-not-prepend precedence policy as the user tool paths above. Not a
+# sed one-liner, so guarded by hand like compat_patch: an omarchy re-pin
+# that restructures env-bootstrap fails the build for re-triage.
+EB="$OMARCHY/default/bash/env-bootstrap"
+grep -qx 'export PATH' "$EB" || {
+    echo "omarchy.chroot: compat patch target vanished (brew PATH): no bare 'export PATH' line in $EB" >&2
+    exit 1
+}
+! grep -q linuxbrew "$EB" || {
+    echo "omarchy.chroot: compat patch target vanished (brew PATH): $EB already mentions linuxbrew" >&2
+    exit 1
+}
+brew_block=$(cat <<'BREW'
+# snosi (Flurry): Homebrew lives at /home/linuxbrew (unpacked on first boot
+# by brew-setup.service); appended so system binaries keep precedence.
+if [ -d /home/linuxbrew/.linuxbrew/bin ]; then
+  case ":$PATH:" in
+    *":/home/linuxbrew/.linuxbrew/bin:"*) ;;
+    *) PATH="${PATH:+$PATH:}/home/linuxbrew/.linuxbrew/bin" ;;
+  esac
+fi
+BREW
+)
+awk -v block="$brew_block" '/^export PATH$/ { print block; print ""; } { print }' "$EB" >"$EB.tmp"
+mv "$EB.tmp" "$EB"
+sh -n "$EB" || { echo "omarchy.chroot: patched env-bootstrap fails sh -n" >&2; exit 1; }
 
 # --- snosi override layer ---------------------------------------------------
 # Whole-file replacements for commands whose Arch mechanics are remapped;

--- a/shared/packages/flurry/mkosi.conf
+++ b/shared/packages/flurry/mkosi.conf
@@ -68,6 +68,11 @@ Packages=xdg-desktop-portal
          qml6-module-qtquick-shapes
          qml6-module-qtquick-window
          libgtk4-layer-shell0
+# gtk-launch: omarchy's app library starts every desktop entry via
+# `uwsm-app -- gtk-launch <id>` (pinned by omarchy's own
+# test/shell.d/app-search-test.sh), and several omarchy-install-* commands
+# do the same. Snow inherits it from the GNOME stack; flurry must ask.
+         libgtk-3-bin
          polkitd
          pkexec
          libnotify-bin
@@ -102,6 +107,9 @@ Packages=pipewire/trixie-backports
          alsa-utils
          alsa-ucm-conf
          alsa-topology-conf
+# pactl (against pipewire-pulse): omarchy-audio-output-sink/-switch drive
+# output switching from the bar with it.
+Packages=pulseaudio-utils
 
 # Network / bluetooth
 Packages=network-manager


### PR DESCRIPTION
Three fixes from the first real installed-flurry sessions (all root-caused, all verified in a rebuilt image):

- **Homebrew on PATH** (fixes #777): guarded append in omarchy's `env-bootstrap` — the single PATH authority for skel bashrc, uwsm session env, login shells, and the rc chain — applied by the vendor script with the same fail-closed grep-guard discipline as the other compat patches. Verified: patched file in image, `sh -n` clean, sourcing simulation appends `/home/linuxbrew/.linuxbrew/bin` last.
- **App library launches**: everything routes through `uwsm-app -- gtk-launch <id>` (omarchy's own test pins it); `gtk-launch` lives in **libgtk-3-bin**, which flurry never pulled — snow gets it via GNOME. This was the "no apps launch, some silently, some 'gtk-launch not found'" report.
- **pulseaudio-utils**: `omarchy-audio-output-sink/-switch` drive `pactl` for bar output switching.

Launch-surface audit against the built image shows no further absences in v4 code paths (playerctl/satty appear only in the stubbed quattro upgrader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)