### PR TITLE
feat(flurry): ship on-machine agent skills — shell-dev and the flurry deltas

### DIFF
--- a/shared/flurry/agent-skills/flurry/SKILL.md
+++ b/shared/flurry/agent-skills/flurry/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: flurry
+description: >
+  REQUIRED companion to the omarchy skill on Flurry (snosi's Debian-based
+  Omarchy). Use whenever installing/removing software, updating the system,
+  managing channels/snapshots/rollback, enabling services (tailscale,
+  docker, 1password), or when any omarchy/Arch advice would invoke pacman,
+  yay, AUR, mkinitcpio, limine, or snapper. Excludes desktop customization
+  (hypr config, bar, themes) — the omarchy skill covers that unchanged.
+---
+
+# Flurry — how this Omarchy differs
+
+This machine looks and behaves like Omarchy, but it is **Flurry**: an
+immutable, image-based Debian system (snosi/bootc). The desktop layer —
+Hyprland config, keybindings, themes, the bar, terminals — is stock
+omarchy; follow the omarchy skill for all of it. Everything below the
+desktop is different, and Arch instructions WILL mislead you.
+
+## Software installation (never pacman/yay/AUR — none exist here)
+
+- GUI apps: `flatpak install <app>` (Flathub is configured).
+- CLI/dev tools: `brew install <tool>` or `mise use -g <tool>`.
+- System services: snosi **sysexts** via
+  `sudo updex --silent features enable <name> --now`
+  (tailscale, docker, 1password, vscode, …; `updex features list`).
+- `apt` exists but MUST NOT install packages: /usr is a read-only image;
+  apt is for inspection only (`apt list --installed`). The `omarchy-pkg-*`
+  and `omarchy-install-*` commands already route to the right mechanism —
+  prefer them.
+- **Sysext warning**: Electron-app sysexts (chatgpt, claude-desktop) are
+  currently incompatible with Flurry — their bundled GUI libraries shadow
+  Flurry's newer graphics stack and break the next login. If a boot lands
+  on a black screen after enabling one, remove its symlink from
+  /var/lib/extensions and reboot.
+
+## Updates, snapshots, rollback
+
+- The OS updates as ONE image, staged automatically (hourly) and applied
+  on reboot. `omarchy-update` triggers the same engine manually. NEVER run
+  raw `bootc upgrade` or suggest `bootc switch <registry-ref>` — the
+  registry-transport pull is broken for these images; the snosi stager
+  (podman transfer) is the only supported path.
+- Status: `snosi-update-status` (root); reboot-pending is announced by
+  motd and a desktop notification.
+- There is exactly one release channel; `omarchy-channel-*` are
+  informational no-ops.
+- No snapper/btrfs snapshots: the previous image IS the snapshot. Broken
+  update → `sudo bootc rollback && sudo reboot`.
+- `omarchy-refresh-limine`/`omarchy-plymouth-set` are no-ops: bootloader
+  and boot splash are baked into the signed image.
+
+## System layout differences
+
+- `/usr` read-only; `/etc` writable and diffable (`snosi-etc-diff`);
+  state in `/var`; homes at `/var/home`; Homebrew at `/home/linuxbrew`
+  (on PATH via omarchy's env-bootstrap).
+- Enabling/disabling systemd services with `systemctl` works as an admin
+  action, but shipped automation must never do it (image policy).
+- Debian package names differ from Arch (fd-find, tealdeer for tldr,
+  libgtk-3-bin for gtk-launch); check `apt list --installed` before
+  telling the user something is missing.
+
+## Not (yet) on Flurry
+
+gpu-screen-recorder (screen recording is stubbed), tensaku, voxtype,
+cliamp, herdr, omacalc/omacut/omawrite, localsend, obsidian, pinta —
+suggest flatpak equivalents where they exist rather than Arch packages.

--- a/shared/flurry/scripts/build/omarchy.chroot
+++ b/shared/flurry/scripts/build/omarchy.chroot
@@ -30,6 +30,41 @@ SKEL="$DESTDIR/etc/skel"
 # --- /usr/share/omarchy: the runtime tree ----------------------------------
 mkdir -p "$OMARCHY"
 cp -a "$SRC"/. "$OMARCHY"/
+# On-machine agent skills: omarchy-provision-user symlinks every directory
+# under default/agents/skills/ into each user's agent skill dirs
+# (~/.claude/skills, ~/.codex/skills, ...). Upstream ships the end-user
+# `omarchy` skill there; we add two:
+# 1. The Quickshell plugin/IPC guide (upstream keeps it repo-only at
+#    agents/skills/shell-dev.md) wrapped as an installable skill, so
+#    on-machine agents can WRITE shell plugins/applets, not just configs.
+#    Deliberate divergence from upstream's install set; grep-guarded so a
+#    re-pin that moves the file forces a re-triage.
+[[ -f "$OMARCHY/agents/skills/shell-dev.md" ]] || {
+    echo "omarchy.chroot: agents/skills/shell-dev.md vanished upstream -- re-triage the shell-dev skill vendoring" >&2
+    exit 1
+}
+mkdir -p "$OMARCHY/default/agents/skills/omarchy-shell-dev"
+{
+    cat <<'FRONTMATTER'
+---
+name: omarchy-shell-dev
+description: >
+  Write or modify Quickshell plugins/widgets/applets for the omarchy shell
+  (bar widgets, panels, IPC handlers). Use when creating a plugin under
+  ~/.config/omarchy/plugins/, editing manifest.json, calling omarchy-shell
+  IPC, or extending the bar beyond what shell.json configures. The plain
+  omarchy skill covers configuration; this one covers plugin CODE.
+---
+
+FRONTMATTER
+    cat "$OMARCHY/agents/skills/shell-dev.md"
+} >"$OMARCHY/default/agents/skills/omarchy-shell-dev/SKILL.md"
+# 2. The Flurry-deltas skill (snosi-authored): stops on-machine agents
+#    giving Arch/pacman advice on this Debian image-based system.
+mkdir -p "$OMARCHY/default/agents/skills/flurry"
+install -m 0644 "$SRCDIR/shared/flurry/agent-skills/flurry/SKILL.md" \
+    "$OMARCHY/default/agents/skills/flurry/SKILL.md"
+
 # Repo-only content that is never installed (omarchy's PKGBUILD excludes
 # these too) and Arch-only machinery that must not ship on Debian/immutable.
 rm -rf "$OMARCHY"/.github "$OMARCHY"/.editorconfig "$OMARCHY"/.gitignore \


### PR DESCRIPTION
Omarchy already symlinks every skill under `default/agents/skills/` into each user's `~/.claude/skills` (and codex/pi/gemini) at provisioning — the mechanism DHH ships for agent-assisted applet building. This PR puts two more skills on that conveyor:

- **omarchy-shell-dev** — upstream's Quickshell plugin contract + IPC guide, repo-only upstream, wrapped with proper frontmatter so on-machine agents can *write* bar widgets and applets. Grep-guarded against re-pin drift like the other vendor divergences.
- **flurry** — the platform deltas an on-machine agent must know before it gives Arch advice: install remaps (flatpak/brew/mise/updex sysexts), image updates + `bootc rollback` (never raw `bootc upgrade`/registry `switch`), single channel, apt-is-inspection-only, `/var/home`, and the Electron-sysext shadowing hazard (#781) with its recovery.

Verified in a full build: the image ships `diagnose-crash`, `flurry`, `omarchy`, `omarchy-shell-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)