### PR TITLE
chore: pin repogen action to v0.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
           sudo ./manifestmv.sh
       - name: Publish sysexts to frostyard repo
         if: github.event_name != 'pull_request'
-        uses: frostyard/repogen/.github/actions/publish-to-r2@6648671cec7015231fac1f278f09ee5799281bc9
+        uses: frostyard/repogen/.github/actions/publish-to-r2@ea8cd1f0b2fe4d2370a83dff1feacfa7a4aef9ae # v0.4.1
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary

- update the pinned `frostyard/repogen` composite action to the immutable commit behind `v0.4.1`
- pick up the R2 publishing fix that prevents the diagnostic file listing from aborting under `pipefail`

This addresses the failure observed in:
https://github.com/frostyard/snosi/actions/runs/33458598572/job/99709258994

Upstream fix:
https://github.com/frostyard/repogen/pull/61

## Verification

- confirmed `v0.4.1` resolves to `ea8cd1f0b2fe4d2370a83dff1feacfa7a4aef9ae`
- confirmed the tagged action contains the corrected `find | sed` pipeline
- parsed `.github/workflows/build.yml` as YAML
- `python3 test/build-workflow-permissions-test.py`
- `bash test/workflow-path-filter-test.sh` — 253 passed
