### PR TITLE
fix(base): create sysext accounts before state directories

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -304,6 +304,9 @@ jobs:
       - name: Test gui-base sysext divergent-lib contract
         run: ./test/sysext-divergent-libs-test.sh
 
+      - name: Test order account provisioning
+        run: sudo python3 ./test/sysext-account-order-test.py
+
       - name: Test staged-update notify unit trigger shape
         run: ./test/update-notify-units-test.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -539,6 +539,12 @@ these before changing anything under the native A/B tree:
 
 ### Sysext Constraints
 
+Sysext provisioning runs sysusers before tmpfiles in `reload-sysext.service`.
+The graceful tmpfiles mode can otherwise create state as root when its intended
+owner is absent. `test/sysext-account-order-test.py` replays the shipped commands
+and checks fresh and previously root-owned Coder homes.
+
+
 **Sysext udev rules and kernel modules (2026-08-28):** a
 `/usr/lib/udev/rules.d/` entry shipped inside a sysext is applied on NO boot
 unless the sysext also wires the post-merge reload.

--- a/docs/design/sysexts.md
+++ b/docs/design/sysexts.md
@@ -208,6 +208,12 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `mkosi.postinst.chroot` — Downloads code-server .deb via `verified_download()`, installs with `dpkg -i`. Upstream package targets `/usr/lib/code-server` with `/usr/bin/code-server` symlink and systemd units under `/usr/lib/systemd/`, so no relocation is required.
 
 ### coder
+
+Sysext provisioning runs sysusers before tmpfiles in `reload-sysext.service`.
+The graceful tmpfiles mode can otherwise create state as root when its intended
+owner is absent. `test/sysext-account-order-test.py` replays the shipped commands
+and checks fresh and previously root-owned Coder homes.
+
 - `mkosi.postinst.chroot` — Downloads the coder .deb (GitHub release, no apt repo) via `verified_download()`, installs with `dpkg -i`. Single static binary + two units, all natively under `/usr`; no relocation
 - `mkosi.finalize` — Captures `/etc/coder.d/` to factory defaults; `coder.service` is gated on `ConditionFileNotEmpty=/etc/coder.d/coder.env`, so the enabled+upheld unit stays inert until an admin fills in `CODER_ACCESS_URL` etc.
 - `usr/lib/sysusers.d/coder.conf` — Recreates the `coder` system user at boot (the deb preinst's `useradd` lands in the buildroot `/etc/passwd`, stripped from the delta) with membership in `docker` (mirrors preinst) and `incus-admin` (Incus-template provisioning); `m` lines implicitly create those groups when the owning sysext isn't merged

--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/reload-sysext.service
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/reload-sysext.service
@@ -11,8 +11,8 @@ ConditionDirectoryNotEmpty=|/.extra/sysext
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=systemd-tmpfiles --create --graceful --no-pager
 ExecStart=systemd-sysusers --no-pager
+ExecStart=systemd-tmpfiles --create --graceful --no-pager
 ExecStart=systemctl daemon-reload
 
 [Install]

--- a/test/registry.tsv
+++ b/test/registry.tsv
@@ -101,6 +101,7 @@ sysext-divergent-libs-test.sh	ci	validate.yml
 sysext-postoutput-test.sh	unwired	-
 sysext-required-paths-test.sh	ci	validate.yml
 sysext-signature-verification-test.sh	ci	nightly-compliance.yml,validate.yml
+sysext-account-order-test.py	ci	validate.yml
 sysext-udev-reload-test.sh	ci	validate.yml
 task2-recovery-key-bytes-test.sh	ci	test-bootc-secure.yml,validate.yml
 task3-console-pump-test.py	ci	test-bootc-secure.yml,validate.yml

--- a/test/sysext-account-order-test.py
+++ b/test/sysext-account-order-test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Replay the shipped post-merge provisioning commands with a fresh account."""
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+
+repo = Path(__file__).resolve().parents[1]
+assert os.geteuid() == 0, "run with sudo python3"
+unit = repo / "mkosi.images/base/mkosi.extra/usr/lib/systemd/system/reload-sysext.service"
+commands = [shlex.split(line.split("=", 1)[1]) for line in unit.read_text().splitlines()
+            if line.startswith("ExecStart=systemd-")]
+assert {c[0] for c in commands} == {"systemd-sysusers", "systemd-tmpfiles"}
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
+    (root / "etc").mkdir()
+    (root / "etc/passwd").write_text("root:x:0:0::/root:/bin/sh\n")
+    (root / "etc/group").write_text("root:x:0:\n")
+    for kind in ("sysusers", "tmpfiles"):
+        dest = root / f"usr/lib/{kind}.d"
+        dest.mkdir(parents=True)
+        shutil.copyfile(repo / f"mkosi.images/coder/mkosi.extra/usr/lib/{kind}.d/coder.conf",
+                        dest / "coder.conf")
+
+    def replay():
+        for command in commands:
+            args = [command[0], f"--root={root}", *command[1:]]
+            if command[0] == "systemd-tmpfiles":
+                args.append("--prefix=/home/coder")
+            subprocess.run(args, check=True)
+
+    replay()
+    account = next(l.split(":") for l in (root / "etc/passwd").read_text().splitlines()
+                   if l.startswith("coder:"))
+    home = root / "home/coder"
+    assert home.stat().st_uid == int(account[2]) != 0
+    assert home.stat().st_gid == int(account[3])
+    assert home.stat().st_mode & 0o777 == 0o700
+    (home / "state").write_text("keep")
+    # A previously root-owned home must be repaired, not replaced.
+    os.chown(home, 0, 0)
+    replay()
+    assert home.stat().st_uid == int(account[2])
+    assert (home / "state").read_text() == "keep"
+print("PASS: shipped post-merge order creates and repairs Coder ownership")


### PR DESCRIPTION
# Summary

On first activation of a sysext, reload-sysext.service runs graceful tmpfiles before sysusers. For Coder this silently creates /home/coder as root with mode 0700; creating the coder account afterward leaves its home inaccessible. Run sysusers first, then tmpfiles, so new accounts exist when ownership is applied. The same sequence repairs an existing root-owned home without replacing its contents.

Risk tier: 3 — shared boot-time provisioning order. A sysusers failure stops the oneshot before tmpfiles; the existing graceful tmpfiles policy remains. Reverting restores the previous ordering and does not remove existing accounts or state.

## Type of change

- [x] Image or profile change
- [x] Focused CI regression coverage and relevant documentation

## Validation

Replays the provisioning ExecStart commands parsed from the shipped unit using real systemd tools in a disposable root. Checks fresh ownership, repair of a root-owned home, and preserved state. Reversing the commands makes the regression fail.

Commands passed:

```text
sudo python3 test/sysext-account-order-test.py
bash test/test-registry-test.sh
bash check-runtime-etc-guard.sh
git diff --check
```

The test is wired into validate.yml and recorded in test/registry.tsv. Python syntax checks also passed. Negative variants were tested in disposable fixture copies. Full image builds, VM boots, and device/application end-to-end tests were not run locally; the focused tests do not claim that coverage.

## Checklist

- [x] One audit category per PR; relevant documentation updated.
- [x] No secrets or host account/service changes.
- [x] No new build-time downloads.
- [x] Changes and validation are ready for maintainer review.
