### PR TITLE
fix(flurry): ship /bin/login; document the sysext lib-shadowing hazard

### DIFF
--- a/shared/packages/flurry/mkosi.conf
+++ b/shared/packages/flurry/mkosi.conf
@@ -230,6 +230,13 @@ Packages=bash-completion
          zbar-tools
          zoxide
 
+# Console login: /bin/login comes from the `login` package (shadow suite),
+# which base does NOT ship -- snow and cayo carry it in their parity
+# blocks. Without it every serial/VT getty dies with "can't exec
+# /bin/login: No such file or directory", discovered live when a broken
+# graphical session made the console the only door (2026-08-25).
+Packages=login
+
 # Filesystems
 Packages=dosfstools
          exfatprogs

--- a/skills/flurry/SKILL.md
+++ b/skills/flurry/SKILL.md
@@ -112,6 +112,14 @@ just flurry                      # or: sudo .mkosi/bin/mkosi --profile flurry -f
   base ships their units); `omarchy-theme-set <theme>` end to end; app
   launches work (`gtk-launch` from libgtk-3-bin — omarchy launches EVERY
   desktop entry via `uwsm-app -- gtk-launch <id>`).
+- **Sysext caveat (root-caused live)**: app sysexts built as deltas vs
+  BASE carry every GUI lib base lacks -- chatgpt/claude-desktop ship
+  trixie's libxkbcommon 1.7, which shadow-downgrades flurry's backports
+  1.13 on merge and kills Hyprland at the next greeter start (harmless
+  same-version shadowing on snow). Until the sysext/product lib story is
+  resolved (see the tracking issue), treat lib-heavy Electron sysexts as
+  incompatible with flurry; recovery is deleting the extension symlink
+  from /var/lib/extensions (offline if needed) and rebooting.
 - incus VM testing: default storage pool may be a small loop file — a
   sparse 50G root + a multi-GB podman pull can ENOSPC-kill qemu (state
   ERROR). Check `incus storage info default` first.


### PR DESCRIPTION
Two findings from tonight's reboot-to-black-screen (root-caused offline via the mounted VM disk):

- **flurry never shipped `/bin/login`** — the `login` package sits in snow/cayo's parity blocks, not base, so every serial/VT getty died with `can't exec /bin/login`. Added with a comment. (This is also a nudge toward auditing what else hides in those parity blocks that is actually functional.)
- **Sysext lib shadowing**: chatgpt/claude-desktop deltas (built vs base) carry trixie GUI libs; merged on flurry they downgrade-shadow the backports stack (`libxkbcommon.so.0` → Hyprland fails `V_1.11.0` symbol lookup → solid-cursor boot). Same shadowing is a harmless same-version no-op on snow, which is why it was never seen. Skill updated with the caveat + recovery; architectural fix tracked in a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)