### PR TITLE
fix(base): provision NFS and rpcbind system accounts at boot

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -293,6 +293,9 @@ jobs:
           ./test/wifi-backend-test.sh
           ./test/socat-package-test.sh
 
+      - name: Test NFS system accounts and tmpfiles ownership
+        run: sudo bash ./test/nfs-system-accounts-test.sh
+
       - name: Test RequiredBy guard and initrd requires-pruning fixtures
         run: |
           ./test/required-by-guard-test.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,6 +455,15 @@ Scripts execute in order: **BuildScripts** (in chroot) -> **PostInstallationScri
 
 ### Immutable Filesystem Constraints
 
+**NFS accounts belong in base:** base installs `nfs-common` and its `rpcbind`
+dependency. Keep `statd` and `_rpc` in base's `usr/lib/sysusers.d/`, with
+Debian-compatible `nogroup` primary groups and nologin shells. Package
+postinst account creation in the build root cannot repair missing accounts
+in an installed machine's persistent `/etc`. The existing base NFS tmpfiles
+rules and packaged rpcbind tmpfiles rule need these accounts at boot.
+`sudo bash test/nfs-system-accounts-test.sh` verifies real sysusers/tmpfiles
+creation and preservation of existing identities/state in disposable roots.
+
 - `/usr/` - Read-only. All binaries and libraries must live here.
 - `/etc/` - Overlay on `/usr/etc`. Base configs in image, user changes persist.
 - `/var/` - Persistent, writable. State, logs, container storage.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ assembly never runs a post-assembly chunk pass.
 
 ## Architecture
 
+All OS profiles inherit NFS client support from base. Base sysusers definitions
+create missing `_rpc` and `statd` service accounts before tmpfiles initializes
+their runtime and persistent state; see
+[base NFS service accounts](docs/design/build-pipeline.md#base-nfs-service-accounts).
+
 Naming, path, and policy contracts for the production native A/B products
 (`floe-ab`, `snow-ab`, `snowfield-ab`) are frozen in
 [`docs/native-ab-contracts.md`](docs/native-ab-contracts.md) and validated

--- a/docs/design/build-pipeline.md
+++ b/docs/design/build-pipeline.md
@@ -564,6 +564,26 @@ test, wired into `validate.yml`; the read side is covered by
 
 Each profile has filesystem overlays (ExtraTrees) that are merged into the image:
 
+### Base NFS service accounts
+
+`mkosi.images/base/mkosi.conf` installs `nfs-common`, which depends on
+`rpcbind`. Debian's package postinst scripts create `statd` and `_rpc` in
+the build-time `/etc`; installed machines with persistent account databases
+can still lack them. Base therefore ships `usr/lib/sysusers.d/nfs-common.conf`
+and `rpcbind.conf` to create missing accounts at boot, with dynamically
+allocated UIDs, primary group `nogroup`, and `/usr/sbin/nologin`, matching
+Debian's account setup. Existing identities are preserved.
+
+The directory rules already exist: base's `usr/lib/tmpfiles.d/nfs-common.conf`
+creates `/var/lib/nfs/{sm,sm.bak,state}`, while Debian's packaged
+`rpcbind.conf` creates `/run/rpcbind`. Sysusers supplies their missing owners
+before tmpfiles runs; no additional tmpfiles rule or service is needed.
+Keep these definitions in base so Floe, Snow, and Snowfield inherit them.
+`sudo bash test/nfs-system-accounts-test.sh` (also run by `validate.yml`)
+reproduces the missing-owner failures in disposable roots, then checks account
+creation, directory ownership, idempotence, and preservation of existing
+identities and NFS state using real systemd tools.
+
 ### shared/snow/tree/
 
 Desktop configuration overlay:

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysusers.d/nfs-common.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysusers.d/nfs-common.conf
@@ -1,0 +1,3 @@
+# Match Debian's statd account, including its nogroup primary group.
+# Existing base tmpfiles rules create the persistent NFS state owned by statd.
+u statd -:nogroup "" /var/lib/nfs /usr/sbin/nologin

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysusers.d/rpcbind.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysusers.d/rpcbind.conf
@@ -1,0 +1,3 @@
+# Debian's postinst creates this account only in the build-time /etc.
+# Recreate it on installed systems before rpcbind's packaged tmpfiles rule runs.
+u _rpc -:nogroup "" /run/rpcbind /usr/sbin/nologin

--- a/test/nfs-system-accounts-test.sh
+++ b/test/nfs-system-accounts-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+# Exercise real sysusers/tmpfiles against disposable roots, never host accounts.
+if (( EUID != 0 )); then
+    echo "Run as root: sudo $0" >&2
+    exit 1
+fi
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+base="$root/mkosi.images/base/mkosi.extra/usr/lib"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+echo '1..4'
+for scenario in missing existing; do
+    target="$work/$scenario"
+    mkdir -p "$target/etc" "$target/usr/lib/sysusers.d" "$target/usr/lib/tmpfiles.d"
+    printf 'root:x:0:0:root:/root:/bin/sh\n' > "$target/etc/passwd"
+    printf 'root:x:0:\nnogroup:x:65534:\n' > "$target/etc/group"
+    cp "$base/tmpfiles.d/nfs-common.conf" "$target/usr/lib/tmpfiles.d/"
+    # Debian rpcbind's packaged rule (the image does not override it).
+    printf 'D /run/rpcbind 0755 _rpc root - -\n' > "$target/usr/lib/tmpfiles.d/rpcbind.conf"
+
+    if [[ "$scenario" == missing ]]; then
+        if systemd-tmpfiles --root="$target" --create nfs-common.conf rpcbind.conf > "$work/missing.log" 2>&1; then
+            echo 'not ok 1 - missing service accounts must fail tmpfiles'
+            exit 1
+        fi
+        grep -q "Failed to resolve user 'statd'" "$work/missing.log"
+        grep -q "Failed to resolve user '_rpc'" "$work/missing.log"
+        echo 'ok 1 - reproduces both missing-account tmpfiles failures'
+    else
+        # Simulate persistent identities and NFS state on an existing install.
+        printf '_rpc:x:123:65534::/run/rpcbind:/usr/sbin/nologin\nstatd:x:124:65534::/var/lib/nfs:/usr/sbin/nologin\n' >> "$target/etc/passwd"
+        cp "$target/etc/passwd" "$work/existing.passwd"
+        mkdir -p "$target/var/lib/nfs"
+        printf 'existing NFS state\n' > "$target/var/lib/nfs/state"
+    fi
+
+    cp "$base/sysusers.d/nfs-common.conf" "$base/sysusers.d/rpcbind.conf" "$target/usr/lib/sysusers.d/"
+    systemd-sysusers --root="$target" nfs-common.conf rpcbind.conf
+    systemd-tmpfiles --root="$target" --create nfs-common.conf rpcbind.conf
+
+    rpc_uid=$(awk -F: '$1 == "_rpc" {print $3}' "$target/etc/passwd")
+    statd_uid=$(awk -F: '$1 == "statd" {print $3}' "$target/etc/passwd")
+    [[ -n "$rpc_uid" && "$rpc_uid" != 0 && -n "$statd_uid" && "$statd_uid" != 0 ]]
+    grep -Eq '^_rpc:x:[0-9]+:65534::/run/rpcbind:/usr/sbin/nologin$' "$target/etc/passwd"
+    grep -Eq '^statd:x:[0-9]+:65534::/var/lib/nfs:/usr/sbin/nologin$' "$target/etc/passwd"
+    [[ $(stat -c '%u:%g:%a' "$target/run/rpcbind") == "$rpc_uid:0:755" ]]
+    for directory in sm sm.bak; do
+        [[ $(stat -c '%u:%g:%a' "$target/var/lib/nfs/$directory") == "$statd_uid:65534:755" ]]
+    done
+    [[ $(stat -c '%u:%g:%a' "$target/var/lib/nfs/state") == "$statd_uid:65534:644" ]]
+
+    if [[ "$scenario" == missing ]]; then
+        echo 'ok 2 - sysusers repairs absent accounts and tmpfiles creates correctly owned state'
+        cp "$target/etc/passwd" "$work/created.passwd"
+        systemd-sysusers --root="$target" nfs-common.conf rpcbind.conf
+        cmp "$work/created.passwd" "$target/etc/passwd"
+        echo 'ok 3 - repeated sysusers preserves allocated identities'
+    else
+        cmp "$work/existing.passwd" "$target/etc/passwd"
+        [[ $(cat "$target/var/lib/nfs/state") == 'existing NFS state' ]]
+        echo 'ok 4 - existing identities and persistent NFS state survive'
+    fi
+done

--- a/test/registry.tsv
+++ b/test/registry.tsv
@@ -76,6 +76,7 @@ native-iso-boot-smoke-test.sh	ci	build-installer-iso.yml,build-native-images.yml
 native-publication-pipeline-test.sh	ci	validate.yml
 native-publish-test.sh	ci	validate.yml
 native-rclone-install-test.py	ci	validate.yml
+nfs-system-accounts-test.sh	ci	validate.yml
 output-organizer-test.sh	unwired	-
 pilothouse-sysext-test.sh	ci	validate.yml
 policy-as-code-test.py	ci	validate.yml


### PR DESCRIPTION
# Summary

Installed systems can lack `_rpc` and `statd` even though base installs `nfs-common` and its `rpcbind` dependency. This causes `rpcbind: cannot get uid of '_rpc': Success`, repeated startup failures, and tmpfiles errors resolving both accounts. Debian's package postinst scripts create the accounts in the build root, but no sysusers definitions existed to repair missing accounts in persistent `/etc`.

Add both sysusers definitions to base, preserving Debian's `nogroup` primary group, home directories, and nologin shells. The existing base NFS tmpfiles rules and Debian's packaged rpcbind rule already cover the state paths. All products inherit the fix; no additional tmpfiles rules are needed.

Risk tier: 3 — changes boot-time account provisioning for NFS services in every OS profile. Missing accounts receive dynamically allocated UIDs; existing identities remain unchanged. Reverting the definitions does not delete accounts or NFS state already created. An installation still missing these accounts would retain the original service failures without this fix.

## Type of change

- [x] Image or profile change (`floe`, `snow`, `snowfield`, native A/B profiles)
- [x] Build pipeline / CI change

## Validation

- [x] ShellCheck passes for the new regression script.
- [x] Relevant tests in `test/` were run.
- [ ] Full image build / VM boot (not run locally).

Commands run successfully:

```text
sudo bash test/nfs-system-accounts-test.sh
mise exec shellcheck@0.11.0 -- shellcheck test/nfs-system-accounts-test.sh
bash test/test-registry-test.sh
bash check-runtime-etc-guard.sh
git diff --cached --check
```

The regression uses real systemd-sysusers and systemd-tmpfiles in disposable roots. All four checks pass: reproduce both missing-owner failures; create accounts and correctly owned state; preserve IDs on repeated sysusers execution; preserve existing IDs and NFS state. It runs in validate.yml and is recorded in the test registry. The packaged rpcbind tmpfiles rule is represented by its Debian rule in the fixture; the NFS rule is read directly from base.

## Checklist

- [x] Changes are focused on the missing NFS service accounts.
- [x] No secrets, keys, or credentials are committed.
- [x] No new external downloads.
- [x] Relevant documentation updated in CLAUDE.md (AGENTS.md), README.md, and docs/design/build-pipeline.md.
