### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -1,5 +1,5 @@
 code=1.135.0-1787669172
 docker-ce=5:29.7.2-1~debian.13~trixie
 1password-cli=2.39.0-1
-claude-desktop=1.37937.3
-chatgpt=26.820.71523
+claude-desktop=1.40609.0
+chatgpt=26.825.32147

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -2,6 +2,6 @@
   "code": "1.135.0-1787669172",
   "docker-ce": "5:29.7.2-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
-  "claude-desktop": "1.37937.3",
-  "chatgpt": "26.820.71523"
+  "claude-desktop": "1.40609.0",
+  "chatgpt": "26.825.32147"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

claude-desktop: 1.37937.3 -> 1.40609.0
chatgpt: 26.820.71523 -> 26.825.32147


**Please verify the builds work before merging.**