### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -2,4 +2,4 @@ code=1.135.0-1787669172
 docker-ce=5:29.7.2-1~debian.13~trixie
 1password-cli=2.39.0-1
 claude-desktop=1.40609.0
-chatgpt=26.825.41651
+chatgpt=26.825.51511

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -3,5 +3,5 @@
   "docker-ce": "5:29.7.2-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
   "claude-desktop": "1.40609.0",
-  "chatgpt": "26.825.41651"
+  "chatgpt": "26.825.51511"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

chatgpt: 26.825.41651 -> 26.825.51511


**Please verify the builds work before merging.**