### PR TITLE
feat(flurry): add Intuneme

### DIFF
--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -27,13 +27,13 @@ Frostyard workspace root (the parent of `snosi/`).
 
 | Tool | Package | Where declared | Scope |
 |---|---|---|---|
-| nbc | `frostyard-nbc` | `snosi/mkosi.images/base/mkosi.conf:44` | all images (legacy updater) |
-| updex | `frostyard-updex` | `snosi/mkosi.images/base/mkosi.conf:45` | all images (sysext feature/update manager) |
-| chairlift | `frostyard-chairlift` | `snosi/shared/packages/snow/mkosi.conf:6` | snow, snowfield (+ `-ab`) |
+| nbc | `frostyard-nbc` | `snosi/mkosi.images/base/mkosi.conf:50` | all images (legacy updater) |
+| updex | `frostyard-updex` | `snosi/mkosi.images/base/mkosi.conf:51` | all images (sysext feature/update manager) |
+| chairlift | `frostyard-chairlift` | `snosi/shared/packages/snow/mkosi.conf:6`; `snosi/shared/packages/flurry/mkosi.conf:8` | snow, snowfield (+ `-ab`), flurry |
 | snow-first-setup | `snow-first-setup` | `snosi/shared/packages/snow/mkosi.conf:7` | snow, snowfield (+ `-ab`) |
-| intuneme | `frostyard-intuneme` | `snosi/shared/packages/snow/mkosi.conf:66` | snow, snowfield (+ `-ab`) |
-| bootc | `bootc` | `snosi/shared/packages/bootc/mkosi.conf:4` | bootc profiles (cayo, snow, snowfield) |
-| ostree | `libostree-1-1` | `snosi/shared/packages/bootc/mkosi.conf:5` | bootc profiles |
+| intuneme | `frostyard-intuneme` | `snosi/shared/packages/snow/mkosi.conf:79`; `snosi/shared/packages/flurry/mkosi.conf:9` | snow, snowfield (+ `-ab`), flurry |
+| bootc | `bootc` | `snosi/shared/packages/bootc/mkosi.conf:5` | bootc profiles (cayo, snow, snowfield, flurry) |
+| ostree | `libostree-1-1` | `snosi/shared/packages/bootc/mkosi.conf:6` | bootc profiles |
 | pilothouse | `frostyard-pilothouse` | `snosi/mkosi.images/pilothouse/mkosi.conf:23` (sysext) | opt-in sysext, all products |
 
 `pilothouse` is the **only** Frostyard-authored sysext (all 19 other sysexts

--- a/shared/packages/flurry/mkosi.conf
+++ b/shared/packages/flurry/mkosi.conf
@@ -6,6 +6,7 @@ BaseTrees=%O/base
 # useradd -m, both of which copy the image's /etc/skel, which the omarchy
 # vendor script populates)
 Packages=frostyard-chairlift
+         frostyard-intuneme
 
 # apt is NOT in the base image -- each product profile carries it (snow and
 # cayo do the same). common-postinst.sh hard-requires it for the package


### PR DESCRIPTION
## Summary

- add `frostyard-intuneme` to the Flurry package composition
- keep the Frostyard integration contract synchronized with Flurry's package scope
- refresh adjacent source references and Flurry scopes in the contract table

## Tests

- `.mkosi/bin/mkosi -f --profile flurry summary` (resolved `frostyard-intuneme`)
- `./check-duplicate-packages.sh`
- `./check-profile-dependencies.sh`
- `git diff --check origin/main...HEAD`