### PR TITLE
fix(flurry): install gawk so omarchy's awk scripts work

### DIFF
--- a/shared/flurry/scripts/postinstall/flurry.postinst.chroot
+++ b/shared/flurry/scripts/postinstall/flurry.postinst.chroot
@@ -25,4 +25,20 @@ if [ -f /etc/pam.d/sddm ]; then
     sed -i '/pam_gnome_keyring\.so/d' /etc/pam.d/sddm
 fi
 
+# gawk must own the `awk` alternative. Omarchy's scripts are Arch-native and
+# assume /usr/bin/awk is gawk (3-arg match(), strtonum(), \s); mawk silently
+# empties the keybindings menu and the power-profile list rather than failing
+# anything. shared/packages/flurry/mkosi.conf installs gawk, whose postinst
+# outranks mawk -- assert the link actually landed so a priority change
+# upstream breaks the build instead of the desktop.
+awk_impl=$(readlink -f /usr/bin/awk)
+case "$awk_impl" in
+    */gawk) ;;
+    *)
+        echo "flurry.postinst: /usr/bin/awk resolves to '$awk_impl', expected gawk --" \
+             "omarchy's awk scripts need gawk extensions" >&2
+        exit 1
+        ;;
+esac
+
 echo "Post-installation complete."

--- a/shared/packages/flurry/mkosi.conf
+++ b/shared/packages/flurry/mkosi.conf
@@ -255,6 +255,25 @@ Packages=bash-completion
 # tier-1 landing; this was the one missing dep, 2026-08-26).
          v4l-utils
 
+# gawk: omarchy's scripts are Arch-native, where /usr/bin/awk IS gawk. The
+# Debian base ships only mawk, and three omarchy commands use gawk-only awk
+# and break on it (2026-08-26 audit of the vendored tree):
+#   omarchy-menu-keybindings    3-arg match() + \s   keybindings menu renders
+#                                                    EMPTY, five awk syntax
+#                                                    errors on stderr
+#   omarchy-bar-text-color      strtonum()           contrast pick errors out,
+#                                                    bar text never adapts
+#   omarchy-powerprofiles-list  \s in the profile    profile list comes back
+#                               regex                empty, silently (exit 0)
+# Installing gawk is the whole fix: its postinst registers the `awk`
+# update-alternatives link above mawk's priority 5, so every gawk-ism --
+# these three and any the next omarchy re-pin brings -- resolves at once.
+# Alternatives are safe here because profile images ship /etc/alternatives
+# (a sysext could not do this; see docs/design/sysexts.md). The flurry
+# postinst asserts the link actually landed on gawk, so a priority change
+# upstream fails the build instead of the desktop.
+Packages=gawk
+
 # Console login: /bin/login comes from the `login` package (shadow suite),
 # which base does NOT ship -- snow and cayo carry it in their parity
 # blocks. Without it every serial/VT getty dies with "can't exec


### PR DESCRIPTION
# Summary

Omarchy's shell scripts are Arch-native, where `/usr/bin/awk` **is** gawk. The Debian base ships only mawk, so every gawk-only awk construct in the vendored omarchy tree fails on Flurry.

An audit of the pinned tree (68 files invoke `awk`) found three commands broken on a booted image today:

| Command | gawk-ism | Effect under mawk |
| --- | --- | --- |
| `omarchy-menu-keybindings` | 3-arg `match()` + `\s` (lines 30, 31, 52, 57) | keybindings menu renders **empty**, five awk syntax errors on stderr |
| `omarchy-bar-text-color` | `strtonum()` (line 47) | `function strtonum never defined`; contrast pick dies, bar text never adapts to the wallpaper |
| `omarchy-powerprofiles-list` | `\s` in the profile regex (line 12) | profile list comes back **empty**, silently, exit 0 |

The last one is the quiet one: `powerprofilesctl list` reports three profiles on this machine and the script returns none. The same regex written with POSIX classes matches all three, so it is the `\s` alone.

Installing `gawk` is the whole fix rather than patching three files in a pinned vendored tree: gawk's postinst registers the `awk` update-alternatives link above mawk's priority 5, so these three — and any gawk-ism a future omarchy re-pin brings — resolve at once. mawk stays installed; gawk is a superset, so nothing else moves. Alternatives are safe here because profile images ship `/etc/alternatives` (a sysext could not do this — see `docs/design/sysexts.md`).

`flurry.postinst.chroot` asserts `/usr/bin/awk` actually resolved to gawk, so a priority change upstream fails the build instead of silently emptying the keybindings menu on users' desktops.

Risk tier: 3 — profile composition (adds a package to the Flurry image and a build-failing assertion to its postinst).

Closes #

## Type of change

- [x] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [ ] Sysext change
- [ ] Build pipeline / CI change
- [ ] Documentation only
- [ ] Other:

## Validation

- [x] `shellcheck` / `validate.yml` static checks pass for touched scripts
- [ ] Relevant `just` build target(s) succeed — **not run locally** (see below)
- [x] Relevant tests in `test/` were run

Commands run:

```
shellcheck -S warning -x shared/flurry/scripts/postinstall/flurry.postinst.chroot   # clean, exit 0
bash -n shared/flurry/scripts/postinstall/flurry.postinst.chroot                     # OK
bash check-duplicate-packages.sh      # No duplicate package entries found
bash check-profile-dependencies.sh    # Profile builds depend only on base.
bash check-runtime-etc-guard.sh       # clean
bash check-required-by-guard.sh       # OK

# Breakage reproduced on a booted Flurry image, all three:
omarchy menu keybindings --print   # 5 awk syntax errors, zero bindings
omarchy-bar-text-color top 30 '#ffffff' '#000000'   # function strtonum never defined
omarchy-powerprofiles-list         # empty, exit 0 (powerprofilesctl lists 3 profiles)
```

`just flurry` was **not** run — a full image build was out of scope for this session. CI or a maintainer should confirm the image builds and that the new postinst assertion passes.

One assumption I could not verify locally: Debian's gawk registers the `awk` alternative at priority 10 against mawk's 5. `apt-get download gawk` fails on a booted Flurry image (read-only `/usr`, no package lists), so this rests on long-standing Debian behavior rather than a read of the postinst. **The assertion in `flurry.postinst.chroot` exists precisely to cover that** — if the assumption is wrong the build fails loudly instead of shipping a broken desktop.

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] New external downloads are pinned and go through `verified_download()` — n/a, no new downloads
- [x] Documentation updated (`CLAUDE.md`, `README.md`, `docs/`) where relevant — n/a; rationale lives in the two touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
