### PR TITLE
fix(flurry): screensaver launch, SVG icon rendering, ~/Projects

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -495,6 +495,19 @@ jobs:
             echo "mise_version=${LATEST_MISE#v}" >> $GITHUB_OUTPUT
           fi
 
+          # Check xdg-terminal-exec (vendored into the flurry image over
+          # Debian's 0.12.3, which predates --print-id; the flurry build
+          # fails closed when Debian reaches 0.13, retiring this entry)
+          CURRENT_XTE=$(jq -r '.["xdg-terminal-exec"].version' "$CHECKSUMS")
+          LATEST_XTE=$(gh_api 'https://api.github.com/repos/Vladimir-csp/xdg-terminal-exec/tags?per_page=100' |
+            jq -r '.[].name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' | sort -V | tail -n1)
+          if [[ "$LATEST_XTE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
+             ver_gt "${LATEST_XTE#v}" "$CURRENT_XTE"; then
+            UPDATES="${UPDATES}xdg-terminal-exec: $CURRENT_XTE -> ${LATEST_XTE#v}\n"
+            echo "xte_update=true" >> $GITHUB_OUTPUT
+            echo "xte_version=${LATEST_XTE#v}" >> $GITHUB_OUTPUT
+          fi
+
           # Check Syft CLI used for SBOM generation
           CURRENT_SYFT=$(awk '$1 == "syft-version:" { print $2; exit }' .github/workflows/build-images.yml)
           LATEST_SYFT=$(gh_api https://api.github.com/repos/anchore/syft/releases/latest | jq -r '.tag_name')
@@ -579,6 +592,8 @@ jobs:
           JBM_VERSION: ${{ steps.check.outputs.jbm_version }}
           MISE_UPDATE: ${{ steps.check.outputs.mise_update }}
           MISE_VERSION: ${{ steps.check.outputs.mise_version }}
+          XTE_UPDATE: ${{ steps.check.outputs.xte_update }}
+          XTE_VERSION: ${{ steps.check.outputs.xte_version }}
           SYFT_UPDATE: ${{ steps.check.outputs.syft_update }}
           SYFT_VERSION: ${{ steps.check.outputs.syft_version }}
           COSIGN_UPDATE: ${{ steps.check.outputs.cosign_update }}
@@ -702,6 +717,19 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VERSION" \
               '.mise.url=$u | .mise.sha256=$s | .mise.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$XTE_UPDATE" == "true" ]]; then
+            VERSION="$XTE_VERSION"
+            validate_update_value "xdg-terminal-exec" "$VERSION" '^[0-9]+\.[0-9]+\.[0-9]+$'
+            URL="https://github.com/Vladimir-csp/xdg-terminal-exec/archive/refs/tags/v${VERSION}.tar.gz"
+            TMP=$(mktemp)
+            curl -fsSL --max-time 120 -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VERSION" \
+              '.["xdg-terminal-exec"].url=$u | .["xdg-terminal-exec"].sha256=$s | .["xdg-terminal-exec"].version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/docs/plans/2026-08-25-flurry-omarchy-plan.md
+++ b/docs/plans/2026-08-25-flurry-omarchy-plan.md
@@ -123,6 +123,31 @@ static wants, `Before=display-manager.service`,
 machine's sole uid>=1000 account on first boot, covering every install
 method; SDDM owns the file from the first real login.
 
+Live-VM findings (2026-08-26, root-caused on the user's incus install):
+- **Screensaver refused to launch** ("only runs in Alacritty, Foot, Ghostty,
+  or Kitty"): `omarchy-launch-screensaver` gates on
+  `xdg-terminal-exec --print-id`, which landed upstream in 0.13.0; trixie's
+  0.12.3 *discards* the unknown option (and launches a bare terminal), so the
+  id was always empty. Fixed by vendoring upstream v0.14.3 (single-file
+  POSIX-sh reference implementation, flag superset of 0.12.3) over
+  `/usr/bin/xdg-terminal-exec` in `flurry-extras.chroot` — pinned in
+  `image-checksums.json`, tracked by check-dependencies, and guarded by a
+  build-time `dpkg --compare-versions` check that fails the build (retire
+  signal) once Debian ships >= 0.13. `omarchy-default-terminal`'s show/set
+  flow depends on the same flag.
+- **Nautilus/GTK icons rendered as scaled-up blurs**: Yaru/Adwaita icons are
+  almost entirely SVG and `librsvg2-common` (the SVG gdk-pixbuf loader) is
+  only a Recommends of the GTK stack, which mkosi does not install; snow
+  inherits it via the GNOME meta packages. Added to the flurry package set.
+  (Omarchy's Arch `theme-system.sh` Yaru action-icon symlinks are NOT
+  needed: Debian's yaru-theme-icon already ships
+  go-previous/next-symbolic.svg in scalable/actions.)
+- **Dead `~/Projects` bookmark**: upstream `omarchy-provision-user`
+  bookmarks Projects in gtk-3.0/bookmarks but only mkdirs
+  Downloads/Pictures/Videos — a genuine upstream gap (only the v3→v4
+  upgrade script creates it). Compat-patched the mkdir line; candidate for
+  an upstream basecamp PR.
+
 ## Installer integration (firn, 2026-08-25)
 
 Firn is the installer (single TUI binary; ISO built by snosi's

--- a/shared/download/image-checksums.json
+++ b/shared/download/image-checksums.json
@@ -39,6 +39,11 @@
     "sha256": "f2092b1e67f0abc8803d3be120dd2bc5b656dd99680ba3159f710e149da10d05",
     "version": "2026.8.12"
   },
+  "xdg-terminal-exec": {
+    "url": "https://github.com/Vladimir-csp/xdg-terminal-exec/archive/refs/tags/v0.14.3.tar.gz",
+    "sha256": "82ac2dfdb357361d15f5163cdeb3cfd457bbb30bf5d2e14436393f493bd32afe",
+    "version": "0.14.3"
+  },
   "cosign-installer": {
     "url": "https://github.com/sigstore/cosign/releases/download/v2.6.2/cosign-linux-amd64",
     "sha256": "d437b8f0d30f5dec169337607fcfa0238de1348503e175f1bb5b94330b1ee409",

--- a/shared/flurry/scripts/build/flurry-extras.chroot
+++ b/shared/flurry/scripts/build/flurry-extras.chroot
@@ -31,4 +31,31 @@ find "$FONTDIR" -type f -exec chmod 644 {} +
 verified_download "mise" "$TMP/mise"
 install -D -m 0755 "$TMP/mise" "$DESTDIR/usr/bin/mise"
 
-echo "flurry extras installed: JetBrainsMono Nerd Font ($count faces), mise"
+# --- xdg-terminal-exec (newer upstream over Debian's 0.12.3) -----------------
+# omarchy drives terminal selection through `xdg-terminal-exec --print-id`
+# (omarchy-launch-screensaver gates on the returned entry id;
+# omarchy-default-terminal's whole show/set flow parses it). --print-id
+# landed upstream in 0.13.0; trixie ships 0.12.3, which DISCARDS the unknown
+# option and then launches the default terminal with no command -- the
+# screensaver saw an empty id and refused with "only runs in Alacritty,
+# Foot, Ghostty, or Kitty" (root-caused 2026-08-25 on the live flurry VM).
+# The tool is the single-file POSIX-sh reference implementation, so we vendor
+# the pinned upstream release over the packaged script (the deb stays for its
+# man page and the gnome/ubuntu terminal lists; 0.14.x is a flag superset of
+# 0.12.3, verified against the --app-id/--title/--dir/-e uses in omarchy).
+# The version guard below retires this the moment Debian catches up.
+deb_xte=$(dpkg-query -W -f='${Version}' xdg-terminal-exec)
+if dpkg --compare-versions "$deb_xte" ge 0.13; then
+    echo "flurry-extras.chroot: Debian's xdg-terminal-exec is now $deb_xte (>= 0.13, has --print-id);" >&2
+    echo "retire the vendored copy (this block + the image-checksums.json/check-dependencies.yml entries)" >&2
+    exit 1
+fi
+verified_download "xdg-terminal-exec" "$TMP/xte.tar.gz"
+tar -xzf "$TMP/xte.tar.gz" -C "$TMP" --strip-components=1 --wildcards '*/xdg-terminal-exec'
+grep -q -- '--print-id' "$TMP/xdg-terminal-exec" || {
+    echo "flurry-extras.chroot: vendored xdg-terminal-exec lacks --print-id" >&2
+    exit 1
+}
+install -D -m 0755 "$TMP/xdg-terminal-exec" "$DESTDIR/usr/bin/xdg-terminal-exec"
+
+echo "flurry extras installed: JetBrainsMono Nerd Font ($count faces), mise, xdg-terminal-exec $(jq -r '.["xdg-terminal-exec"].version' "$SRCDIR/shared/download/image-checksums.json") (over deb $deb_xte)"

--- a/shared/flurry/scripts/build/omarchy.chroot
+++ b/shared/flurry/scripts/build/omarchy.chroot
@@ -276,6 +276,15 @@ BREW
 awk -v block="$brew_block" '/^export PATH$/ { print block; print ""; } { print }' "$EB" >"$EB.tmp"
 mv "$EB.tmp" "$EB"
 sh -n "$EB" || { echo "omarchy.chroot: patched env-bootstrap fails sh -n" >&2; exit 1; }
+# Upstream gap (not trixie drift): omarchy-provision-user bookmarks
+# ~/Projects in gtk-3.0/bookmarks but only ever mkdirs Downloads/Pictures/
+# Videos -- the fresh-install path never creates Projects (only the v3->v4
+# upgrade script does), leaving a dead file-manager bookmark. Remove when
+# upstream adds Projects to this mkdir (candidate for an upstream PR).
+compat_patch "$OMARCHY/bin/omarchy-provision-user" \
+    'mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0' \
+    's|mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0|mkdir -p ~/Downloads ~/Projects ~/Pictures ~/Videos ~/.config/gtk-3.0|' \
+    'upstream missing ~/Projects mkdir'
 
 # --- snosi override layer ---------------------------------------------------
 # Whole-file replacements for commands whose Arch mechanics are remapped;

--- a/shared/packages/flurry/mkosi.conf
+++ b/shared/packages/flurry/mkosi.conf
@@ -182,6 +182,12 @@ Packages=chromium
          webp-pixbuf-loader
          gnome-themes-extra
          yaru-theme-icon
+# SVG gdk-pixbuf loader: Yaru/Adwaita icons are almost entirely SVG, and
+# without this loader GTK silently falls back to scaling the few tiny PNGs
+# around -- every Nautilus/GTK icon renders as a blur. It is only a
+# Recommends of the GTK stack (mkosi installs without Recommends); snow
+# inherits it through the GNOME meta packages, flurry must ask.
+         librsvg2-common
          flatpak
 
 # Terminals (foot is omarchy's default; ghostty comes from the griffo

--- a/skills/flurry/SKILL.md
+++ b/skills/flurry/SKILL.md
@@ -32,10 +32,13 @@ changes. Origin story: PRs #772–#778, firn#81, issue #777.
   `flurry-sddm-state-seed.service` (+ `usr/libexec/` script),
   `user-preset/90-flurry.preset`.
 - `shared/flurry/scripts/build/omarchy.chroot` — the vendor script (below).
-- `shared/flurry/scripts/build/flurry-extras.chroot` — Nerd Font + mise.
+- `shared/flurry/scripts/build/flurry-extras.chroot` — Nerd Font + mise +
+  upstream xdg-terminal-exec v0.14.x vendored over Debian's 0.12.3 (omarchy
+  needs `--print-id`, added upstream in 0.13.0; a dpkg version guard fails
+  the build — retire signal — once Debian ships >= 0.13).
 - `shared/flurry/omarchy-overrides/` — whole-file command replacements.
 - `shared/flurry/omarchy-neutralize-allow.txt` — guard allowlist.
-- Pins: `omarchy`, `jetbrains-mono-nerd`, `mise` in
+- Pins: `omarchy`, `jetbrains-mono-nerd`, `mise`, `xdg-terminal-exec` in
   `shared/download/image-checksums.json`, refreshed by
   `.github/workflows/check-dependencies.yml` (omarchy follows release TAGS,
   not HEAD, deliberately).
@@ -69,7 +72,9 @@ changes. Origin story: PRs #772–#778, firn#81, issue #777.
    `monitor.reserved` nil-guard (remove at hyprland ≥ 0.56 in backports);
    foot 1.21 `[colors-dark]`→`[colors]` + `cursor=`→`[cursor]` (remove at
    foot ≥ 1.23); Qt 6.8 QML reserved word `transient` renamed in the
-   notifications plugin (remove at Qt ≥ 6.9); Homebrew PATH appended to
+   notifications plugin (remove at Qt ≥ 6.9); `~/Projects` added to
+   omarchy-provision-user's mkdir (upstream gap — it bookmarks Projects but
+   never creates it; remove when upstream fixes); Homebrew PATH appended to
    `default/bash/env-bootstrap` (the single PATH authority: skel .bashrc,
    uwsm env.d, profile.d, rc chain all source it — hook PATH/env things
    THERE, nowhere else; no shell on either product is a login shell, so


### PR DESCRIPTION
Three issues root-caused on the live flurry install:

## Screensaver never launches
`omarchy-launch-screensaver` gates on `xdg-terminal-exec --print-id` — a flag added upstream in **0.13.0**. Trixie ships **0.12.3**, which *discards* unknown options (and then launches a bare terminal with no command), so the terminal id was always empty and the case statement refused with "Screensaver only runs in Alacritty, Foot, Ghostty, or Kitty".

Fix: vendor upstream **v0.14.3** (the single-file POSIX-sh reference implementation; flag superset of 0.12.3 — verified against every `--app-id`/`--title`/`--dir`/`-e` use in omarchy) over `/usr/bin/xdg-terminal-exec` in `flurry-extras.chroot`. Pinned in `image-checksums.json`, tracked by `check-dependencies.yml` (tags, `ver_gt`-guarded), and a build-time `dpkg --compare-versions` guard fails the build as a retire signal the day Debian ships ≥ 0.13. This also un-breaks `omarchy-default-terminal`'s show/set flow, which parses the same output. The deb stays installed for its man page and the gnome/ubuntu terminal lists.

## Files app icons render as blurs
Yaru/Adwaita icons are almost entirely SVG, and `librsvg2-common` (the SVG gdk-pixbuf loader) is only a *Recommends* of the GTK stack — mkosi installs without Recommends; snow inherits it through the GNOME meta packages. Without it GTK scales the few tiny PNGs around. Added to the flurry package set. (Checked omarchy's Arch-side `theme-system.sh` Yaru action-icon symlinks too: not needed — Debian's yaru-theme-icon already ships `go-previous/next-symbolic.svg`.)

## Dead `~/Projects` bookmark
Genuine upstream gap: `omarchy-provision-user` bookmarks Projects in `gtk-3.0/bookmarks` but only ever mkdirs Downloads/Pictures/Videos (only the v3→v4 upgrade script creates it). Grep-guarded compat patch adds it to the mkdir line; candidate for an upstream basecamp PR. Existing installs where provisioning already marked done need one manual `mkdir ~/Projects`.

## Verification
- Full `flurry` image build green (var-audit clean).
- Shipped `/usr/bin/xdg-terminal-exec` has `--print-id` and resolves `foot.desktop` against the shipped hyprland terminal list (matches the screensaver's `*foot*` arm).
- `libpixbufloader_svg.so` present and registered in `loaders.cache`.
- `~/Projects` present in the patched provision-user mkdir line.
- Split-checksums fixture suites pass (5/5, 34/34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)