### PR TITLE
fix: adapt Lemonade sysext to 11.8 config layout

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -240,6 +240,11 @@ jobs:
         # required-paths.txt entries. No root, network, or image build.
         run: ./test/sysext-required-paths-test.sh
 
+      - name: Validate Lemonade sysext integration
+        # Lemonade 11.8 moved its environment template to /etc/default/lemond;
+        # exercise the sysext's factory relocation and tmpfiles wiring.
+        run: ./test/lemonade-sysext-test.sh
+
       - name: Validate Pilothouse sysext integration
         # Structural service/drop-in and direct-DEB dependency fixtures. No root,
         # network, live endpoints, or image build.

--- a/mkosi.images/lemonade/mkosi.extra/usr/lib/tmpfiles.d/lemonade.conf
+++ b/mkosi.images/lemonade/mkosi.extra/usr/lib/tmpfiles.d/lemonade.conf
@@ -1,4 +1,3 @@
-# Copy lemonade config from factory defaults (see mkosi.finalize);
-# lemond.service reads EnvironmentFile drop-ins from /etc/lemonade/conf.d
-# (HF_TOKEN, LEMONADE_API_KEY, …).
-C /etc/lemonade - - - - -
+# Copy Lemonade's environment file from factory defaults (see mkosi.finalize).
+# Lemonade 11.8's lemond.service reads EnvironmentFile=-/etc/default/lemond.
+C /etc/default/lemond - - - - -

--- a/mkosi.images/lemonade/mkosi.finalize
+++ b/mkosi.images/lemonade/mkosi.finalize
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -euo pipefail
 
-# Capture /etc/lemonade to factory defaults for tmpfiles.d to restore at
-# boot. lemond.service reads EnvironmentFile=-/etc/lemonade/conf.d/*.conf
-# (HF_TOKEN, LEMONADE_API_KEY, …); the deb ships only the commented
-# zz-secrets.conf template, so the factory copy carries no real secrets.
-mkdir -p "$BUILDROOT/usr/share/factory/etc"
+# Capture /etc/default/lemond to factory defaults for tmpfiles.d to restore at
+# boot. Lemonade 11.8 moved its EnvironmentFile from the former
+# /etc/lemonade/conf.d/*.conf drop-ins to this single file. The deb ships only
+# a commented template, so the factory copy carries no real secrets.
+mkdir -p "$BUILDROOT/usr/share/factory/etc/default"
 
-if [ -d "$BUILDROOT/etc/lemonade" ]; then
-    cp --archive --update=none "$BUILDROOT/etc/lemonade" \
-       "$BUILDROOT/usr/share/factory/etc/"
+if [ -e "$BUILDROOT/etc/default/lemond" ]; then
+    cp --archive --update=none "$BUILDROOT/etc/default/lemond" \
+       "$BUILDROOT/usr/share/factory/etc/default/"
 fi

--- a/mkosi.images/lemonade/required-paths.txt
+++ b/mkosi.images/lemonade/required-paths.txt
@@ -5,8 +5,8 @@
 /usr/lib/sysusers.d/lemonade.conf
 # Sole backports dependency, pulled via Packages= (not present in base)
 /usr/lib/x86_64-linux-gnu/libcpp-httplib.so.0.41
-# Factory copy of /etc/lemonade (injected at boot by tmpfiles)
-/usr/share/factory/etc/lemonade/conf.d/zz-secrets.conf
+# Factory copy of /etc/default/lemond (injected at boot by tmpfiles)
+/usr/share/factory/etc/default/lemond
 # Boot-time group memberships, config injection, and activation
 /usr/lib/sysusers.d/lemonade-groups.conf
 /usr/lib/tmpfiles.d/lemonade.conf

--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -50,9 +50,9 @@
     "version": "1.36.3+k3s1"
   },
   "lemonade": {
-    "url": "https://github.com/lemonade-sdk/lemonade/releases/download/v11.7.0/lemonade-server_11.7.0-debian13_amd64.deb",
-    "sha256": "68bbb117c4f6a87aa9b21dabadb553423baae3175c2daeed0bfd3985f1440857",
-    "version": "11.7.0"
+    "url": "https://github.com/lemonade-sdk/lemonade/releases/download/v11.8.1/lemonade-server_11.8.1-debian13_amd64.deb",
+    "sha256": "faf3ab2a3366a5e07471b372c546461f660f174fcaf63c6e61fbbe39b8aa1c86",
+    "version": "11.8.1"
   },
   "paseo": {
     "url": "https://github.com/getpaseo/paseo/releases/download/v0.5.1/Paseo-0.5.1-amd64.deb",

--- a/test/lemonade-sysext-test.sh
+++ b/test/lemonade-sysext-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+finalize="$repo_root/mkosi.images/lemonade/mkosi.finalize"
+tmpfiles="$repo_root/mkosi.images/lemonade/mkosi.extra/usr/lib/tmpfiles.d/lemonade.conf"
+required_paths="$repo_root/mkosi.images/lemonade/required-paths.txt"
+checksums="$repo_root/shared/download/sysext-checksums.json"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+version="$(jq -er '.lemonade.version' "$checksums")"
+if ! dpkg --compare-versions "$version" ge 11.8.1; then
+    printf 'expected pinned Lemonade version >= 11.8.1, found %s\n' "$version" >&2
+    exit 1
+fi
+
+buildroot="$work_dir/buildroot"
+source_file="$buildroot/etc/default/lemond"
+factory_file="$buildroot/usr/share/factory/etc/default/lemond"
+mkdir -p "$(dirname "$source_file")"
+printf '#HF_TOKEN=\n#LEMONADE_API_KEY=\n' >"$source_file"
+chmod 0640 "$source_file"
+
+BUILDROOT="$buildroot" "$finalize"
+cmp "$source_file" "$factory_file"
+[[ $(stat -c '%a' "$factory_file") == 640 ]]
+
+grep -qx 'C /etc/default/lemond - - - - -' "$tmpfiles"
+grep -qx '/usr/share/factory/etc/default/lemond' "$required_paths"
+
+if grep -Fq '/etc/lemonade/conf.d' "$tmpfiles" "$required_paths"; then
+    echo 'legacy Lemonade conf.d contract is still present' >&2
+    exit 1
+fi
+
+echo 'lemonade-sysext-test: PASSED'

--- a/test/registry.tsv
+++ b/test/registry.tsv
@@ -57,6 +57,7 @@ firn-installer-iso-test.sh	unwired	-
 flurry-keyring-test.sh	unwired	-
 generate-sbom-test.sh	unwired	-
 latest-apt-version-test.sh	ci	validate.yml
+lemonade-sysext-test.sh	ci	validate.yml
 native-ab-components-test.sh	unwired	-
 native-ab-contracts-test.sh	ci	nightly-compliance.yml,validate.yml
 native-ab-include-order-test.sh	unwired	-


### PR DESCRIPTION
# Summary

- pin Lemonade Server 11.8.1, taking only the Lemonade update from #905
- follow upstream's move from `/etc/lemonade/conf.d/*.conf` to `/etc/default/lemond`
- preserve the packaged environment template under `/usr/share/factory` and restore it at boot through tmpfiles
- add a focused fixture test and wire it into `validate.yml`

This fixes the failure in https://github.com/frostyard/snosi/actions/runs/33414066322/job/99560408640. The other automated dependency updates in #905 remain outside this focused change.

## Type of change

- [ ] Image or profile change (`cayo`, `snow`, `snowfield`, native A/B profiles)
- [x] Sysext change
- [x] Build pipeline / CI change
- [ ] Documentation only
- [ ] Other:

## Validation

- [x] `shellcheck` / `validate.yml` static checks pass for touched scripts
- [x] Relevant `just` build target(s) succeed
- [x] Relevant tests in `test/` were run

Commands run:

```text
shellcheck -S warning -x mkosi.images/lemonade/mkosi.finalize test/lemonade-sysext-test.sh
./test/lemonade-sysext-test.sh
./test/sysext-required-paths-test.sh
./test/sysext-authoring-contract-test.sh
./test/test-registry-test.sh
git diff --check
just sysexts
```

The clean sysext build produced `lemonade-server 11.8.1~13` and completed all sysexts successfully.

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] New external downloads are pinned and go through `verified_download()`
- [x] Documentation updated (`CLAUDE.md`, `README.md`, `docs/`) where relevant
