### PR TITLE
fix(flurry): vendor ttfx, the omarchy-screensaver renderer (#786)

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -495,6 +495,17 @@ jobs:
             echo "mise_version=${LATEST_MISE#v}" >> $GITHUB_OUTPUT
           fi
 
+          # Check ttfx (built from source into the flurry image -- the
+          # omarchy-screensaver renderer; upstream ships no binaries)
+          CURRENT_TTFX=$(jq -r '.ttfx.version' "$CHECKSUMS")
+          LATEST_TTFX=$(gh_api https://api.github.com/repos/omacom-io/ttfx/releases/latest | jq -r '.tag_name')
+          if [[ "$LATEST_TTFX" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
+             ver_gt "${LATEST_TTFX#v}" "$CURRENT_TTFX"; then
+            UPDATES="${UPDATES}ttfx: $CURRENT_TTFX -> ${LATEST_TTFX#v}\n"
+            echo "ttfx_update=true" >> $GITHUB_OUTPUT
+            echo "ttfx_version=${LATEST_TTFX#v}" >> $GITHUB_OUTPUT
+          fi
+
           # Check xdg-terminal-exec (vendored into the flurry image over
           # Debian's 0.12.3, which predates --print-id; the flurry build
           # fails closed when Debian reaches 0.13, retiring this entry)
@@ -592,6 +603,8 @@ jobs:
           JBM_VERSION: ${{ steps.check.outputs.jbm_version }}
           MISE_UPDATE: ${{ steps.check.outputs.mise_update }}
           MISE_VERSION: ${{ steps.check.outputs.mise_version }}
+          TTFX_UPDATE: ${{ steps.check.outputs.ttfx_update }}
+          TTFX_VERSION: ${{ steps.check.outputs.ttfx_version }}
           XTE_UPDATE: ${{ steps.check.outputs.xte_update }}
           XTE_VERSION: ${{ steps.check.outputs.xte_version }}
           SYFT_UPDATE: ${{ steps.check.outputs.syft_update }}
@@ -717,6 +730,19 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VERSION" \
               '.mise.url=$u | .mise.sha256=$s | .mise.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$TTFX_UPDATE" == "true" ]]; then
+            VERSION="$TTFX_VERSION"
+            validate_update_value "ttfx" "$VERSION" '^[0-9]+\.[0-9]+\.[0-9]+$'
+            URL="https://github.com/omacom-io/ttfx/archive/refs/tags/v${VERSION}.tar.gz"
+            TMP=$(mktemp)
+            curl -fsSL --max-time 120 -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VERSION" \
+              '.ttfx.url=$u | .ttfx.sha256=$s | .ttfx.version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/docs/plans/2026-08-25-flurry-omarchy-plan.md
+++ b/docs/plans/2026-08-25-flurry-omarchy-plan.md
@@ -142,6 +142,13 @@ Live-VM findings (2026-08-26, root-caused on the user's incus install):
   (Omarchy's Arch `theme-system.sh` Yaru action-icon symlinks are NOT
   needed: Debian's yaru-theme-icon already ships
   go-previous/next-symbolic.svg in scalable/actions.)
+- **Screensaver renderer missing** (issue #786): `omarchy-screensaver`
+  runs `ttfx` (omacom-io's Rust port of terminaltexteffects; omarchy
+  migration 1786355450 replaced the Python original). No deb, no upstream
+  binaries — built from the pinned v0.3.2 source tarball at image build
+  (`ttfx.chroot`; trixie's rustc 1.85 suffices; Cargo.lock inside the
+  pinned tarball + `--locked` transitively pins the crate tree; cargo
+  lives only in the discarded build overlay).
 - **Dead `~/Projects` bookmark**: upstream `omarchy-provision-user`
   bookmarks Projects in gtk-3.0/bookmarks but only mkdirs
   Downloads/Pictures/Videos — a genuine upstream gap (only the v3→v4

--- a/shared/composition/flurry/mkosi.conf
+++ b/shared/composition/flurry/mkosi.conf
@@ -18,6 +18,12 @@ ExtraTrees=%D/shared/flurry/tree
 BuildScripts=%D/shared/flurry/scripts/build/omarchy.chroot
 # vendored essentials: JetBrainsMono Nerd Font, mise
 BuildScripts=%D/shared/flurry/scripts/build/flurry-extras.chroot
+# ttfx (omarchy-screensaver's renderer, issue #786): built from the pinned
+# source tarball -- no deb, no upstream binaries. cargo/rustc live only in
+# the discarded build overlay, never in the image.
+BuildScripts=%D/shared/flurry/scripts/build/ttfx.chroot
+BuildPackages=cargo
+              ca-certificates
 # brew build script (CLI-tool install remap target, same as snow/cayo)
 BuildScripts=%D/shared/scripts/build/brew.chroot
 

--- a/shared/download/image-checksums.json
+++ b/shared/download/image-checksums.json
@@ -44,6 +44,11 @@
     "sha256": "82ac2dfdb357361d15f5163cdeb3cfd457bbb30bf5d2e14436393f493bd32afe",
     "version": "0.14.3"
   },
+  "ttfx": {
+    "url": "https://github.com/omacom-io/ttfx/archive/refs/tags/v0.3.2.tar.gz",
+    "sha256": "d0c0df4867e7f03142fb7f77c66670d0e8da15534239c1a7abfd89f19dfc00f6",
+    "version": "0.3.2"
+  },
   "cosign-installer": {
     "url": "https://github.com/sigstore/cosign/releases/download/v2.6.2/cosign-linux-amd64",
     "sha256": "d437b8f0d30f5dec169337607fcfa0238de1348503e175f1bb5b94330b1ee409",

--- a/shared/flurry/scripts/build/ttfx.chroot
+++ b/shared/flurry/scripts/build/ttfx.chroot
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# ttfx: omacom-io's single-binary Rust port of terminaltexteffects -- the
+# renderer behind omarchy-screensaver (issue #786; omarchy replaced the
+# Python `terminaltexteffects` with it in migration 1786355450). No Debian
+# package and upstream publishes no prebuilt binaries, so build from the
+# pinned release tarball. The tarball pin transitively pins the whole
+# crate dependency tree: Cargo.lock ships inside it and --locked makes
+# cargo refuse any drift, with cargo's own checksum enforcement on every
+# crate download. Needs BuildPackages=cargo (shared/composition/flurry).
+# Writes to $DESTDIR only (frostyard/snosi#293).
+
+source "$SRCDIR/shared/download/verified-download.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+verified_download "ttfx" "$TMP/ttfx.tar.gz"
+tar -xzf "$TMP/ttfx.tar.gz" -C "$TMP" --strip-components=1
+[[ -f "$TMP/Cargo.lock" ]] || { echo "ttfx.chroot: pinned tarball ships no Cargo.lock; refusing an unpinned dependency build" >&2; exit 1; }
+CARGO_HOME="$TMP/cargo" cargo build --release --locked --manifest-path "$TMP/Cargo.toml"
+"$TMP/target/release/ttfx" --version >/dev/null
+install -D -m 0755 "$TMP/target/release/ttfx" "$DESTDIR/usr/bin/ttfx"
+
+echo "ttfx installed: $("$TMP/target/release/ttfx" --version 2>/dev/null || echo built)"


### PR DESCRIPTION
Fixes #786.

`omarchy-screensaver` runs [`ttfx`](https://github.com/omacom-io/ttfx) — the omarchy project's single-binary Rust port of terminaltexteffects (omarchy migration 1786355450 replaced the Python `terminaltexteffects` with it). No Debian package, and upstream publishes no prebuilt release binaries, so flurry builds it from the pinned v0.3.2 source tarball at image build time.

- `shared/flurry/scripts/build/ttfx.chroot`: `verified_download` of the pinned tag tarball → `cargo build --release --locked` → install `/usr/bin/ttfx`. The tarball pin transitively pins the entire crate dependency tree (its `Cargo.lock` rides inside the pinned tarball; `--locked` forbids drift and cargo checksums every crate); the script fails closed if a future tarball ships no lockfile.
- `shared/composition/flurry/mkosi.conf`: `BuildPackages=cargo` — toolchain lives only in mkosi's discarded build overlay, verified absent from the built image.
- `image-checksums.json` pin + `check-dependencies.yml` release-tag tracking (ver_gt-guarded).

## Verification
- Trixie's rustc 1.85 builds v0.3.2 clean in ~45s (`edition 2021`).
- Full flurry image build green; `/usr/bin/ttfx` present (`ttfx 0.3.2`), no cargo/rustc in the image.
- **Live QEMU proof**: fresh install → omarchy session → `omarchy-launch-screensaver force` → foot goes fullscreen and ttfx animates the omarchy branding text (screendump-confirmed) — completing the screensaver chain whose terminal gate was fixed in #783 and which previously died at `ttfx: command not found`.
- shellcheck clean; split-checksums fixture suites pass (5/5, 34/34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)