### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -1,5 +1,5 @@
 code=1.134.0-1787078834
 docker-ce=5:29.7.2-1~debian.13~trixie
 1password-cli=2.39.0-1
-claude-desktop=1.34493.1
-chatgpt=26.818.61809
+claude-desktop=1.37937.1
+chatgpt=26.820.60940

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -2,6 +2,6 @@
   "code": "1.134.0-1787078834",
   "docker-ce": "5:29.7.2-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
-  "claude-desktop": "1.34493.1",
-  "chatgpt": "26.818.61809"
+  "claude-desktop": "1.37937.1",
+  "chatgpt": "26.820.60940"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

claude-desktop: 1.34493.1 -> 1.37937.1
chatgpt: 26.818.61809 -> 26.820.60940


**Please verify the builds work before merging.**