### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -1,5 +1,5 @@
 code=1.136.1-1788413865
 docker-ce=5:29.8.0-1~debian.13~trixie
 1password-cli=2.39.0-1
-claude-desktop=1.40609.1
-chatgpt=26.901.31953
+claude-desktop=1.46388.2
+chatgpt=26.901.41600

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -2,6 +2,6 @@
   "code": "1.136.1-1788413865",
   "docker-ce": "5:29.8.0-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
-  "claude-desktop": "1.40609.1",
-  "chatgpt": "26.901.31953"
+  "claude-desktop": "1.46388.2",
+  "chatgpt": "26.901.41600"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

claude-desktop: 1.40609.1 -> 1.46388.2
chatgpt: 26.901.31953 -> 26.901.41600


**Please verify the builds work before merging.**