### PR TITLE
feat(sysext): build desktop-app sysexts against gui-base (#781)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -274,6 +274,9 @@ jobs:
           ./test/required-by-guard-test.sh
           ./test/etc-overlay-prune-test.sh
 
+      - name: Test gui-base sysext divergent-lib contract
+        run: ./test/sysext-divergent-libs-test.sh
+
   runtime-etc-guard:
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,6 +549,28 @@ nonfatal. The GitHub-release DEB's complete `Depends` expression must pass
 `assert_deb_dependencies_satisfied` before `dpkg -i`; add newly required
 runtime packages through `Packages=` rather than installing them implicitly.
 
+**Desktop-app sysexts build against `gui-base`, not `base` (issue #781):**
+app sysext deltas omit only packages their BUILD BASE has, so base-built
+Electron/GTK deltas carried the whole GUI closure — and products that pin
+those libs from other suites (flurry: xkbcommon/pipewire/alsa/mesa from
+backports) got shadow-DOWNGRADED for all of `/usr` on merge (killed
+Hyprland, root-caused live 2026-08-25). `mkosi.images/gui-base` is an
+internal never-published directory image (base + common GUI lib closure);
+the nine desktop-app sysexts use `Dependencies=gui-base` +
+`BaseTrees=%O/gui-base` + the `sysext-no-divergent-libs.sh` finalize
+tripwire (fails the build on any delta file matching
+`shared/sysext/divergent-lib-families.txt`). THE CONTRACT: every gui-base
+package must be in EVERY desktop product's closure (presence, not
+version, drives delta omission — each product supplies its own suite's
+version at merge). Packages absent from a desktop product stay OUT
+(libxss1/zenity/fonts-liberation/libayatana-appindicator3-1 today).
+Wiring parity and script behavior are pinned by
+`test/sysext-divergent-libs-test.sh` (validate.yml). Server sysexts stay
+base-built (incus needs its qemu GUI libs on cayo); content-only rebases
+require a `SYSEXT_REVISION` bump or the republish silently skips. Full
+pattern: `docs/design/sysexts.md` "Desktop-App Sysexts Build Against
+gui-base".
+
 Sysexts can ONLY provide files under `/usr`. They cannot modify `/etc` or `/var` at runtime. Configs needed in `/etc` must be:
 
 1. Captured to `/usr/share/factory/etc` during build (via `mkosi.finalize`) — capture ONLY the specific paths the sysext's tmpfiles rules reference, never all of `/etc` (the buildroot `/etc` is the merged base view; a full capture ships `/etc/shadow` and SSH host keys in the published sysext)

--- a/docs/design/sysexts.md
+++ b/docs/design/sysexts.md
@@ -463,6 +463,70 @@ succeeds the moment the cache is stale or absent.
   own copy of either will mask newer base state the same way the icon cache
   did. Evaluate per sysext.
 
+## Desktop-App Sysexts Build Against gui-base (issue #781)
+
+App sysexts are `Overlay=yes` deltas: apt omits from the delta exactly the
+packages the *build base* already has. Built against the server-ish `base`,
+an Electron/GTK app's delta carried its whole GUI closure — including
+libraries desktop products pin from **other suites**. Flurry ships
+libxkbcommon/pipewire/alsa/mesa from trixie-backports; the merged delta's
+trixie copy shadow-**downgrades** the product's version for the entire
+`/usr` overlay (root-caused live 2026-08-25: chatgpt + claude-desktop
+deltas shipped libxkbcommon 1.7 over flurry's 1.13 and killed Hyprland at
+the next greeter start with a missing `V_1.11.0` symbol; snow suffered the
+same shadowing on mesa but survived because gbm's ABI tolerated it).
+
+**The fix — `mkosi.images/gui-base`**: an internal, never-published
+directory image (base + the common GUI lib closure). Desktop-app sysexts
+(1password, azurevpn, bitwarden, chatgpt, claude-desktop, edge,
+github-copilot, sunshine, vscode) set `Dependencies=gui-base` +
+`BaseTrees=%O/gui-base`, so their deltas omit the entire common GUI stack
+and each product supplies its own suite's version at merge time.
+
+**The contract** (stated in gui-base's own conf): every package in
+gui-base must be in the installed closure of EVERY desktop product.
+Package *presence* is what drives delta omission — versions are
+irrelevant, so gui-base installs plain trixie even where products use
+backports. A package some desktop product lacks must stay OUT (it would
+strip that lib from deltas and break the app on that product): today
+libxss1 and xdg-utils (absent from snow), zenity / fonts-liberation /
+the ayatana-appindicator+dbusmenu stack (absent from flurry), and
+gnupg2 / libminiupnpc18 (absent from both) stay in the deltas that need
+them, which is safe — a lib no product ships from a divergent suite
+cannot shadow-downgrade anything. The closure can also be GROWN to admit
+a package: chatgpt's deb hard-depends on mesa-vulkan-drivers (the
+divergent mesa family's Vulkan ICDs), which snow never pulled — so
+`shared/packages/snow/mkosi.conf` now ships it explicitly (kept in sync
+with gui-base by comments on both sides). Verification procedure for additions
+(run 2026-08-26): flurry closure = `output/base.manifest` ∪ the flurry
+profile manifest; snow closure = base ∪ `apt-get install --simulate` of
+`shared/packages/snow/mkosi.conf` in a podman trixie container using the
+repo's `mkosi.sandbox/etc/apt` config and base's dpkg status.
+
+**The tripwire**: every gui-base sysext also lists
+`shared/sysext/finalize/sysext-no-divergent-libs.sh` in
+`FinalizeScripts=`, which fails the build if the delta contains any file
+matching `shared/sysext/divergent-lib-families.txt` (xkbcommon, pipewire,
+mesa, alsa, hyprland, systemd families). This catches the two rot modes:
+gui-base losing a package, and apt *upgrading* a lib into the delta
+because the app now requires a newer version than gui-base carries.
+`test/sysext-divergent-libs-test.sh` (wired into `validate.yml`) pins the
+script's behavior plus the wiring parity: BaseTrees=gui-base ⇔ tripwire
+present, in both directions.
+
+**Deliberately still base-built**: server/CLI sysexts, including incus —
+it carries qemu's GUI libs precisely because cayo (no GUI closure) needs
+them in the delta. Consequence: enabling lib-heavy *server* sysexts on
+flurry remains cautioned (skills/flurry/SKILL.md), and sysexts built in
+**other repositories** are outside this guarantee entirely — an updex-side
+merge-time shadow check is the possible future defense for those
+(issue #781's option 4).
+
+**Publishing note**: rebasing a sysext onto gui-base changes content
+without changing its KEYPACKAGE version, so each moved sysext carries a
+`SYSEXT_REVISION` bump — without it the republish is silently skipped
+(`skip-duplicates`) and installs keep the shadowing deltas forever.
+
 ## Adding a New Sysext
 
 1. Create `mkosi.images/<name>/mkosi.conf` following the pattern above

--- a/docs/plans/2026-08-25-flurry-omarchy-plan.md
+++ b/docs/plans/2026-08-25-flurry-omarchy-plan.md
@@ -183,6 +183,13 @@ key pre-creates the home dir, silently skipping skel — fatal for flurry
   as `custom_picker_binary` — verify xdph falls back cleanly, else trim the
   skel config.
 - ufw-docker integration when the docker sysext is enabled.
+- ~~Sysext deltas shadow-downgrading flurry's backports libs (issue
+  #781)~~ FIXED (2026-08-26): the nine desktop-app sysexts now build
+  against `gui-base` so their deltas carry no product-divergent GUI libs;
+  see docs/design/sysexts.md "Desktop-App Sysexts Build Against gui-base".
+  Residual: server sysexts (incus) and externally-built sysexts remain
+  outside the guarantee — an updex merge-time shadow check (issue #781
+  option 4) is the future defense for those.
 - First-login blips seen in the VM, benign but untriaged: a stray ghostty
   instance killed by `omarchy-restart-terminal`'s SIGUSR2 during the initial
   theme-set (terminal selection order?). RESOLVED since: fumon's

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -1,6 +1,8 @@
 [Config]
-# list base + any sysexts that get built by default
+# list base + gui-base (the desktop-app sysext build base, issue #781) +
+# any sysexts that get built by default
 Dependencies=base
+             gui-base
              1password
              1password-cli
              azurevpn

--- a/mkosi.images/1password/mkosi.conf
+++ b/mkosi.images/1password/mkosi.conf
@@ -1,5 +1,8 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Output]
 ImageId=1password
@@ -10,9 +13,9 @@ Format=sysext
 
 [Content]
 Bootable=no
-BaseTrees=%O/base
+BaseTrees=%O/gui-base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
 
 # 1Password desktop app. Installed by mkosi.postinst.chroot from a pinned
 # .deb via verified_download (NOT Packages=1password from the apt repo: the
@@ -44,3 +47,7 @@ Packages=curl
 
 [Build]
 Environment=KEYPACKAGE=1password
+# SYSEXT_REVISION forces a republish of the gui-base rebuild (issue #781)
+# even though KEYPACKAGE's version is unchanged; remove when the package
+# version next bumps.
+Environment=SYSEXT_REVISION=1

--- a/mkosi.images/azurevpn/mkosi.conf
+++ b/mkosi.images/azurevpn/mkosi.conf
@@ -1,5 +1,8 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Output]
 ImageId=azurevpn
@@ -10,7 +13,7 @@ Format=sysext
 
 [Content]
 Bootable=no
-BaseTrees=%O/base
+BaseTrees=%O/gui-base
 # Downloads the pinned Azure VPN client .deb via verified_download, relocates
 # /opt/microsoft/microsoft-azurevpnclient -> /usr/lib/microsoft-azurevpnclient,
 # patchelf-fixes the rpaths, adapts the polkit rules to Debian, and sets
@@ -20,7 +23,7 @@ BaseTrees=%O/base
 # profiles need a runtime setcap workaround service.
 PostInstallationScripts=%D/shared/packages/azurevpn/mkosi.postinst.d/azurevpn.chroot
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
 
 [Include]
 # Build tool + runtime deps for the .deb
@@ -28,3 +31,7 @@ Include=%D/shared/packages/azurevpn/mkosi.conf
 
 [Build]
 Environment=KEYPACKAGE=microsoft-azurevpnclient
+# SYSEXT_REVISION forces a republish of the gui-base rebuild (issue #781)
+# even though KEYPACKAGE's version is unchanged; remove when the package
+# version next bumps.
+Environment=SYSEXT_REVISION=1

--- a/mkosi.images/bitwarden/mkosi.conf
+++ b/mkosi.images/bitwarden/mkosi.conf
@@ -1,5 +1,8 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Output]
 ImageId=bitwarden
@@ -10,13 +13,13 @@ Format=sysext
 
 [Content]
 Bootable=no
-BaseTrees=%O/base
+BaseTrees=%O/gui-base
 # Downloads the pinned Bitwarden .deb via verified_download, relocates
 # /opt/Bitwarden -> /usr/lib/Bitwarden, fixes the /usr/bin symlinks and the
 # desktop file Exec
 PostInstallationScripts=%D/shared/packages/bitwarden/mkosi.postinst.d/bitwarden.chroot
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
 
 [Include]
 # Runtime deps for the Bitwarden .deb
@@ -24,3 +27,7 @@ Include=%D/shared/packages/bitwarden/mkosi.conf
 
 [Build]
 Environment=KEYPACKAGE=bitwarden
+# SYSEXT_REVISION forces a republish of the gui-base rebuild (issue #781)
+# even though KEYPACKAGE's version is unchanged; remove when the package
+# version next bumps.
+Environment=SYSEXT_REVISION=1

--- a/mkosi.images/chatgpt/mkosi.conf
+++ b/mkosi.images/chatgpt/mkosi.conf
@@ -1,5 +1,8 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Output]
 ImageId=chatgpt
@@ -10,9 +13,9 @@ Format=sysext
 
 [Content]
 Bootable=no
-BaseTrees=%O/base
+BaseTrees=%O/gui-base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
 
 # ChatGPT desktop app with Codex (from the official OpenAI APT repository at
 # persistent.oaistatic.com/codex-app-prod/linux/deb in mkosi.sandbox).
@@ -31,3 +34,7 @@ Packages=chatgpt
 
 [Build]
 Environment=KEYPACKAGE=chatgpt
+# SYSEXT_REVISION forces a republish of the gui-base rebuild (issue #781)
+# even though KEYPACKAGE's version is unchanged; remove when the package
+# version next bumps.
+Environment=SYSEXT_REVISION=1

--- a/mkosi.images/claude-desktop/mkosi.conf
+++ b/mkosi.images/claude-desktop/mkosi.conf
@@ -1,5 +1,8 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Output]
 ImageId=claude-desktop
@@ -10,9 +13,9 @@ Format=sysext
 
 [Content]
 Bootable=no
-BaseTrees=%O/base
+BaseTrees=%O/gui-base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
 
 # Claude desktop app (from downloads.claude.ai/claude-desktop/apt in
 # mkosi.sandbox). Installs entirely under /usr — no /opt relocation needed.
@@ -26,3 +29,7 @@ Packages=claude-desktop
 
 [Build]
 Environment=KEYPACKAGE=claude-desktop
+# SYSEXT_REVISION forces a republish of the gui-base rebuild (issue #781)
+# even though KEYPACKAGE's version is unchanged; remove when the package
+# version next bumps.
+Environment=SYSEXT_REVISION=1

--- a/mkosi.images/edge/mkosi.conf
+++ b/mkosi.images/edge/mkosi.conf
@@ -1,5 +1,8 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Output]
 ImageId=edge
@@ -15,7 +18,7 @@ Bootable=no
 # logos into hicolor
 PostInstallationScripts=%D/shared/packages/edge/mkosi.postinst.d/edge.chroot
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
 
 [Include]
 # Runtime deps + BaseTrees for the Edge .deb
@@ -25,4 +28,4 @@ Include=%D/shared/packages/edge/mkosi.conf
 Environment=KEYPACKAGE=microsoft-edge-stable
 # r1 (2026-07-07): republish with the alternatives-symlink repoint (dangling
 # /etc/alternatives targets via sysext). Remove when the Edge version bumps.
-Environment=SYSEXT_REVISION=1
+Environment=SYSEXT_REVISION=2

--- a/mkosi.images/github-copilot/mkosi.conf
+++ b/mkosi.images/github-copilot/mkosi.conf
@@ -1,5 +1,8 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Output]
 ImageId=github-copilot
@@ -10,12 +13,16 @@ Format=sysext
 
 [Content]
 Bootable=no
-BaseTrees=%O/base
+BaseTrees=%O/gui-base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
 Packages=libayatana-appindicator3-1
          libwebkit2gtk-4.1-0
          libgtk-3-0
 
 [Build]
 Environment=KEYPACKAGE=github
+# SYSEXT_REVISION forces a republish of the gui-base rebuild (issue #781)
+# even though KEYPACKAGE's version is unchanged; remove when the package
+# version next bumps.
+Environment=SYSEXT_REVISION=1

--- a/mkosi.images/gui-base/mkosi.conf
+++ b/mkosi.images/gui-base/mkosi.conf
@@ -1,0 +1,126 @@
+# gui-base: the build base for DESKTOP-APP sysexts (issue #781).
+#
+# App sysexts are Overlay=yes deltas: every package the build base already
+# has is omitted from the delta at apt level. Built against the server-ish
+# `base`, an Electron/GTK app's delta carried its entire GUI lib closure --
+# including libs the desktop products ship from OTHER SUITES (flurry pins
+# libxkbcommon/pipewire/mesa from trixie-backports), and the merged sysext
+# copy shadow-DOWNGRADED the product's lib for all of /usr (root-caused
+# live 2026-08-25: chatgpt + claude-desktop deltas shipped trixie
+# libxkbcommon 1.7 over flurry's backports 1.13 and killed Hyprland with a
+# missing V_1.11.0 symbol; snow survived the same shadowing only because
+# its versions happened to match).
+#
+# gui-base = base + the common GUI lib closure. THE CONTRACT: every package
+# listed here MUST be in the installed closure of EVERY desktop product
+# (snow, snowfield, flurry -- snowfield shares snow's package set). The
+# versions here are irrelevant -- delta omission is decided by package
+# PRESENCE, and each product supplies its own version at merge time (snow's
+# trixie pipewire, flurry's backports pipewire). Adding a package here that
+# some desktop product lacks makes app sysexts lose that lib on that
+# product, so additions must be re-verified against both closures (base +
+# profile manifest for flurry; base + apt --simulate of
+# shared/packages/snow/mkosi.conf for snow -- the 2026-08-26 verification
+# procedure is recorded in docs/design/sysexts.md).
+#
+# Deliberately NOT here (verified absent from at least one desktop
+# product's closure, 2026-08-26): libxss1 (snow), zenity (flurry),
+# fonts-liberation (flurry), the libayatana-appindicator/libdbusmenu stack
+# (flurry), xdg-utils (snow), gnupg2 and libminiupnpc18 (both) -- those
+# stay in the deltas that need them, which is safe: a lib no product ships
+# from a divergent suite cannot shadow-downgrade anything.
+#
+# This image is an internal build stage: never published, no transfer, no
+# postoutput. Server/CLI sysexts stay on `base` (incus deliberately so: it
+# needs its qemu GUI libs present on cayo, which lacks this closure --
+# enabling lib-heavy server sysexts on flurry remains cautioned in
+# skills/flurry/SKILL.md).
+
+[Config]
+Dependencies=base
+
+[Output]
+Format=directory
+ImageId=gui-base
+Output=gui-base
+ImageVersion=
+ManifestFormat=json
+
+[Content]
+Bootable=no
+CleanPackageMetadata=no
+WithDocs=yes
+BaseTrees=%O/base
+
+# GTK3 stack (every product ships GTK3: snow via GNOME, flurry explicitly)
+Packages=libgtk-3-0t64
+         libgdk-pixbuf-2.0-0
+         libpango-1.0-0
+         libpangocairo-1.0-0
+         libcairo-gobject2
+         libcairo-script-interpreter2
+         libatk1.0-0t64
+         libatk-bridge2.0-0t64
+         libatspi2.0-0t64
+         libepoxy0
+         libharfbuzz0b
+         libharfbuzz-subset0
+
+# GTK4/libadwaita stack (snow via GNOME, flurry via nautilus)
+Packages=libgtk-4-1
+         libgtk-4-common
+         libadwaita-1-0
+         libgraphene-1.0-0
+
+# X11/Wayland client libs
+Packages=libxcomposite1
+         libxcb-shape0
+         libxkbfile1
+         libxdamage1
+         libxfixes3
+         libxrandr2
+         libxcursor1
+         libxi6
+         libxinerama1
+         libxtst6
+         libwayland-client0
+         libwayland-cursor0
+         libwayland-egl1
+         libxkbcommon0
+         libxkbcommon-x11-0
+
+# GPU userspace (mesa is a DIVERGENT family: flurry gets 26.x from
+# backports via the hyprland closure while snow tracks trixie -- exactly
+# the class this image exists to keep out of deltas)
+Packages=libgbm1
+         libgl1
+         libegl1
+         libgles2
+         mesa-libgallium
+         libvulkan1
+# mesa-vulkan-drivers: chatgpt's deb hard-depends on it, and the mesa ICDs
+# are the same divergent mesa family. Snow did not pull it until
+# shared/packages/snow/mkosi.conf added it for exactly this contract
+# (2026-08-26) -- keep the two in sync.
+         mesa-vulkan-drivers
+# VA-API client libs (hardware video accel; snow via GNOME, flurry via mpv)
+         libva2
+         libva-drm2
+
+# Audio (alsa + pipewire client are divergent on flurry: backports)
+Packages=libasound2t64
+         libpipewire-0.3-0t64
+         libpulse0
+
+# Desktop plumbing common to Electron/GTK apps
+Packages=libnotify4
+         libsecret-1-0
+         libcups2t64
+         libevdev2
+         libinput10
+         libwebkit2gtk-4.1-0
+         libglib2.0-bin
+         libglib2.0-data
+         libnuma1
+         xdg-desktop-portal
+         xdg-desktop-portal-gtk

--- a/mkosi.images/sunshine/mkosi.conf
+++ b/mkosi.images/sunshine/mkosi.conf
@@ -1,5 +1,8 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Output]
 ImageId=sunshine
@@ -10,9 +13,9 @@ Format=sysext
 
 [Content]
 Bootable=no
-BaseTrees=%O/base
+BaseTrees=%O/gui-base
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
 Packages=debianutils
          libcap2
          libcurl4t64
@@ -39,3 +42,7 @@ Packages=debianutils
 
 [Build]
 Environment=KEYPACKAGE=sunshine
+# SYSEXT_REVISION forces a republish of the gui-base rebuild (issue #781)
+# even though KEYPACKAGE's version is unchanged; remove when the package
+# version next bumps.
+Environment=SYSEXT_REVISION=1

--- a/mkosi.images/vscode/mkosi.conf
+++ b/mkosi.images/vscode/mkosi.conf
@@ -1,5 +1,8 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Output]
 ImageId=vscode
@@ -10,14 +13,18 @@ Format=sysext
 
 [Content]
 Bootable=no
-BaseTrees=%O/base
+BaseTrees=%O/gui-base
 # Adds inode/directory to code.desktop's MimeType
 PostInstallationScripts=%D/shared/packages/vscode/mkosi.postinst.d/vscode.chroot
 PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
-FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
 
 # Visual Studio Code (from packages.microsoft.com/repos/code in mkosi.sandbox)
 Packages=code
 
 [Build]
 Environment=KEYPACKAGE=code
+# SYSEXT_REVISION forces a republish of the gui-base rebuild (issue #781)
+# even though KEYPACKAGE's version is unchanged; remove when the package
+# version next bumps.
+Environment=SYSEXT_REVISION=1

--- a/shared/packages/edge/mkosi.conf
+++ b/shared/packages/edge/mkosi.conf
@@ -1,8 +1,11 @@
 [Config]
-Dependencies=base
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
 
 [Content]
-BaseTrees=%O/base
+BaseTrees=%O/gui-base
 
 # Runtime deps from microsoft-edge-stable's Depends (installed via mkosi's
 # host-side apt so dpkg -i in the postinst can install the patched .deb).

--- a/shared/packages/snow/mkosi.conf
+++ b/shared/packages/snow/mkosi.conf
@@ -64,6 +64,15 @@ Packages=libnotify-bin
 # automount in Files. Graphical images only — cayo has no gvfs/libmtp at all.
 Packages=libmtp-runtime
 
+# Vulkan ICDs. Two reasons: real hardware support (nothing in the GNOME
+# stack pulls the mesa Vulkan drivers -- only the loader libvulkan1 -- so
+# Vulkan-capable apps silently fell back to software), and the gui-base
+# desktop-sysext contract (issue #781): chatgpt's deb hard-depends on
+# mesa-vulkan-drivers, so mkosi.images/gui-base must carry it, and every
+# gui-base package must be in EVERY desktop product's closure. Keep in
+# sync with mkosi.images/gui-base/mkosi.conf.
+Packages=mesa-vulkan-drivers
+
 
 # nspawn
 Packages=systemd-container

--- a/shared/sysext/divergent-lib-families.txt
+++ b/shared/sysext/divergent-lib-families.txt
@@ -1,0 +1,54 @@
+# Shared-library families that at least one desktop product ships from a
+# non-trixie suite (backports/forky), so a sysext delta copy would
+# shadow-DOWNGRADE the product's version for the whole merged /usr
+# (issue #781; root-caused live 2026-08-25 on flurry).
+#
+# Format: one shell glob per line, matched against paths RELATIVE to the
+# delta's /usr (e.g. lib/x86_64-linux-gnu/libxkbcommon.so.0.0.0).
+# Comments and blank lines ignored.
+#
+# A match in a gui-base-built sysext delta fails the build
+# (shared/sysext/finalize/sysext-no-divergent-libs.sh): it means either
+# gui-base lost the package or apt upgraded the lib INTO the delta because
+# the app now needs a newer version than gui-base carries -- both need
+# re-triage, never normalization.
+
+# xkbcommon (flurry: trixie-backports 1.13 vs trixie 1.7 -- the original
+# Hyprland-killing case)
+lib/*/libxkbcommon*.so*
+lib/*/libxkbregistry*.so*
+
+# pipewire family (flurry: trixie-backports 1.4.9 vs trixie 1.4.2)
+lib/*/libpipewire*.so*
+lib/*/pipewire-0.3/*
+lib/*/spa-0.2/*
+lib/*/libwireplumber*.so*
+
+# mesa userspace (flurry: trixie-backports 26.x via the hyprland closure).
+# Includes the mesa-vulkan-drivers ICDs and layers -- chatgpt's deb
+# hard-depends on that package, which is why gui-base and
+# shared/packages/snow both carry it.
+lib/*/libgbm.so*
+lib/*/libgallium*.so*
+lib/*/libEGL_mesa*.so*
+lib/*/libGLX_mesa*.so*
+lib/*/dri/*
+lib/*/gbm/*
+lib/*/libvulkan_*.so*
+lib/*/libVkLayer_*.so*
+
+# alsa (flurry: trixie-backports 1.2.16 vs trixie 1.2.14)
+lib/*/libasound.so*
+
+# hyprland closure (flurry-only, all trixie-backports; no app sysext should
+# ever carry these, so any match is a hard recipe error)
+lib/*/libhyprutils*.so*
+lib/*/libhyprlang*.so*
+lib/*/libhyprcursor*.so*
+lib/*/libhyprgraphics*.so*
+lib/*/libaquamarine*.so*
+
+# systemd libraries (secure bootc products ship the forky systemd family;
+# theoretical member of the class -- no sysext ships these today)
+lib/*/libsystemd.so*
+lib/*/libudev.so*

--- a/shared/sysext/finalize/sysext-no-divergent-libs.sh
+++ b/shared/sysext/finalize/sysext-no-divergent-libs.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Shared finalize script for gui-base-built (desktop-app) sysexts: fail the
+# build if the delta ships any shared library from a product-divergent
+# family (shared/sysext/divergent-lib-families.txt).
+#
+# Why (issue #781): app sysext deltas omit only packages their BUILD BASE
+# already has. A delta copy of a lib that a desktop product ships from a
+# different suite shadow-downgrades the product's version for the whole
+# merged /usr — chatgpt/claude-desktop deltas built against `base` shipped
+# trixie libxkbcommon 1.7 over flurry's backports 1.13 and killed Hyprland
+# (root-caused live 2026-08-25). gui-base keeps those families out of the
+# delta by construction; this tripwire catches the two ways the
+# construction can silently rot: gui-base losing a package, or apt
+# UPGRADING a lib into the delta because the app began requiring a newer
+# version than gui-base carries. Both are re-triage events, so this fails
+# the build rather than warning.
+#
+# Scope: wired only into sysexts whose BaseTrees is %O/gui-base. Server
+# sysexts (incus with its qemu GUI libs, needed on cayo) legitimately carry
+# some of these families and must NOT get this check.
+set -euo pipefail
+
+FAMILIES_FILE="$SRCDIR/shared/sysext/divergent-lib-families.txt"
+if [[ ! -f "$FAMILIES_FILE" ]]; then
+    echo "sysext-no-divergent-libs: $FAMILIES_FILE not found" >&2
+    exit 1
+fi
+
+[[ -d "$BUILDROOT/usr" ]] || {
+    echo "sysext-no-divergent-libs: no /usr in the delta buildroot?" >&2
+    exit 1
+}
+
+shopt -s nullglob globstar
+offenders=()
+patterns=0
+while IFS= read -r glob; do
+    glob="${glob%%#*}"
+    glob="${glob#"${glob%%[![:space:]]*}"}"
+    glob="${glob%"${glob##*[![:space:]]}"}"
+    [[ -n "$glob" ]] || continue
+    patterns=$((patterns + 1))
+    # Globs are relative to the delta's /usr; a trailing dir glob (…/*)
+    # matches direct children, which is enough to flag the family.
+    for match in "$BUILDROOT/usr/"$glob; do
+        offenders+=("${match#"$BUILDROOT"}")
+    done
+done < "$FAMILIES_FILE"
+
+if (( patterns == 0 )); then
+    echo "sysext-no-divergent-libs: $FAMILIES_FILE contains no patterns; refusing to pass vacuously" >&2
+    exit 1
+fi
+
+if (( ${#offenders[@]} > 0 )); then
+    echo "sysext-no-divergent-libs: ${IMAGE_ID:-sysext} delta ships product-divergent library files:" >&2
+    printf '  %s\n' "${offenders[@]}" >&2
+    cat >&2 <<'EOF'
+These families are pinned from backports/forky by at least one desktop
+product; a delta copy shadow-downgrades the product's version for the whole
+merged /usr (issue #781). Either gui-base lost the owning package, or apt
+pulled a newer version into the delta because this app now requires more
+than gui-base carries. Fix gui-base (mkosi.images/gui-base/mkosi.conf) or
+re-triage the family — do not remove the pattern to make the build pass.
+EOF
+    exit 1
+fi
+
+echo "sysext-no-divergent-libs: ${IMAGE_ID:-sysext} delta clean ($patterns family patterns checked)"

--- a/skills/flurry/SKILL.md
+++ b/skills/flurry/SKILL.md
@@ -117,14 +117,18 @@ just flurry                      # or: sudo .mkosi/bin/mkosi --profile flurry -f
   base ships their units); `omarchy-theme-set <theme>` end to end; app
   launches work (`gtk-launch` from libgtk-3-bin — omarchy launches EVERY
   desktop entry via `uwsm-app -- gtk-launch <id>`).
-- **Sysext caveat (root-caused live)**: app sysexts built as deltas vs
-  BASE carry every GUI lib base lacks -- chatgpt/claude-desktop ship
-  trixie's libxkbcommon 1.7, which shadow-downgrades flurry's backports
-  1.13 on merge and kills Hyprland at the next greeter start (harmless
-  same-version shadowing on snow). Until the sysext/product lib story is
-  resolved (see the tracking issue), treat lib-heavy Electron sysexts as
-  incompatible with flurry; recovery is deleting the extension symlink
-  from /var/lib/extensions (offline if needed) and rebooting.
+- **Sysext caveat (root-caused live, fixed for frostyard desktop
+  sysexts)**: app sysext deltas omit only packages their BUILD BASE has;
+  base-built Electron deltas carried trixie libxkbcommon 1.7, which
+  shadow-downgraded flurry's backports 1.13 on merge and killed Hyprland
+  at the next greeter start. Frostyard's nine desktop-app sysexts now
+  build against `gui-base` (docs/design/sysexts.md "Desktop-App Sysexts
+  Build Against gui-base") so their deltas carry no product-divergent
+  libs -- but only REPUBLISHED builds have the fix (check the sysext's
+  publish date), SERVER sysexts (incus, with qemu's GUI libs for cayo)
+  still carry the hazard, and sysexts from other repos are outside the
+  guarantee. Recovery from a shadowed session: delete the extension
+  symlink from /var/lib/extensions (offline if needed) and reboot.
 - incus VM testing: default storage pool may be a small loop file — a
   sparse 50G root + a multi-GB podman pull can ENOSPC-kill qemu (state
   ERROR). Check `incus storage info default` first.

--- a/test/sysext-divergent-libs-test.sh
+++ b/test/sysext-divergent-libs-test.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Fixture suite for the gui-base desktop-sysext contract (issue #781):
+#  - shared/sysext/finalize/sysext-no-divergent-libs.sh behavior (a delta
+#    carrying a product-divergent lib family fails the build; a clean delta
+#    passes; an empty family list fails vacuous passes)
+#  - static wiring parity: every sysext built against gui-base carries the
+#    no-divergent-libs finalize, and vice versa (a tripwire without the
+#    gui-base rebase, or a rebase without the tripwire, is half a fix —
+#    the exact split-brain that let issue #781's class ship)
+#  - gui-base image shape: internal-only (directory format, no transfer,
+#    no postoutput), listed in the root build set
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+script="$root/shared/sysext/finalize/sysext-no-divergent-libs.sh"
+families="$root/shared/sysext/divergent-lib-families.txt"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+test_number=0
+failures=0
+
+ok() {
+    test_number=$((test_number + 1))
+    echo "ok $test_number - $1"
+}
+
+fail() {
+    test_number=$((test_number + 1))
+    failures=$((failures + 1))
+    echo "not ok $test_number - $1"
+    [[ -n ${2:-} ]] && sed "s/^/#   /" <<<"$2"
+}
+
+# The script resolves the family list as $SRCDIR/shared/sysext/...; build a
+# fake SRCDIR per case so tests never depend on (or mutate) the real file.
+make_srcdir() { # name family-content -> path
+    local d="$work/$1/src"
+    mkdir -p "$d/shared/sysext"
+    printf '%s\n' "$2" >"$d/shared/sysext/divergent-lib-families.txt"
+    echo "$d"
+}
+
+make_delta() { # name -> path (empty /usr skeleton)
+    local d="$work/$1/delta"
+    mkdir -p "$d/usr/lib/x86_64-linux-gnu"
+    echo "$d"
+}
+
+# --- case 1: clean delta passes -------------------------------------------
+src=$(make_srcdir clean 'lib/*/libxkbcommon*.so*')
+delta=$(make_delta clean)
+touch "$delta/usr/lib/x86_64-linux-gnu/libfoo.so.1"
+if out=$(BUILDROOT="$delta" SRCDIR="$src" IMAGE_ID=testext "$script" 2>&1); then
+    ok "clean delta passes"
+else
+    fail "clean delta passes" "$out"
+fi
+
+# --- case 2: divergent lib fails, names the file --------------------------
+src=$(make_srcdir dirty 'lib/*/libxkbcommon*.so*')
+delta=$(make_delta dirty)
+touch "$delta/usr/lib/x86_64-linux-gnu/libxkbcommon.so.0.0.0"
+if out=$(BUILDROOT="$delta" SRCDIR="$src" IMAGE_ID=testext "$script" 2>&1); then
+    fail "divergent lib fails the build" "$out"
+elif [[ $out == *libxkbcommon.so.0.0.0* && $out == *"do not remove the pattern"* ]]; then
+    ok "divergent lib fails the build and names the offender"
+else
+    fail "divergent lib failure output names the offender" "$out"
+fi
+
+# --- case 3: directory-family glob (pipewire modules dir) -----------------
+src=$(make_srcdir dirglob 'lib/*/spa-0.2/*')
+delta=$(make_delta dirglob)
+mkdir -p "$delta/usr/lib/x86_64-linux-gnu/spa-0.2/support"
+if out=$(BUILDROOT="$delta" SRCDIR="$src" IMAGE_ID=testext "$script" 2>&1); then
+    fail "directory family glob fails the build" "$out"
+else
+    ok "directory family glob fails the build"
+fi
+
+# --- case 4: comments/blank lines ignored, empty list refuses -------------
+src=$(make_srcdir empty '# only comments
+
+# here')
+delta=$(make_delta empty)
+if out=$(BUILDROOT="$delta" SRCDIR="$src" IMAGE_ID=testext "$script" 2>&1); then
+    fail "pattern-free family list refuses to pass" "$out"
+elif [[ $out == *vacuously* ]]; then
+    ok "pattern-free family list refuses to pass vacuously"
+else
+    fail "pattern-free family list error message" "$out"
+fi
+
+# --- case 5: missing family list fails ------------------------------------
+delta=$(make_delta nofile)
+if out=$(BUILDROOT="$delta" SRCDIR="$work/nofile/does-not-exist" IMAGE_ID=testext "$script" 2>&1); then
+    fail "missing family list fails" "$out"
+else
+    ok "missing family list fails"
+fi
+
+# --- case 6: real family list is non-empty and covers the known families --
+if [[ -f "$families" ]]; then
+    ok "shipped divergent-lib-families.txt exists"
+else
+    fail "shipped divergent-lib-families.txt exists"
+fi
+for fam in libxkbcommon libpipewire libgbm libasound spa-0.2; do
+    if grep -q "$fam" "$families"; then
+        ok "family list covers $fam"
+    else
+        fail "family list covers $fam"
+    fi
+done
+
+# --- case 7: wiring parity across mkosi.images ----------------------------
+declare -a rebased=() wired=()
+for conf in "$root"/mkosi.images/*/mkosi.conf; do
+    img=$(basename "$(dirname "$conf")")
+    uses_gui_base=no
+    grep -q '^BaseTrees=%O/gui-base' "$conf" && uses_gui_base=yes
+    # edge keeps its BaseTrees in an [Include]d fragment
+    while IFS= read -r inc; do
+        inc=${inc#Include=}
+        inc=${inc//%D/$root}
+        [[ -f $inc ]] && grep -q '^BaseTrees=%O/gui-base' "$inc" && uses_gui_base=yes
+    done < <(grep '^Include=' "$conf" || true)
+    has_tripwire=no
+    grep -q 'sysext-no-divergent-libs.sh' <(grep '^FinalizeScripts=' "$conf") && has_tripwire=yes
+    [[ $uses_gui_base == yes ]] && rebased+=("$img")
+    [[ $has_tripwire == yes ]] && wired+=("$img")
+    if [[ $uses_gui_base != "$has_tripwire" ]]; then
+        fail "$img: gui-base rebase and no-divergent-libs tripwire must come together (BaseTrees=gui-base: $uses_gui_base, tripwire: $has_tripwire)"
+    fi
+done
+if ((${#rebased[@]} > 0)); then
+    ok "gui-base sysexts all carry the tripwire and vice versa (${#rebased[@]} images: ${rebased[*]})"
+else
+    fail "at least one sysext is built against gui-base"
+fi
+
+# every gui-base sysext must also depend on gui-base so mkosi orders builds
+for img in "${rebased[@]}"; do
+    if grep -q '^Dependencies=gui-base' "$root/mkosi.images/$img/mkosi.conf"; then
+        ok "$img depends on gui-base"
+    else
+        fail "$img depends on gui-base"
+    fi
+done
+
+# --- case 8: gui-base image shape -----------------------------------------
+gb="$root/mkosi.images/gui-base/mkosi.conf"
+if [[ -f $gb ]] && grep -q '^Format=directory' "$gb" &&
+    ! grep -q 'PostOutputScripts' "$gb" && ! grep -q 'KEYPACKAGE' "$gb"; then
+    ok "gui-base is an internal directory image (no postoutput, no KEYPACKAGE)"
+else
+    fail "gui-base is an internal directory image"
+fi
+if [[ ! -d "$root/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.gui-base.d" ]]; then
+    ok "gui-base has no sysupdate transfer (never published)"
+else
+    fail "gui-base has no sysupdate transfer"
+fi
+if awk '/^Dependencies=/{f=1} f&&/gui-base/{found=1} /^\[/{if(NR>1)f=0} END{exit !found}' "$root/mkosi.conf"; then
+    ok "root mkosi.conf builds gui-base by default"
+else
+    fail "root mkosi.conf builds gui-base by default"
+fi
+
+echo
+echo "# Results: $((test_number - failures)) passed, $failures failed, $test_number total"
+((failures == 0))


### PR DESCRIPTION
Fixes #781 for every frostyard-built desktop sysext.

## Mechanism recap
App sysexts are `Overlay=yes` deltas — apt omits from the delta exactly the packages the **build base** already has. Built against the server-ish `base`, an Electron/GTK app's delta carried its entire GUI closure, including libs the desktop products pin from **other suites**: flurry ships xkbcommon/pipewire/alsa/**mesa** from trixie-backports, so the merged delta's trixie copy shadow-**downgraded** the product's lib for all of `/usr` (chatgpt + claude-desktop killed Hyprland via libxkbcommon 1.7-over-1.13; en route we found snow was silently taking the same shadowing on mesa — its backports surface is bigger than the issue assumed).

## The fix: one intersection base, not a per-product matrix
`mkosi.images/gui-base` — an internal, never-published directory image (base + 54 common GUI lib packages). The nine desktop-app sysexts (1password, azurevpn, bitwarden, chatgpt, claude-desktop, edge, github-copilot, sunshine, vscode) set `Dependencies=gui-base` + `BaseTrees=%O/gui-base`. Key insight: package **presence**, not version, drives delta omission — each product supplies its own suite's version at merge time, so one base serves snow, snowfield, and flurry with **no updex changes, no transfer relocation, no publish-matrix growth**.

**The contract** (in gui-base's conf): every gui-base package must be in every desktop product's closure. Verified against base+flurry build manifests and a podman `apt --simulate` of snow's package set (procedure recorded in `docs/design/sysexts.md`). Packages absent from a product stay in deltas (libxss1, zenity, fonts-liberation, ayatana stack, xdg-utils, gnupg2, miniupnpc — safe: nothing they could shadow). One package went the other way: **chatgpt hard-depends on `mesa-vulkan-drivers`** (divergent mesa family), which snow never pulled — so snow's package set now ships it explicitly, which also gives snow/snowfield real Vulkan ICDs for the first time (previously only the loader).

## Fail-closed guards
- `shared/sysext/finalize/sysext-no-divergent-libs.sh` + `shared/sysext/divergent-lib-families.txt`: any gui-base sysext delta containing a file from the divergent families (xkbcommon, pipewire, mesa incl. vulkan ICDs/layers, alsa, hyprland, systemd) **fails the build** — catching gui-base losing a package or apt upgrading a lib into the delta because an app now needs newer than gui-base carries.
- `test/sysext-divergent-libs-test.sh` (24 cases, wired into validate.yml): script behavior fixtures plus static wiring parity — `BaseTrees=gui-base` ⇔ tripwire present, in both directions, so the fix can't half-apply to a future sysext.
- Every moved sysext carries a `SYSEXT_REVISION` bump so the content-only rebuild actually republishes (publishing skips existing filenames).

## Deliberately out of scope
- **incus stays base-built**: it carries qemu's GUI libs *for cayo*, which lacks the closure. Enabling lib-heavy server sysexts on flurry remains cautioned in the flurry skill.
- **Externally-built sysexts** are outside this guarantee — issue #781's option 4 (updex merge-time shadow check) is the future defense; noted in docs.

## Verification (full local build, both before/after)
- All 23 sysexts + gui-base build green; all nine tripwires ran clean (22 family patterns).
- chatgpt delta: **126 system shared libs → 0** (`systemd-dissect --list`); claude-desktop **248 → 0**; sunshine's 12 remaining system libs are exactly the exception-list ayatana/dbusmenu/miniupnpc set.
- Per-sysext manifests collapsed to app + exception-list packages only (e.g. chatgpt: `[chatgpt, xdg-utils]`).
- `test/sysext-divergent-libs-test.sh` 24/24; sysext authoring contract, duplicate-package, profile-dependency, runtime-etc, and RequiredBy guards all pass; shellcheck clean at `-S warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)