### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -1,5 +1,5 @@
-code=1.136.0-1788342447
-docker-ce=5:29.7.2-1~debian.13~trixie
+code=1.136.1-1788413865
+docker-ce=5:29.8.0-1~debian.13~trixie
 1password-cli=2.39.0-1
 claude-desktop=1.40609.1
-chatgpt=26.901.20858
+chatgpt=26.901.31953

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -1,7 +1,7 @@
 {
-  "code": "1.136.0-1788342447",
-  "docker-ce": "5:29.7.2-1~debian.13~trixie",
+  "code": "1.136.1-1788413865",
+  "docker-ce": "5:29.8.0-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
   "claude-desktop": "1.40609.1",
-  "chatgpt": "26.901.20858"
+  "chatgpt": "26.901.31953"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

code: 1.136.0-1788342447 -> 1.136.1-1788413865
docker-ce: 5:29.7.2-1~debian.13~trixie -> 5:29.8.0-1~debian.13~trixie
chatgpt: 26.901.20858 -> 26.901.31953


**Please verify the builds work before merging.**