### PR TITLE
feat(flurry): inxi + explicit intel VAAPI driver pin

### DIFF
--- a/shared/packages/flurry/mkosi.conf
+++ b/shared/packages/flurry/mkosi.conf
@@ -134,6 +134,21 @@ Packages=power-profiles-daemon
 # MTP device probing (graphical images only, same rationale as snow)
 Packages=libmtp-runtime
 
+# VAAPI encode/decode drivers (gpu-screen-recorder's baseline encode
+# path). AMD/legacy-Intel VAAPI needs NO extra package here: mesa >=
+# 25.2.8-3 folds the VA-API drivers into mesa-libgallium (see
+# shared/kernel/backports/mkosi.conf), which this image already ships from
+# trixie-backports -- and mesa-va-drivers no longer exists at that
+# version, so never re-add it. intel-media-va-driver-non-free (modern
+# Intel) currently arrives via the multimedia stack, but it is
+# load-bearing for screen recording, so pin it explicitly rather than
+# trusting the transitive pull to persist.
+Packages=intel-media-va-driver-non-free
+
+# inxi: omarchy-debug embeds `inxi -Farz` in its report; present in trixie,
+# was silently missing (2026-08-26 skipped-apps audit).
+Packages=inxi
+
 # Printing (CUPS)
 Packages=cups
          cups-browsed


### PR DESCRIPTION
Tier 3 of the 2026-08-26 skipped-apps audit — rebased after #790 landed the base pciutils/usbutils half (thanks!); this is now flurry-only:

- **inxi**: omarchy-debug embeds `inxi -Farz`; present in trixie, was silently missing.
- **intel-media-va-driver-non-free** pinned explicitly — load-bearing for gpu-screen-recorder's Intel VAAPI encode, previously only a transitive pull.
- **AMD VAAPI needs nothing**: mesa ≥ 25.2.8-3 folds the VA drivers into `mesa-libgallium` (already shipped from backports via the kernel fragment) and `mesa-va-drivers` no longer exists at that version — the packages comment records this so nobody re-adds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)