### PR TITLE
chore: update image dependencies

### DIFF
--- a/shared/download/image-checksums.json
+++ b/shared/download/image-checksums.json
@@ -5,9 +5,9 @@
     "version": "d8887bc8ce14a47d5b9d45f6697f05d53e43fe9a"
   },
   "brew-install": {
-    "url": "https://raw.githubusercontent.com/Homebrew/install/c8188c1d48d7/install.sh",
+    "url": "https://raw.githubusercontent.com/Homebrew/install/7a133dcc7405/install.sh",
     "sha256": "12479a24be3f5307eecac7cde670fad7118640f031229e964f544b1367b52a41",
-    "version": "c8188c1d48d7"
+    "version": "7a133dcc7405"
   },
   "hotedge": {
     "url": "https://codeload.github.com/frostyard/hotedge/tar.gz/5411c3802803dbaafc6d8014b3a983027dab4704",


### PR DESCRIPTION
Automated update of dependencies consumed by OCI image profile builds.

These updates modify `shared/download/image-checksums.json` and/or
inline Syft, Cosign, and chunkah pins. They should trigger
`build-images.yml`, not the sysext publishing workflow.

**Please verify the image builds work before merging.**