### PR TITLE
feat: add voxtype sysext (AI voice dictation for Wayland)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 snosi is a bootable container image build system using [mkosi](https://github.com/systemd/mkosi) to produce Debian Trixie-based immutable OS images and system extensions (sysexts). Images are deployed via bootc/systemd-boot with atomic updates.
 
-**Outputs:** 3 OCI desktop images (snow, snowfield, flurry — flurry is the Hyprland/Omarchy-replica desktop, see docs/plans/2026-08-25-flurry-omarchy-plan.md), 1 OCI server image (cayo), and 26 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, chatgpt, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, localsend, moonlight, nix, obsidian, paseo, pilothouse, podman, sunshine, tailscale, vscode).
+**Outputs:** 3 OCI desktop images (snow, snowfield, flurry — flurry is the Hyprland/Omarchy-replica desktop, see docs/plans/2026-08-25-flurry-omarchy-plan.md), 1 OCI server image (cayo), and 27 sysext overlay images (1password, 1password-cli, azurevpn, bitwarden, chatgpt, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, localsend, moonlight, nix, obsidian, paseo, pilothouse, podman, sunshine, tailscale, voxtype, vscode).
 
 ## Build Commands
 
@@ -14,7 +14,7 @@ Requires: just, git, python3, root/sudo access. mkosi itself is auto-bootstrappe
 
 ```bash
 just                    # List targets
-just sysexts            # Build base + all 26 sysexts
+just sysexts            # Build base + all 27 sysexts
 just snow               # Build snow desktop image
 just snowfield          # Build snowfield (Surface kernel)
 just cayo               # Build cayo server image
@@ -560,7 +560,7 @@ those libs from other suites (flurry: xkbcommon/pipewire/alsa/mesa from
 backports) got shadow-DOWNGRADED for all of `/usr` on merge (killed
 Hyprland, root-caused live 2026-08-25). `mkosi.images/gui-base` is an
 internal never-published directory image (base + common GUI lib closure);
-the desktop-app sysexts (twelve today; the wiring-parity test enumerates them) use `Dependencies=gui-base` +
+the desktop-app sysexts (thirteen today; the wiring-parity test enumerates them) use `Dependencies=gui-base` +
 `BaseTrees=%O/gui-base` + the `sysext-no-divergent-libs.sh` finalize
 tripwire (fails the build on any delta file matching
 `shared/sysext/divergent-lib-families.txt`). THE CONTRACT: every gui-base

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The project produces:
 | **podman**          | Podman + Distrobox                                              | sysext        |
 | **sunshine**        | Sunshine self-hosted game streaming host for Moonlight          | sysext        |
 | **tailscale**       | Tailscale VPN client                                            | sysext        |
+| **voxtype**         | Voxtype AI voice dictation for Wayland                          | sysext        |
 | **vscode**          | Visual Studio Code desktop application                          | sysext        |
 
 Protected bootc publication validates each candidate with host Podman while
@@ -208,7 +209,7 @@ sudo test/native-ab-update-test.sh \
              sysexts                         profiles
     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐  │
     │    │    │    │    │    │    │    │    │    │    │  ┌──┴──────┐
-  1password 1password-cli azurevpn bitwarden chatgpt claude-desktop code-server coder debdev dev docker edge github-copilot incus k3s lemonade nix paseo pilothouse podman sunshine tailscale vscode
+  1password 1password-cli azurevpn bitwarden chatgpt claude-desktop code-server coder debdev dev docker edge github-copilot incus k3s lemonade localsend moonlight nix obsidian paseo pilothouse podman sunshine tailscale voxtype vscode
                                      snow            cayo
                                       │
                                   snowfield
@@ -252,6 +253,7 @@ Sysexts are overlay images that extend the base system without modifying it. The
 | **podman**        | Podman, Distrobox, buildah, crun              | [mkosi.images/podman/mkosi.conf](mkosi.images/podman/mkosi.conf)               |
 | **sunshine**      | Sunshine self-hosted game streaming host for Moonlight | [mkosi.images/sunshine/mkosi.conf](mkosi.images/sunshine/mkosi.conf)     |
 | **tailscale**     | Tailscale VPN client                          | [mkosi.images/tailscale/mkosi.conf](mkosi.images/tailscale/mkosi.conf)         |
+| **voxtype**       | Voxtype AI voice dictation for Wayland         | [mkosi.images/voxtype/mkosi.conf](mkosi.images/voxtype/mkosi.conf)             |
 | **vscode**        | Visual Studio Code desktop application         | [mkosi.images/vscode/mkosi.conf](mkosi.images/vscode/mkosi.conf)               |
 
 The Pilothouse sysext explicitly configures Updex, Podman, Docker, and Incus.
@@ -608,7 +610,7 @@ Where feasible, third-party workflow actions are pinned to specific commit SHAs 
 
 Triggered on push/PR to main, this workflow:
 
-1. Builds the base image and all 23 sysexts (1password, 1password-cli, azurevpn, bitwarden, chatgpt, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, nix, paseo, pilothouse, podman, sunshine, tailscale, vscode). The PR-facing root mkosi build holds only `contents: read` and no package, OIDC, or attestation write scope.
+1. Builds the base image and all 27 sysexts (1password, 1password-cli, azurevpn, bitwarden, chatgpt, claude-desktop, code-server, coder, debdev, dev, docker, edge, github-copilot, incus, k3s, lemonade, localsend, moonlight, nix, obsidian, paseo, pilothouse, podman, sunshine, tailscale, voxtype, vscode). The PR-facing root mkosi build holds only `contents: read` and no package, OIDC, or attestation write scope.
 2. Outside pull requests, publishes sysexts to the Frostyard repository (Cloudflare R2) via the `frostyard/repogen` action
 3. Outside pull requests, uploads package manifests for version tracking
 

--- a/docs/design/sysexts.md
+++ b/docs/design/sysexts.md
@@ -486,7 +486,8 @@ same shadowing on mesa but survived because gbm's ABI tolerated it).
 **The fix — `mkosi.images/gui-base`**: an internal, never-published
 directory image (base + the common GUI lib closure). Desktop-app sysexts
 (1password, azurevpn, bitwarden, chatgpt, claude-desktop, edge,
-github-copilot, localsend, moonlight, obsidian, sunshine, vscode) set
+github-copilot, localsend, moonlight, obsidian, sunshine, voxtype,
+vscode) set
 `Dependencies=gui-base` +
 `BaseTrees=%O/gui-base`, so their deltas omit the entire common GUI stack
 and each product supplies its own suite's version at merge time.

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -28,6 +28,7 @@ Dependencies=base
              podman
              sunshine
              tailscale
+             voxtype
              vscode
 
 

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.voxtype.d/voxtype.feature
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.voxtype.d/voxtype.feature
@@ -1,0 +1,4 @@
+[Feature]
+Description=Voxtype AI voice dictation for Wayland
+Documentation=https://github.com/peteonrails/voxtype
+Enabled=false

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.voxtype.d/voxtype.transfer
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysupdate.voxtype.d/voxtype.transfer
@@ -1,0 +1,20 @@
+[Transfer]
+Features=voxtype
+Verify=true
+
+[Source]
+Type=url-file
+Path=https://repository.frostyard.org/ext/voxtype/
+MatchPattern=voxtype_@v_%w_%a.raw.zst \
+             voxtype_@v_%w_%a.raw.xz \
+             voxtype_@v_%w_%a.raw.gz \
+             voxtype_@v_%w_%a.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d/
+MatchPattern=voxtype_@v_%w_%a.raw.zst \
+             voxtype_@v_%w_%a.raw.xz \
+             voxtype_@v_%w_%a.raw.gz \
+             voxtype_@v_%w_%a.raw
+CurrentSymlink=voxtype.raw

--- a/mkosi.images/voxtype/mkosi.conf
+++ b/mkosi.images/voxtype/mkosi.conf
@@ -1,0 +1,39 @@
+[Config]
+# Desktop-app sysext: built against gui-base (base + the common GUI lib
+# closure) so the delta cannot carry product-divergent GUI libraries
+# (issue #781) — voxtype's deb depends on libasound2t64, a divergent
+# family on flurry (backports alsa); the no-divergent-libs finalize is
+# the matching tripwire.
+Dependencies=gui-base
+
+[Output]
+ImageId=voxtype
+Output=voxtype
+Overlay=yes
+ManifestFormat=json
+Format=sysext
+
+[Content]
+Bootable=no
+BaseTrees=%O/gui-base
+PostOutputScripts=%D/shared/sysext/postoutput/sysext-postoutput.sh
+FinalizeScripts=%D/shared/sysext/finalize/sysext-required-paths.sh,%D/shared/sysext/finalize/sysext-strip-icon-cache.sh,%D/shared/sysext/finalize/sysext-no-divergent-libs.sh
+
+# voxtype comes from the Frostyard APT repository (built by
+# frostyard/omarchy-apps); apt resolves its runtime dependencies.
+# The text-output chain is bundled so the sysext works on every desktop
+# product: wtype (wlroots/Hyprland virtual-keyboard typing — flurry),
+# ydotool (uinput typing, the only driver GNOME/mutter supports — snow;
+# trixie has no ydotool, so apt takes the sandbox's trixie-backports
+# candidate, same pattern as lemonade's libcpp-httplib0.41), and
+# wl-clipboard for voxtype's clipboard/paste fallback. ydotool's deb
+# ships its own user service and the 80-uinput udev rule (input-group
+# access); like sunshine's udev rules, those take effect on the next
+# boot unless applied manually after the first merge.
+Packages=voxtype
+         wtype
+         ydotool
+         wl-clipboard
+
+[Build]
+Environment=KEYPACKAGE=voxtype

--- a/mkosi.images/voxtype/required-paths.txt
+++ b/mkosi.images/voxtype/required-paths.txt
@@ -1,0 +1,10 @@
+# voxtype sysext: AI voice dictation for Wayland (Frostyard APT package)
+/usr/bin/voxtype
+# Text-output chain: wtype (wlroots), ydotool (GNOME/uinput), clipboard fallback
+/usr/bin/wtype
+/usr/bin/ydotool
+/usr/bin/ydotoold
+/usr/lib/systemd/user/ydotool.service
+/usr/lib/udev/rules.d/80-uinput.rules
+/usr/bin/wl-copy
+/usr/bin/wl-paste


### PR DESCRIPTION
## Summary

Adds a **voxtype** sysext packaging the Frostyard-repo `voxtype` deb (0.7.5; upstream [peteonrails/voxtype](https://github.com/peteonrails/voxtype), repackaged by frostyard/omarchy-apps) — push-to-talk whisper dictation for Wayland.

- **gui-base build** with the `sysext-no-divergent-libs.sh` tripwire (issue #781 pattern): voxtype depends on `libasound2t64`, and alsa is a divergent family on flurry (backports). voxtype becomes the 13th gui-base sysext.
- **Bundled text-output chain** so the sysext is self-contained on every desktop product: `wtype` (wlroots/Hyprland typing), `ydotool` from trixie-backports (the only typing driver GNOME/mutter supports — sole-candidate backports pull, same pattern as lemonade's `libcpp-httplib0.41`; its deb ships the ydotoold user service and the `80-uinput` input-group udev rule), and `wl-clipboard` for voxtype's clipboard/paste fallback. Like sunshine's udev rules, the uinput rule takes effect on the next boot unless applied manually after the first merge. No preset/`Upholds=` activation — ydotoold and the voxtype daemon are user-scope, started per-user (voxtype's own `voxtype setup systemd` installs its user service).
- Per-component sysupdate `voxtype.transfer`/`voxtype.feature` (`Enabled=false`), `required-paths.txt`, root `mkosi.conf` wiring, and doc updates (AGENTS.md counts/lists, README tables, docs/design/sysexts.md gui-base list).

## Test plan

- `test/sysext-divergent-libs-test.sh`: 28/28, voxtype detected with correct gui-base + tripwire wiring
- Local mkosi build: delta clean per the divergent-libs check; image carries only voxtype + the three output tools, ydotool.service, and the udev rule
- Live validation on a snow install: merged via `systemd-sysext refresh`, uinput udev rule applied (`root:input 0660`), ydotoold user service active, `voxtype setup check` all green, whisper transcription verified on the whisper.cpp JFK sample (0.66s, word-perfect), and real end-to-end dictation (evdev hotkey → whisper → ydotool typing) used to write part of this review

🤖 Generated with [Claude Code](https://claude.com/claude-code)