### PR TITLE
Add socat to the base image

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -277,6 +277,7 @@ jobs:
           ./test/runtime-etc-guard-test.sh
           ./test/duplicate-packages-test.sh
           ./test/base-hardware-utils-test.sh
+          ./test/socat-package-test.sh
 
       - name: Test RequiredBy guard and initrd requires-pruning fixtures
         run: |

--- a/mkosi.images/base/mkosi.conf
+++ b/mkosi.images/base/mkosi.conf
@@ -75,6 +75,7 @@ Packages=fish
 # Utilities
 Packages=vim
          netcat-traditional
+         socat
          openssh-server
          cifs-utils
          pciutils

--- a/shared/packages/flurry/mkosi.conf
+++ b/shared/packages/flurry/mkosi.conf
@@ -234,7 +234,6 @@ Packages=bash-completion
          plocate
          qrencode
          ripgrep
-         socat
          starship
          tealdeer
          tesseract-ocr

--- a/test/socat-package-test.sh
+++ b/test/socat-package-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+base_conf="$root/mkosi.images/base/mkosi.conf"
+flurry_conf="$root/shared/packages/flurry/mkosi.conf"
+
+package_is_listed() {
+    local package=$1
+    local conf=$2
+    grep -Eq "^(Packages=|[[:space:]]+)${package}$" "$conf"
+}
+
+echo "1..2"
+
+if package_is_listed socat "$base_conf"; then
+    echo "ok 1 - base explicitly includes socat"
+else
+    echo "not ok 1 - base explicitly includes socat"
+    exit 1
+fi
+
+if package_is_listed socat "$flurry_conf"; then
+    echo "not ok 2 - flurry does not duplicate base's socat package"
+    exit 1
+else
+    echo "ok 2 - flurry does not duplicate base's socat package"
+fi


### PR DESCRIPTION
## Summary

- install `socat` in the shared base image so every product has it
- remove Flurry's now-redundant explicit `socat` entry
- add a validation check that pins both package-placement requirements

## Tests

- `./test/socat-package-test.sh`
- `./test/duplicate-packages-test.sh`
- `./test/base-hardware-utils-test.sh`
- `./test/workflow-path-filter-test.sh`
- `./check-duplicate-packages.sh`
- `python3 test/policy-as-code-test.py`
- `git diff --check`

Closes #795