### PR TITLE
feat(installer): default_groups in the shipped catalog (#789)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -145,6 +145,13 @@ jobs:
         # 8.3), intentionally out of scope for this fast per-PR check.
         run: ./test/snosi-install-test.sh
 
+      - name: Validate installer catalog shape
+        # shared/firn-installer/catalog.json replaces firn's builtin catalog
+        # wholesale on the ISO; firn fails soft on malformed optional fields,
+        # so the shape contract (family/ref/product split, default_groups
+        # per frostyard/snosi#789) is pinned here instead.
+        run: ./test/firn-catalog-test.sh
+
       - name: Validate snosi-setup GUI model
         # Pure-python test of setup_gui/model.py (validation, argv assembly,
         # proto-1 event parsing, disk-list/typed-confirm handling) against an

--- a/shared/firn-installer/catalog.json
+++ b/shared/firn-installer/catalog.json
@@ -4,45 +4,110 @@
     "name": "snow",
     "description": "GNOME desktop with backports kernel",
     "ref": "ghcr.io/frostyard/snow:latest",
-    "cosign_pub_key": "/usr/lib/snosi/cosign.pub"
+    "cosign_pub_key": "/usr/lib/snosi/cosign.pub",
+    "default_groups": [
+      "sudo",
+      "adm",
+      "video",
+      "input",
+      "render",
+      "plugdev",
+      "netdev",
+      "lpadmin",
+      "scanner"
+    ]
   },
   {
     "family": "bootc",
     "name": "snowfield",
     "description": "GNOME desktop with linux-surface kernel for Surface devices",
     "ref": "ghcr.io/frostyard/snowfield:latest",
-    "cosign_pub_key": "/usr/lib/snosi/cosign.pub"
+    "cosign_pub_key": "/usr/lib/snosi/cosign.pub",
+    "default_groups": [
+      "sudo",
+      "adm",
+      "video",
+      "input",
+      "render",
+      "plugdev",
+      "netdev",
+      "lpadmin",
+      "scanner"
+    ]
   },
   {
     "family": "bootc",
     "name": "flurry",
     "description": "Hyprland desktop (Omarchy replica) with backports kernel",
     "ref": "ghcr.io/frostyard/flurry:latest",
-    "cosign_pub_key": "/usr/lib/snosi/cosign.pub"
+    "cosign_pub_key": "/usr/lib/snosi/cosign.pub",
+    "default_groups": [
+      "sudo",
+      "adm",
+      "video",
+      "input",
+      "render",
+      "plugdev",
+      "netdev",
+      "lpadmin",
+      "scanner"
+    ]
   },
   {
     "family": "bootc",
     "name": "cayo",
     "description": "Headless server with podman and backports kernel",
     "ref": "ghcr.io/frostyard/cayo:latest",
-    "cosign_pub_key": "/usr/lib/snosi/cosign.pub"
+    "cosign_pub_key": "/usr/lib/snosi/cosign.pub",
+    "default_groups": [
+      "sudo",
+      "adm",
+      "netdev"
+    ]
   },
   {
     "family": "ab",
     "name": "snow-ab",
     "description": "Native A/B GNOME desktop with backports kernel",
-    "product": "snow-ab"
+    "product": "snow-ab",
+    "default_groups": [
+      "sudo",
+      "adm",
+      "video",
+      "input",
+      "render",
+      "plugdev",
+      "netdev",
+      "lpadmin",
+      "scanner"
+    ]
   },
   {
     "family": "ab",
     "name": "snowfield-ab",
     "description": "Native A/B GNOME desktop with linux-surface kernel",
-    "product": "snowfield-ab"
+    "product": "snowfield-ab",
+    "default_groups": [
+      "sudo",
+      "adm",
+      "video",
+      "input",
+      "render",
+      "plugdev",
+      "netdev",
+      "lpadmin",
+      "scanner"
+    ]
   },
   {
     "family": "ab",
     "name": "cayo-ab",
     "description": "Native A/B headless server with podman",
-    "product": "cayo-ab"
+    "product": "cayo-ab",
+    "default_groups": [
+      "sudo",
+      "adm",
+      "netdev"
+    ]
   }
 ]

--- a/test/firn-catalog-test.sh
+++ b/test/firn-catalog-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Shape test for the shipped installer catalog
+# (shared/firn-installer/catalog.json, installed to /etc/firn/catalog.json,
+# where it REPLACES firn's builtin catalog wholesale). firn tolerates
+# unknown fields and missing optional ones, so a malformed entry here fails
+# soft at the worst time -- on the installer ISO. Pin the contract:
+#  - bare JSON array; every entry has family/name/description
+#  - family=bootc entries carry ref (immutable registry path) +
+#    cosign_pub_key; family=ab entries carry product; never both
+#  - every entry declares default_groups (frostyard/snosi#789), a nonempty
+#    string array starting with sudo -- firn preselects these in the user
+#    wizard (join-where-exists at install time)
+#  - desktop entries carry the device/admin set, server entries the
+#    minimal set (keep in sync with firn's builtinCatalog defaults)
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+catalog="$root/shared/firn-installer/catalog.json"
+
+test_number=0
+failures=0
+ok() { test_number=$((test_number + 1)); echo "ok $test_number - $1"; }
+fail() { test_number=$((test_number + 1)); failures=$((failures + 1)); echo "not ok $test_number - $1"; }
+
+jq -e 'type == "array" and length > 0' "$catalog" >/dev/null &&
+    ok "catalog is a nonempty JSON array" || fail "catalog is a nonempty JSON array"
+
+jq -e 'all(.[]; (.family | IN("bootc", "ab")) and .name != "" and .description != "")' "$catalog" >/dev/null &&
+    ok "every entry has family/name/description" || fail "every entry has family/name/description"
+
+jq -e 'all(.[] | select(.family == "bootc");
+        (.ref | test("^ghcr\\.io/frostyard/[a-z-]+:")) and .cosign_pub_key == "/usr/lib/snosi/cosign.pub" and (has("product") | not))' "$catalog" >/dev/null &&
+    ok "bootc entries carry a frostyard ref + the shipped cosign key, no product" ||
+    fail "bootc entries carry a frostyard ref + the shipped cosign key, no product"
+
+jq -e 'all(.[] | select(.family == "ab"); (.product != null) and (has("ref") | not))' "$catalog" >/dev/null &&
+    ok "ab entries carry product, no ref" || fail "ab entries carry product, no ref"
+
+jq -e 'all(.[]; (.default_groups | type == "array" and length > 0 and .[0] == "sudo" and all(.[]; type == "string" and . != "")))' "$catalog" >/dev/null &&
+    ok "every entry declares default_groups, sudo first" ||
+    fail "every entry declares default_groups, sudo first"
+
+desktop='["sudo","adm","video","input","render","plugdev","netdev","lpadmin","scanner"]'
+server='["sudo","adm","netdev"]'
+jq -e --argjson d "$desktop" --argjson s "$server" '
+    all(.[]; if (.name | test("^cayo")) then .default_groups == $s else .default_groups == $d end)' "$catalog" >/dev/null &&
+    ok "desktop entries carry the device/admin set, cayo entries the server set" ||
+    fail "desktop entries carry the device/admin set, cayo entries the server set"
+
+# Every preselected group must exist in the images (join-where-exists would
+# silently drop it): pinned against base's group sources plus the shared
+# graphical set's packages. Static approximation: require each group to be a
+# well-known Debian static group or one that base/greeter packages create.
+known="sudo adm video input render plugdev netdev lpadmin scanner"
+missing=$(jq -r '[.[].default_groups[]] | unique | .[]' "$catalog" | grep -vxF -f <(tr ' ' '\n' <<<"$known") || true)
+if [[ -z "$missing" ]]; then
+    ok "all preselected groups are in the vetted known-good set"
+else
+    fail "unvetted groups in default_groups: $missing (verify they exist in every image's /etc/group, then extend the known list)"
+fi
+
+echo
+echo "# Results: $((test_number - failures)) passed, $failures failed, $test_number total"
+((failures == 0))


### PR DESCRIPTION
Fixes #789 — the snosi half; the firn half is frostyard/firn#83 (wizard preselects `default_groups` from the selected entry).

From the first physical flurry install inspection: the created user landed in only `[user, sudo]`. The logind seat hides it (session works fine), but lpadmin/adm/video/input/render/plugdev gaps surface later in specific corners.

- Every `shared/firn-installer/catalog.json` entry now declares `default_groups`: desktops `sudo,adm,video,input,render,plugdev,netdev,lpadmin,scanner`; cayo entries `sudo,adm,netdev`. All verified present in the images' `/etc/group`. `audio` deliberately unselected (discouraged under logind); `dialout` opt-in. Join-where-exists at install time is unchanged and the user can still edit the selection.
- **Ordering-independent with the firn release**: old firn ignores the field; new firn falls back to `{"sudo"}` on an old catalog.
- New `test/firn-catalog-test.sh` (validate.yml) pins the catalog shape contract for the first time — firn fails *soft* on malformed optional fields, on the installer ISO, at the worst moment; now the bare-array shape, bootc ref/cosign-key vs ab product split, and the exact default_groups sets are enforced per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)