### PR TITLE
feat(sysext): obsidian, localsend, and moonlight desktop sysexts

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -60,6 +60,25 @@ jobs:
             echo "bitwarden_version=$LATEST_BW" >> $GITHUB_OUTPUT
           fi
 
+          # Check Obsidian (releases include mobile-only tags with no .deb --
+          # pick the newest release actually carrying an amd64.deb asset)
+          CURRENT_OBS=$(jq -r '.obsidian.version' "$CHECKSUMS")
+          LATEST_OBS=$(gh_api 'https://api.github.com/repos/obsidianmd/obsidian-releases/releases?per_page=15' | jq -r '[.[] | select(.draft == false and .prerelease == false) | select([.assets[].name | test("_amd64\\.deb$")] | any)][0].tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_OBS" && "$LATEST_OBS" != "null" ]] && ver_gt "$LATEST_OBS" "$CURRENT_OBS"; then
+            UPDATES="${UPDATES}obsidian: $CURRENT_OBS -> $LATEST_OBS\n"
+            echo "obsidian_update=true" >> $GITHUB_OUTPUT
+            echo "obsidian_version=$LATEST_OBS" >> $GITHUB_OUTPUT
+          fi
+
+          # Check LocalSend
+          CURRENT_LSEND=$(jq -r '.localsend.version' "$CHECKSUMS")
+          LATEST_LSEND=$(gh_api https://api.github.com/repos/localsend/localsend/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [[ -n "$LATEST_LSEND" && "$LATEST_LSEND" != "null" ]] && ver_gt "$LATEST_LSEND" "$CURRENT_LSEND"; then
+            UPDATES="${UPDATES}localsend: $CURRENT_LSEND -> $LATEST_LSEND\n"
+            echo "localsend_update=true" >> $GITHUB_OUTPUT
+            echo "localsend_version=$LATEST_LSEND" >> $GITHUB_OUTPUT
+          fi
+
           # Check GitHub Copilot desktop app
           CURRENT_GITHUB_COPILOT=$(jq -r '."github-copilot".version' "$CHECKSUMS")
           LATEST_GITHUB_COPILOT=$(gh_api https://api.github.com/repos/github/app/releases | jq -r '[.[] | select(.draft == false and .prerelease == false)][0].tag_name' | sed 's/^v//')
@@ -181,6 +200,10 @@ jobs:
         # keeps a malicious upstream tag from injecting shell commands.
         env:
           BITWARDEN_UPDATE: ${{ steps.check.outputs.bitwarden_update }}
+          OBSIDIAN_UPDATE: ${{ steps.check.outputs.obsidian_update }}
+          OBSIDIAN_VERSION: ${{ steps.check.outputs.obsidian_version }}
+          LOCALSEND_UPDATE: ${{ steps.check.outputs.localsend_update }}
+          LOCALSEND_VERSION: ${{ steps.check.outputs.localsend_version }}
           BITWARDEN_VERSION: ${{ steps.check.outputs.bitwarden_version }}
           GITHUB_COPILOT_UPDATE: ${{ steps.check.outputs.github_copilot_update }}
           GITHUB_COPILOT_VERSION: ${{ steps.check.outputs.github_copilot_version }}
@@ -215,6 +238,30 @@ jobs:
             SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
             jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
               '.bitwarden.url=$u | .bitwarden.sha256=$s | .bitwarden.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$OBSIDIAN_UPDATE" == "true" ]]; then
+            VER="$OBSIDIAN_VERSION"
+            URL="https://github.com/obsidianmd/obsidian-releases/releases/download/v${VER}/obsidian_${VER}_amd64.deb"
+            TMP=$(mktemp)
+            curl -fsSL --max-time 120 -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.obsidian.url=$u | .obsidian.sha256=$s | .obsidian.version=$v' \
+              "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
+            rm -f "$TMP"
+          fi
+
+          if [[ "$LOCALSEND_UPDATE" == "true" ]]; then
+            VER="$LOCALSEND_VERSION"
+            URL="https://github.com/localsend/localsend/releases/download/v${VER}/LocalSend-${VER}-linux-x86-64.deb"
+            TMP=$(mktemp)
+            curl -fsSL --max-time 120 -o "$TMP" "$URL"
+            SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+            jq --arg u "$URL" --arg s "$SHA" --arg v "$VER" \
+              '.localsend.url=$u | .localsend.sha256=$s | .localsend.version=$v' \
               "$CHECKSUMS" > tmp.json && mv tmp.json "$CHECKSUMS"
             rm -f "$TMP"
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 3 OCI desktop images (snow, snowfield, flurry — flurry is the Hyprland/Omarchy-replica desktop, see docs/plans/2026-08-25-flurry-omarchy-plan.md), 1 OCI server image (cayo), and 23 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, chatgpt, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, sunshine, tailscale, vscode).
+**Outputs:** 3 OCI desktop images (snow, snowfield, flurry — flurry is the Hyprland/Omarchy-replica desktop, see docs/plans/2026-08-25-flurry-omarchy-plan.md), 1 OCI server image (cayo), and 26 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, chatgpt, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, localsend, moonlight, nix, obsidian, paseo, pilothouse, podman, sunshine, tailscale, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 23 sysexts
+just sysexts            # Build base + all 26 sysexts
 just snow               # Build snow desktop image
 just snowfield          # Build snowfield (Surface kernel)
 just cayo               # Build cayo server image
@@ -556,7 +556,7 @@ those libs from other suites (flurry: xkbcommon/pipewire/alsa/mesa from
 backports) got shadow-DOWNGRADED for all of `/usr` on merge (killed
 Hyprland, root-caused live 2026-08-25). `mkosi.images/gui-base` is an
 internal never-published directory image (base + common GUI lib closure);
-the nine desktop-app sysexts use `Dependencies=gui-base` +
+the desktop-app sysexts (twelve today; the wiring-parity test enumerates them) use `Dependencies=gui-base` +
 `BaseTrees=%O/gui-base` + the `sysext-no-divergent-libs.sh` finalize
 tripwire (fails the build on any delta file matching
 `shared/sysext/divergent-lib-families.txt`). THE CONTRACT: every gui-base

--- a/docs/design/sysexts.md
+++ b/docs/design/sysexts.md
@@ -479,7 +479,8 @@ same shadowing on mesa but survived because gbm's ABI tolerated it).
 **The fix — `mkosi.images/gui-base`**: an internal, never-published
 directory image (base + the common GUI lib closure). Desktop-app sysexts
 (1password, azurevpn, bitwarden, chatgpt, claude-desktop, edge,
-github-copilot, sunshine, vscode) set `Dependencies=gui-base` +
+github-copilot, localsend, moonlight, obsidian, sunshine, vscode) set
+`Dependencies=gui-base` +
 `BaseTrees=%O/gui-base`, so their deltas omit the entire common GUI stack
 and each product supplies its own suite's version at merge time.
 

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -19,7 +19,10 @@ Dependencies=base
              incus
              k3s
              lemonade
+             localsend
+             moonlight
              nix
+             obsidian
              paseo
              pilothouse
              podman

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.localsend.d/localsend.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.localsend.d/localsend.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=LocalSend cross-platform file sharing (AirDrop alternative)
+Documentation=https://localsend.org
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.localsend.d/localsend.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.localsend.d/localsend.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=localsend
+Verify=true
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/localsend/
+MatchPattern=localsend_@v_%w_%a.raw.zst \
+             localsend_@v_%w_%a.raw.xz \
+             localsend_@v_%w_%a.raw.gz \
+             localsend_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=localsend_@v_%w_%a.raw.zst \
+             localsend_@v_%w_%a.raw.xz \
+             localsend_@v_%w_%a.raw.gz \
+             localsend_@v_%w_%a.raw
+CurrentSymlink=localsend.raw

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.moonlight.d/moonlight.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.moonlight.d/moonlight.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=Moonlight game-streaming client (pairs with the sunshine host sysext)
+Documentation=https://moonlight-stream.org
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.moonlight.d/moonlight.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.moonlight.d/moonlight.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=moonlight
+Verify=true
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/moonlight/
+MatchPattern=moonlight_@v_%w_%a.raw.zst \
+             moonlight_@v_%w_%a.raw.xz \
+             moonlight_@v_%w_%a.raw.gz \
+             moonlight_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=moonlight_@v_%w_%a.raw.zst \
+             moonlight_@v_%w_%a.raw.xz \
+             moonlight_@v_%w_%a.raw.gz \
+             moonlight_@v_%w_%a.raw
+CurrentSymlink=moonlight.raw

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.obsidian.d/obsidian.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.obsidian.d/obsidian.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=Obsidian knowledge base and note-taking app
+Documentation=https://obsidian.md
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.obsidian.d/obsidian.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.obsidian.d/obsidian.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=obsidian
+Verify=true
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/obsidian/
+MatchPattern=obsidian_@v_%w_%a.raw.zst \
+             obsidian_@v_%w_%a.raw.xz \
+             obsidian_@v_%w_%a.raw.gz \
+             obsidian_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=obsidian_@v_%w_%a.raw.zst \
+             obsidian_@v_%w_%a.raw.xz \
+             obsidian_@v_%w_%a.raw.gz \
+             obsidian_@v_%w_%a.raw
+CurrentSymlink=obsidian.raw

--- a/mkosi.images/localsend/mkosi.conf
+++ b/mkosi.images/localsend/mkosi.conf
@@ -1,0 +1,25 @@
+[Config]
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
+
+[Output]
+ImageId=localsend
+Output=localsend
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/gui-base
+PostInstallationScripts=%D/shared/packages/localsend/mkosi.postinst.d/localsend.chroot
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
+
+[Include]
+Include=%D/shared/packages/localsend/mkosi.conf
+
+[Build]
+Environment=KEYPACKAGE=localsend

--- a/mkosi.images/localsend/required-paths.txt
+++ b/mkosi.images/localsend/required-paths.txt
@@ -1,0 +1,5 @@
+# localsend sysext: LocalSend file sharing (Flutter), relocated /opt -> /usr/lib
+/usr/lib/localsend_app/localsend_app
+/usr/bin/localsend
+/usr/bin/localsend_app
+/usr/share/applications/localsend_app.desktop

--- a/mkosi.images/moonlight/mkosi.conf
+++ b/mkosi.images/moonlight/mkosi.conf
@@ -1,0 +1,29 @@
+[Config]
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
+
+[Output]
+ImageId=moonlight
+Output=moonlight
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/gui-base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
+
+# Moonlight game-streaming client from the frostyard APT repo
+# (frostyard/omarchy-apps builds it by repacking the upstream AppImage --
+# upstream publishes NO amd64 debs: its Cloudsmith repo carries arm64
+# only, verified 2026-08-26). Pairs with the sunshine sysext (the
+# streaming HOST) on the other end. RELEASE ORDER: omarchy-apps must have
+# published moonlight-qt before this sysext can build.
+Packages=moonlight-qt
+
+[Build]
+Environment=KEYPACKAGE=moonlight-qt

--- a/mkosi.images/moonlight/required-paths.txt
+++ b/mkosi.images/moonlight/required-paths.txt
@@ -1,0 +1,3 @@
+# moonlight sysext: Moonlight game-streaming client (Qt) from upstream apt repo
+/usr/bin/moonlight-qt
+/usr/share/applications/com.moonlight_stream.Moonlight.desktop

--- a/mkosi.images/obsidian/mkosi.conf
+++ b/mkosi.images/obsidian/mkosi.conf
@@ -1,0 +1,25 @@
+[Config]
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781); the no-divergent-libs finalize is the matching tripwire.
+Dependencies=gui-base
+
+[Output]
+ImageId=obsidian
+Output=obsidian
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/gui-base
+PostInstallationScripts=%D/shared/packages/obsidian/mkosi.postinst.d/obsidian.chroot
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
+
+[Include]
+Include=%D/shared/packages/obsidian/mkosi.conf
+
+[Build]
+Environment=KEYPACKAGE=obsidian

--- a/mkosi.images/obsidian/required-paths.txt
+++ b/mkosi.images/obsidian/required-paths.txt
@@ -1,0 +1,6 @@
+# obsidian sysext: Obsidian desktop app (Electron), relocated /opt -> /usr/lib
+/usr/lib/Obsidian/obsidian
+/usr/lib/Obsidian/chrome-sandbox
+/usr/bin/obsidian
+/usr/share/applications/md.obsidian.Obsidian.desktop
+/usr/share/icons/hicolor/512x512/apps/obsidian.png

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -9,6 +9,16 @@
     "sha256": "720ecc392eef1992780af2aaabd4733916807155c8ee217ed67f3f93287bb415",
     "version": "2026.8.0"
   },
+  "obsidian": {
+    "url": "https://github.com/obsidianmd/obsidian-releases/releases/download/v1.13.7/obsidian_1.13.7_amd64.deb",
+    "sha256": "17dc33b49cb3e785ecc27edd2ea0c79e40207798b554fd2886e36ebee7af9ae0",
+    "version": "1.13.7"
+  },
+  "localsend": {
+    "url": "https://github.com/localsend/localsend/releases/download/v1.18.2/LocalSend-1.18.2-linux-x86-64.deb",
+    "sha256": "cc42a4f3eacdcb25ec31f0016b1272acb003145ab30484db8965450e20c72cd2",
+    "version": "1.18.2"
+  },
   "microsoft-azurevpnclient": {
     "url": "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-azurevpnclient/microsoft-azurevpnclient_3.1.0_amd64.deb",
     "sha256": "636c829e1bc8aef3e71adc6c729971bd7c09deab2ccdb82c6c7ce4185b35e861",

--- a/shared/packages/localsend/mkosi.conf
+++ b/shared/packages/localsend/mkosi.conf
@@ -1,0 +1,11 @@
+[Content]
+# Runtime deps from the LocalSend .deb's Depends that the build base lacks:
+# the ayatana appindicator/dbusmenu stack (tray icon) plus its GIR binding.
+# These stay in the delta by design -- no desktop product ships them from a
+# divergent suite (see the gui-base contract in docs/design/sysexts.md).
+# Flurry note: the image already bakes the ufw allow rule for LocalSend's
+# port 53317 (vendored from omarchy).
+Packages=libayatana-appindicator3-1
+         gir1.2-ayatanaappindicator3-0.1
+         libayatana-ido3-0.4-0
+         xdg-user-dirs

--- a/shared/packages/localsend/mkosi.postinst.d/localsend.chroot
+++ b/shared/packages/localsend/mkosi.postinst.d/localsend.chroot
@@ -1,0 +1,19 @@
+#!/bin/bash
+# LocalSend sysext: install the pinned upstream .deb and relocate /opt ->
+# /usr/lib (sysexts can only ship /usr; /opt is /var-backed at runtime).
+set -euo pipefail
+[[ "${DEBUG_BUILD:-0}" == "1" ]] && set -x
+
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "localsend" "$DEBS/localsend.deb"
+
+dpkg -i "$DEBS/localsend.deb"
+
+mv /opt/localsend_app /usr/lib/localsend_app
+rm -rf /opt/localsend_app
+mkdir -p /usr/bin
+ln -sf /usr/lib/localsend_app/localsend_app /usr/bin/localsend
+ln -sf /usr/lib/localsend_app/localsend_app /usr/bin/localsend_app
+sed -i 's|/opt/localsend_app/localsend_app|/usr/bin/localsend_app|g' /usr/share/applications/localsend_app.desktop

--- a/shared/packages/obsidian/mkosi.conf
+++ b/shared/packages/obsidian/mkosi.conf
@@ -1,0 +1,7 @@
+[Content]
+# Runtime deps from the Obsidian .deb's Depends that neither base nor
+# gui-base carries (libxss1 is absent from snow by design -- see the
+# gui-base contract; xdg-utils is absent from snow). Everything else
+# (gtk3, notify, nss, secret, atspi, uuid) is already in the build base.
+Packages=libxss1
+         xdg-utils

--- a/shared/packages/obsidian/mkosi.postinst.d/obsidian.chroot
+++ b/shared/packages/obsidian/mkosi.postinst.d/obsidian.chroot
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Obsidian sysext: install the pinned upstream .deb and relocate /opt ->
+# /usr/lib (sysexts can only ship /usr; /opt is /var-backed at runtime).
+set -euo pipefail
+[[ "${DEBUG_BUILD:-0}" == "1" ]] && set -x
+
+source "$SRCDIR/shared/download/verified-download.sh"
+DEBS=$(mktemp -d)
+trap 'rm -rf "$DEBS"' EXIT
+verified_download "obsidian" "$DEBS/obsidian.deb"
+
+dpkg -i "$DEBS/obsidian.deb"
+
+mv /opt/Obsidian /usr/lib/Obsidian
+rm -rf /opt/Obsidian
+mkdir -p /usr/bin
+ln -sf /usr/lib/Obsidian/obsidian /usr/bin/obsidian
+chmod 4755 /usr/lib/Obsidian/chrome-sandbox
+sed -i 's|/opt/Obsidian/obsidian|/usr/bin/obsidian|g' /usr/share/applications/md.obsidian.Obsidian.desktop


### PR DESCRIPTION
Tier 2 of the 2026-08-26 skipped-apps audit: the three Omarchy apps with usable upstream artifacts, as gui-base desktop sysexts (the #781 pattern — `Dependencies=gui-base`, `BaseTrees=%O/gui-base`, no-divergent-libs tripwire).

- **obsidian** — upstream .deb (pinned in sysext-checksums.json), /opt→/usr/lib relocation, chrome-sandbox setuid, desktop `Exec` rewrite. Restores omarchy's `SUPER+SHIFT+O` binding and the theme-CSS hook.
- **localsend** — upstream .deb, same relocation; the ayatana appindicator tray stack rides in the delta (no product ships it from a divergent suite — documented exception class). The flurry image already bakes omarchy's ufw allow for its port 53317. Restores the Share → Receive menu entry.
- **moonlight** — `Packages=moonlight-qt` from the **frostyard APT repo**: upstream publishes no amd64 debs anywhere (its Cloudsmith repo carries only arm64 — verified against empty `binary-amd64` indexes across debian/ubuntu suites) and Debian doesn't package it, so [frostyard/omarchy-apps](https://github.com/frostyard/omarchy-apps) builds a deb by repacking the upstream AppImage. Pairs with the sunshine host sysext.

**Release order**: the moonlight sysext build fails until omarchy-apps has published `moonlight-qt` to the frostyard repo — expect this PR's moonlight leg to stay red until that publication lands, then rerun.

check-dependencies tracks both pinned debs (obsidian's check selects the newest release actually carrying an amd64.deb — mobile-only tags ship none). Counts + gui-base docs updated (26 sysexts, twelve on gui-base).

**Verification**: local full sysext-set build green (minus moonlight per the ordering above) — obsidian and localsend assemble with all required paths present, tripwires clean (22 family patterns), and correctly versioned artifacts; sysext authoring contract suite passes at 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)