### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -2,4 +2,4 @@ code=1.136.1-1788413865
 docker-ce=5:29.8.0-1~debian.13~trixie
 1password-cli=2.39.0-1
 claude-desktop=1.46388.2
-chatgpt=26.901.41600
+chatgpt=26.901.51231

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -3,5 +3,5 @@
   "docker-ce": "5:29.8.0-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
   "claude-desktop": "1.46388.2",
-  "chatgpt": "26.901.41600"
+  "chatgpt": "26.901.51231"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

chatgpt: 26.901.41600 -> 26.901.51231


**Please verify the builds work before merging.**