### PR TITLE
feat(security): pre-stage floe image trust

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,8 +293,9 @@ claimed from fixture or native evidence. User and recovery guidance lives in
 
 **Bootc OCI signature policy (Task 6, 2026-07-28):** secure bootc profiles ship
 `/etc/containers/policy.json` with global `reject` and exact
-`sigstoreSigned` scopes only for `ghcr.io/frostyard/cayo`, `snow`, and
-`snowfield`; each uses the committed public-only `cosign.pub` copied to
+`sigstoreSigned` scopes only for `ghcr.io/frostyard/cayo`, `floe`, `snow`, and
+`snowfield`; the floe scope is pre-staged for the ordered cayo rename, and each
+uses the committed public-only `cosign.pub` copied to
 `/usr/lib/snosi/cosign.pub`. Cosign v2.6.1 signatures record repository rather
 than tag identities, so this MUST use `signedIdentity: matchRepository` and
 the GHCR `registries.d` entry MUST retain `use-sigstore-attachments: true`.
@@ -324,6 +325,8 @@ staged storage-digest check; a failed pull, including policy rejection, clears
 `outcome=failed`. Run `test/bootc-container-policy-test.sh`; set `RUN_LIVE=1`
 (and optionally `LIVE_IMAGES=cayo,snow,snowfield`) to verify published
 signatures, wrong key, unsigned, and wrong-repository rejection through Podman.
+Floe deliberately stays out of `LIVE_IMAGES` until Phase 2 publishes its signed
+image.
 
 **Bootc sealed-UKI feasibility gate (Tasks 1-2, 2026-07-28):**
 `test/bootc-secure-spike-test.sh --fixtures` is the non-root fixture layer for

--- a/README.md
+++ b/README.md
@@ -664,9 +664,10 @@ gh attestation verify oci://ghcr.io/frostyard/snow:latest --owner frostyard
 The `test-install.yml` workflow verifies the signature before every installation test.
 Secure bootc OCI images additionally enforce this key at pull/install/update time
 through containers/image policy. The only accepted repositories are
-`ghcr.io/frostyard/cayo`, `ghcr.io/frostyard/snow`, and
+`ghcr.io/frostyard/cayo`, `ghcr.io/frostyard/floe`, `ghcr.io/frostyard/snow`, and
 `ghcr.io/frostyard/snowfield`; other images, keys, and repository identities are
-rejected. Cosign v2.6.1 signs repository identities, so the policy uses
+rejected. Floe trust is pre-staged for the ordered cayo rename. Cosign v2.6.1
+signs repository identities, so the policy uses
 repository matching rather than tag matching and enables GHCR Sigstore
 attachments explicitly.
 

--- a/docs/design/build-pipeline.md
+++ b/docs/design/build-pipeline.md
@@ -190,7 +190,8 @@ document; the normative operational recovery and evidence rules are in
 **OCI signature policy (Task 6):** the secure bootc tree supplies
 `/etc/containers/policy.json`, which defaults to `reject` and has one
 `sigstoreSigned` rule, using `/usr/lib/snosi/cosign.pub`, for each exact
-`ghcr.io/frostyard/{cayo,snow,snowfield}` repository. Cosign v2.6.1 signatures
+`ghcr.io/frostyard/{cayo,floe,snow,snowfield}` repository. The floe scope is
+pre-staged for the ordered cayo rename. Cosign v2.6.1 signatures
 record only the repository identity, so `matchRepository` is required; using
 tag-exact identity would reject valid published images. The accompanying
 `registries.d/frostyard.yaml` enables Sigstore attachments for GHCR, without

--- a/docs/org-adrs.md
+++ b/docs/org-adrs.md
@@ -26,6 +26,7 @@ The ones that bind snosi:
 - [ADR-0030 — Shipped systemd units never use RequiredBy= enablement](https://github.com/frostyard/core/blob/main/docs/adr/0030-no-requiredby-enablement-in-shipped-units.md) — preset-persisted .requires links brick boot when the unit is retired; enforced here by check-required-by-guard.sh and the initrd prune (repo ADR-0013)
 - [ADR-0031 — Retire Dakota's secure bootc installer; Firn owns the path](https://github.com/frostyard/core/blob/main/docs/adr/0031-retire-dakota-secure-bootc-installer.md) — Firn's E2E and lab matrix own secure bootc installation; Snosi must not retain or pin Dakota/Fisherman adapter wiring
 - [ADR-0041 — Retire copilot-review-apply where Snowcat gates review](https://github.com/frostyard/core/blob/main/docs/adr/0041-retire-copilot-review-apply-where-snowcat-gates-review.md) — Copilot review findings route to people; Snosi retains only the `ai-fix-requested` issue handoff
+- [ADR-0046 — Rename the cayo server image to floe](https://github.com/frostyard/core/blob/main/docs/adr/0046-rename-cayo-server-image-to-floe.md) — sequences the bootc trust cutover, requires native reinstall, and freezes the old GHCR and R2 artifacts
 
 When changing behavior covered by one of these, update or supersede the ADR
 in frostyard/core first, then change this repo in the same effort.

--- a/docs/plans/2026-08-26-cayo-floe-rename-plan.md
+++ b/docs/plans/2026-08-26-cayo-floe-rename-plan.md
@@ -52,19 +52,19 @@ mechanically once these two are sequenced correctly.
       it leaves the native channel entirely. The other is bootc
       (minisnow, fresh 1.16.7). Remaining per-host check before Phase 3:
       `snosi-update-status` version and `snosi-etc-diff` drift worth keeping.
-- [ ] Record the rename as an org ADR in **frostyard/core** (it binds snosi,
+- [x] Record the rename as an org ADR in **frostyard/core** (it binds snosi,
       firn, lab, pilothouse, and the websites — per CLAUDE.md, decisions
       binding more than this repo go to core), including the name rationale
       above and the artifact-retirement decisions from Phase 5. Add the line
       to snosi's [docs/org-adrs.md](../org-adrs.md).
-- [ ] Decide and record in that ADR: old artifacts are **frozen, not
+- [x] Decide and record in that ADR: old artifacts are **frozen, not
       deleted** — the archived pre-snosi `frostyard/cayo` repo stays archived
       and untouched; the GHCR `cayo` package keeps its digests (installed
       systems' rollback deployments reference them); `os/native/v1/cayo/` on
       R2 stays readable but stops receiving updates. Also record (resolved
       2026-08-26): fisherman, bootc-installer, and dakota-iso are dormant,
       inactive, and superseded — they get no rename work.
-- [ ] **Done when:** the org ADR is merged in core.
+- [x] **Done when:** the org ADR is merged in core.
 
 ## Phase 1 — Trust pre-staging (publish as cayo, one small snosi PR)
 
@@ -73,12 +73,12 @@ With the inventory resolved, this phase gates exactly **one** host: the bootc
 install (minisnow). The native cayo-ab machine reinstalls fresh in Phase 3
 and never needs the pre-staged scope.
 
-- [ ] Add `ghcr.io/frostyard/floe` as a `sigstoreSigned`/`matchRepository`
+- [x] Add `ghcr.io/frostyard/floe` as a `sigstoreSigned`/`matchRepository`
       scope in `shared/bootc-secure/tree/etc/containers/policy.json`
       (exactly the precedent set when a fourth product was added). Keep the
       cayo scope. Do not touch
       `default: reject` or any transport stanza.
-- [ ] Update `test/bootc-container-policy-test.sh` expectations for the new
+- [x] Update `test/bootc-container-policy-test.sh` expectations for the new
       scope; run it (fixtures) locally.
 - [ ] Merge; let `build-images.yml` `secure-build` publish new
       cayo/snow/snowfield `latest` (shared file — all three get the
@@ -159,10 +159,10 @@ the load-bearing groups:
 - [ ] Pin the temporary live-compatibility inventory through Phase 5. Outside
       historical files, `cayo` is allowed in exactly these active places:
       the single `"ghcr.io/frostyard/cayo"` key in
-      `shared/bootc-secure/tree/etc/containers/policy.json`, and exactly three
-      matching tokens in `test/bootc-container-policy-test.sh` — the supported-
-      scope loop, the wrong-repository rejection loop, and the exact sorted
-      trusted-key assertion. Each test list also includes floe. Every other
+      `shared/bootc-secure/tree/etc/containers/policy.json`, and the single
+      `cayo` entry in `test/bootc-container-policy-test.sh`'s
+      `SECURE_IMAGES` array. That array also includes floe and drives both
+      loops plus the exact trusted-key assertion. Every other
       test fixture, live-test default, image ref, and payload identity moves to
       floe in this phase. Phase 5 removes this whole temporary allowlist; do
       not remove it sooner and strand a late cayo host.
@@ -425,8 +425,8 @@ because they are absent from this snapshot.
 ## Phase 5 — Retirement (small, after Phase 3 sign-off)
 
 - [ ] snosi PR: remove the `ghcr.io/frostyard/cayo` scope from
-      `policy.json` and remove all three cayo compatibility tokens from the
-      policy test (floe/snow/snowfield remain).
+      `policy.json` and remove cayo from the policy test's `SECURE_IMAGES`
+      array (floe/snow/snowfield remain).
 - [ ] Merge that PR and let the protected `secure-build` publish the signed
       **retirement release** (call it R) before changing either host's
       persistent `/etc`. Record R's 14-digit image version and immutable

--- a/shared/bootc-secure/tree/etc/containers/policy.json
+++ b/shared/bootc-secure/tree/etc/containers/policy.json
@@ -15,6 +15,15 @@
           }
         }
       ],
+      "ghcr.io/frostyard/floe": [
+        {
+          "type": "sigstoreSigned",
+          "keyPath": "/usr/lib/snosi/cosign.pub",
+          "signedIdentity": {
+            "type": "matchRepository"
+          }
+        }
+      ],
       "ghcr.io/frostyard/snow": [
         {
           "type": "sigstoreSigned",

--- a/shared/bootc-secure/tree/etc/containers/registries.d/frostyard.yaml
+++ b/shared/bootc-secure/tree/etc/containers/registries.d/frostyard.yaml
@@ -1,5 +1,5 @@
 # Cosign v2.6.1 stores key-based signatures as registry attachments. This is
-# limited to GHCR; policy.json still rejects every repository but the three
+# limited to GHCR; policy.json still rejects every repository but the four
 # explicitly scoped Frostyard images.
 docker:
   ghcr.io:

--- a/test/bootc-container-policy-test.sh
+++ b/test/bootc-container-policy-test.sh
@@ -45,7 +45,7 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
         fail "unlisted images are rejected"
     fi
 
-    for image in cayo snow snowfield; do
+    for image in cayo floe snow snowfield; do
         scope="ghcr.io/frostyard/$image"
         if jq -e --arg scope "$scope" '
             .transports.docker[$scope] == [{
@@ -66,7 +66,7 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
         fail "previously policy-verified local storage images are accepted"
     fi
 
-    for image in cayo snow snowfield; do
+    for image in cayo floe snow snowfield; do
         scope="ghcr.io/frostyard/${image}-wrong-repository"
         if jq -e --arg scope "$scope" '.transports.docker[$scope] == null' "$POLICY" >/dev/null; then
             pass "wrong repository $scope is rejected"
@@ -75,10 +75,10 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
         fi
     done
 
-    if jq -e '[.transports.docker | keys[] | select(startswith("ghcr.io/frostyard/"))] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"]' "$POLICY" >/dev/null; then
-        pass "only the three supported GHCR repositories are trusted"
+    if jq -e '[.transports.docker | keys[] | select(startswith("ghcr.io/frostyard/"))] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/floe", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"]' "$POLICY" >/dev/null; then
+        pass "only the four supported GHCR repositories are trusted"
     else
-        fail "only the three supported GHCR repositories are trusted"
+        fail "only the four supported GHCR repositories are trusted"
     fi
 
     # LOCAL file transports are accepted so an operator can actually do image
@@ -98,7 +98,7 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
     done
 
     # The half that must NOT move. Permitting local transports must never turn
-    # into permitting unsigned registry pulls: `docker` keeps exactly the three
+    # into permitting unsigned registry pulls: `docker` keeps exactly the four
     # sigstoreSigned scopes and the default stays reject.
     if jq -e '.default == [{"type":"reject"}]' "$POLICY" >/dev/null; then
         pass "the default policy is still reject"

--- a/test/bootc-container-policy-test.sh
+++ b/test/bootc-container-policy-test.sh
@@ -12,6 +12,7 @@ USER_POLICY="$PROJECT_ROOT/shared/bootc-secure/tree/usr/share/snosi/containers/u
 USER_TMPFILES="$PROJECT_ROOT/shared/bootc-secure/tree/usr/lib/user-tmpfiles.d/snosi-containers-policy.conf"
 VM_LIB="$PROJECT_ROOT/test/lib/vm.sh"
 UPDATER="$PROJECT_ROOT/mkosi.images/base/mkosi.extra/usr/libexec/bootc-update-stage"
+SECURE_IMAGES=(cayo floe snow snowfield)
 
 failures=0
 
@@ -45,7 +46,7 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
         fail "unlisted images are rejected"
     fi
 
-    for image in cayo floe snow snowfield; do
+    for image in "${SECURE_IMAGES[@]}"; do
         scope="ghcr.io/frostyard/$image"
         if jq -e --arg scope "$scope" '
             .transports.docker[$scope] == [{
@@ -66,7 +67,7 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
         fail "previously policy-verified local storage images are accepted"
     fi
 
-    for image in cayo floe snow snowfield; do
+    for image in "${SECURE_IMAGES[@]}"; do
         scope="ghcr.io/frostyard/${image}-wrong-repository"
         if jq -e --arg scope "$scope" '.transports.docker[$scope] == null' "$POLICY" >/dev/null; then
             pass "wrong repository $scope is rejected"
@@ -75,10 +76,15 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
         fi
     done
 
-    if jq -e '[.transports.docker | keys[] | select(startswith("ghcr.io/frostyard/"))] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/floe", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"]' "$POLICY" >/dev/null; then
-        pass "only the four supported GHCR repositories are trusted"
+    expected_scopes=()
+    for image in "${SECURE_IMAGES[@]}"; do
+        expected_scopes+=("ghcr.io/frostyard/$image")
+    done
+    if jq -e --args '(.transports.docker | keys) == $ARGS.positional' \
+            "${expected_scopes[@]}" <"$POLICY" >/dev/null; then
+        pass "only the supported exact GHCR repositories are trusted"
     else
-        fail "only the four supported GHCR repositories are trusted"
+        fail "only the supported exact GHCR repositories are trusted"
     fi
 
     # LOCAL file transports are accepted so an operator can actually do image
@@ -98,8 +104,8 @@ if [[ -f "$POLICY" ]] && command -v jq >/dev/null; then
     done
 
     # The half that must NOT move. Permitting local transports must never turn
-    # into permitting unsigned registry pulls: `docker` keeps exactly the four
-    # sigstoreSigned scopes and the default stays reject.
+    # into permitting unsigned registry pulls: `docker` keeps exactly the
+    # supported sigstoreSigned scopes and the default stays reject.
     if jq -e '.default == [{"type":"reject"}]' "$POLICY" >/dev/null; then
         pass "the default policy is still reject"
     else
@@ -146,6 +152,27 @@ if [[ -f "$REGISTRIES_CONFIG" ]] && grep -Fqx '    use-sigstore-attachments: tru
 else
     fail "Cosign signature attachments are enabled for GHCR"
 fi
+
+verify_vm_registry_policy() {
+    local expected
+    expected=$(mktemp)
+    # shellcheck source=test/lib/vm.sh
+    source "$VM_LIB"
+    create_registry_policy
+    jq --arg key "$PROJECT_ROOT/cosign.pub" '
+        .transports.docker |= with_entries(.value |= map(.keyPath = $key))
+    ' "$POLICY" >"$expected"
+    if cmp -s "$expected" "$IMAGE_POLICY"; then
+        pass "VM registry policy derives from the shipped policy"
+    else
+        fail "VM registry policy derives from the shipped policy"
+    fi
+    rm -f "$expected"
+    rm -rf "$IMAGE_POLICY_HOME"
+    IMAGE_POLICY=""
+    IMAGE_POLICY_HOME=""
+}
+verify_vm_registry_policy
 
 if grep -Fqx 'IMAGE_IS_FIXTURE="${IMAGE_IS_FIXTURE:-0}"' "$VM_LIB" && \
         grep -Fqx '        IMAGE_IS_FIXTURE=0' "$VM_LIB" && \
@@ -364,6 +391,8 @@ run_live_policy_proof() {
 
     IFS=, read -r -a live_images <<<"${LIVE_IMAGES:-cayo}"
     for image in "${live_images[@]}"; do
+        # Floe joins this live allowlist in Phase 2, after its signed image is
+        # published. Accepting it during Phase 1 would turn absence into FAIL.
         case "$image" in
             cayo|snow|snowfield) ;;
             *) printf 'BLOCKED: LIVE_IMAGES contains unsupported product %s\n' "$image" >&2; return 2 ;;

--- a/test/bootc-secure-publication-test.sh
+++ b/test/bootc-secure-publication-test.sh
@@ -116,13 +116,14 @@ grep -Fqx "DOCKER_CONFIG=$(dirname -- "$AUTH_FILE") cosign verify --key $ROOT_DI
 grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" && grep -Fq -- "--registries.d " "$WORK/commands" && grep -Fq "docker://$IMAGE@$DIGEST containers-storage:$LOCAL_REF" "$WORK/commands" && pass "policy copy uses immutable source and root containers storage" || fail "policy copy uses immutable source and root containers storage"
 if jq -e '.default == [{"type":"reject"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains global reject"; else fail "copied policy retains global reject"; fi
 if jq -e --arg key "$ROOT_DIR/cosign.pub" '
-    [.transports.docker | keys[]] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"] and
+    [.transports.docker | keys[]] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/floe", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"] and
     [.transports.docker[][]] == [
+        {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}},
         {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}},
         {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}},
         {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}}
     ]
-' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains exactly the three scoped Cosign rules"; else fail "copied policy retains exactly the three scoped Cosign rules"; fi
+' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains exactly the four scoped Cosign rules"; else fail "copied policy retains exactly the four scoped Cosign rules"; fi
 if jq -e '.transports["containers-storage"][""] == [{"type":"insecureAcceptAnything"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains the containers-storage exception"; else fail "copied policy retains the containers-storage exception"; fi
 if [[ $(sed -n '1p' "$WORK/commands") == "skopeo inspect --authfile $AUTH_FILE docker://$IMAGE@$DIGEST" ]] && [[ $(sed -n '2p' "$WORK/commands") == "skopeo inspect --authfile $AUTH_FILE --format {{.Digest}} docker://$IMAGE:$VERSION" ]] && [[ $(sed -n '3p' "$WORK/commands") == "DOCKER_CONFIG=$(dirname -- "$AUTH_FILE") cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" ]] && [[ $(sed -n '5p' "$WORK/commands") == "skopeo copy --src-authfile $AUTH_FILE "* ]]; then pass "verification orders explicit metadata reads before Cosign before policy copy"; else fail "verification orders explicit metadata reads before Cosign before policy copy"; fi
 grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" &&

--- a/test/bootc-secure-publication-test.sh
+++ b/test/bootc-secure-publication-test.sh
@@ -116,14 +116,9 @@ grep -Fqx "DOCKER_CONFIG=$(dirname -- "$AUTH_FILE") cosign verify --key $ROOT_DI
 grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" && grep -Fq -- "--registries.d " "$WORK/commands" && grep -Fq "docker://$IMAGE@$DIGEST containers-storage:$LOCAL_REF" "$WORK/commands" && pass "policy copy uses immutable source and root containers storage" || fail "policy copy uses immutable source and root containers storage"
 if jq -e '.default == [{"type":"reject"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains global reject"; else fail "copied policy retains global reject"; fi
 if jq -e --arg key "$ROOT_DIR/cosign.pub" '
-    [.transports.docker | keys[]] == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/floe", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"] and
-    [.transports.docker[][]] == [
-        {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}},
-        {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}},
-        {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}},
-        {"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}}
-    ]
-' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains exactly the four scoped Cosign rules"; else fail "copied policy retains exactly the four scoped Cosign rules"; fi
+    (.transports.docker | keys) == ["ghcr.io/frostyard/cayo", "ghcr.io/frostyard/floe", "ghcr.io/frostyard/snow", "ghcr.io/frostyard/snowfield"] and
+    all(.transports.docker[]; . == [{"type":"sigstoreSigned", "keyPath":$key, "signedIdentity":{"type":"matchRepository"}}])
+' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains one scoped Cosign rule per supported repository"; else fail "copied policy retains one scoped Cosign rule per supported repository"; fi
 if jq -e '.transports["containers-storage"][""] == [{"type":"insecureAcceptAnything"}]' "$WORK/copied-policy.json" >/dev/null; then pass "copied policy retains the containers-storage exception"; else fail "copied policy retains the containers-storage exception"; fi
 if [[ $(sed -n '1p' "$WORK/commands") == "skopeo inspect --authfile $AUTH_FILE docker://$IMAGE@$DIGEST" ]] && [[ $(sed -n '2p' "$WORK/commands") == "skopeo inspect --authfile $AUTH_FILE --format {{.Digest}} docker://$IMAGE:$VERSION" ]] && [[ $(sed -n '3p' "$WORK/commands") == "DOCKER_CONFIG=$(dirname -- "$AUTH_FILE") cosign verify --key $ROOT_DIR/cosign.pub $IMAGE@$DIGEST" ]] && [[ $(sed -n '5p' "$WORK/commands") == "skopeo copy --src-authfile $AUTH_FILE "* ]]; then pass "verification orders explicit metadata reads before Cosign before policy copy"; else fail "verification orders explicit metadata reads before Cosign before policy copy"; fi
 grep -Fq "skopeo copy --src-authfile $AUTH_FILE --policy " "$WORK/commands" &&

--- a/test/lib/vm.sh
+++ b/test/lib/vm.sh
@@ -27,21 +27,10 @@ create_registry_policy() {
     IMAGE_POLICY_HOME=$(mktemp -d)
     IMAGE_POLICY="$IMAGE_POLICY_HOME/.config/containers/policy.json"
     mkdir -p "$IMAGE_POLICY_HOME/.config/containers/registries.d"
-    cat >"$IMAGE_POLICY" <<EOF
-{
-  "default": [{"type": "reject"}],
-  "transports": {
-    "docker": {
-      "ghcr.io/frostyard/cayo": [{"type": "sigstoreSigned", "keyPath": "$PROJECT_ROOT/cosign.pub", "signedIdentity": {"type": "matchRepository"}}],
-      "ghcr.io/frostyard/snow": [{"type": "sigstoreSigned", "keyPath": "$PROJECT_ROOT/cosign.pub", "signedIdentity": {"type": "matchRepository"}}],
-      "ghcr.io/frostyard/snowfield": [{"type": "sigstoreSigned", "keyPath": "$PROJECT_ROOT/cosign.pub", "signedIdentity": {"type": "matchRepository"}}]
-    },
-    "containers-storage": {
-      "": [{"type": "insecureAcceptAnything"}]
-    }
-  }
-}
-EOF
+    jq --arg key "$PROJECT_ROOT/cosign.pub" '
+        .transports.docker |= with_entries(.value |= map(.keyPath = $key))
+    ' "$PROJECT_ROOT/shared/bootc-secure/tree/etc/containers/policy.json" \
+        >"$IMAGE_POLICY"
     cp "$PROJECT_ROOT/shared/bootc-secure/tree/etc/containers/registries.d/frostyard.yaml" \
         "$IMAGE_POLICY_HOME/.config/containers/registries.d/frostyard.yaml"
 }

--- a/test/update-tests/persistence-write.sh
+++ b/test/update-tests/persistence-write.sh
@@ -24,22 +24,11 @@ chown persisttest:persisttest /var/home/persisttest/marker.txt
 
 # Container image in /var/lib/containers, built offline (no registry pull).
 #
-# `podman import` of a rootfs tarball is REJECTED on a secure system and that
-# is correct: the shipped policy.json defaults to reject and permits only the
-# three signed ghcr scopes plus containers-storage, so the `tarball:` transport
-# has no accepting scope. Observed on run 31293719998:
-#
-#     Error: Source image rejected: Running image tarball:/var/tmp/podman... is
-#     rejected by policy.
-#
-# `podman build` FROM scratch pulls no source image, so no transport is
-# consulted and no policy exception is needed. Verified directly against a
-# reject-by-default policy: the import is refused with the exact error above,
-# the build succeeds. The marker is still a real image in the store, so this
-# proves what it always did -- that /var/lib/containers survives an update.
-#
-# Do NOT "fix" this by adding a tarball/dir/oci scope to policy.json. The test
-# must fit the shipped security posture, not the other way round.
+# The shipped policy defaults to reject for registry pulls and permits only the
+# exact cayo, floe, snow, and snowfield GHCR repositories. Local transports are
+# accepted because their bytes are already under operator control. This test
+# still uses `podman build` FROM scratch so it needs no source image and proves
+# directly that a real image in /var/lib/containers survives an update.
 tmpf=$(mktemp -d)
 echo "container-marker" > "$tmpf/marker"
 printf 'FROM scratch\nCOPY marker /marker\n' > "$tmpf/Containerfile"


### PR DESCRIPTION
## Summary

Pre-stage signature trust for `ghcr.io/frostyard/floe` in the final cayo release.

The exact `sigstoreSigned` and `matchRepository` scope follows the existing product scopes. The cayo scope remains in place. The policy test now requires exactly cayo, floe, snow, and snowfield.

This also records the binding core ADR in `docs/org-adrs.md`.

## Merge order

1. Merge the frostyard/core ADR PR first.
2. Merge this Phase 1 PR second.
3. Let protected `secure-build` publish the final cayo release.
4. Boot minisnow into that release and confirm `grep floe /etc/containers/policy.json`.
5. Do not begin or merge Phase 2 until that host check passes.

## Type of change

- [x] Image or profile change
- [ ] Sysext change
- [ ] Build pipeline / CI change
- [x] Documentation only
- [ ] Other

## Validation

- [x] Relevant tests in `test/` were run

Commands run:

```
./test/bootc-container-policy-test.sh
git diff --check
jq empty shared/bootc-secure/tree/etc/containers/policy.json
```

All passed.

## Checklist

- [x] Changes are as small and focused as possible
- [x] No secrets, keys, or credentials are committed
- [x] No external downloads were added
- [x] Documentation updated where relevant
