### PR TITLE
fix(accounts): correct service group memberships

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -296,6 +296,9 @@ jobs:
       - name: Test NFS system accounts and tmpfiles ownership
         run: sudo bash ./test/nfs-system-accounts-test.sh
 
+      - name: Test memberships account provisioning
+        run: sudo python3 ./test/service-account-memberships-test.py
+
       - name: Test RequiredBy guard and initrd requires-pruning fixtures
         run: |
           ./test/required-by-guard-test.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,6 +455,13 @@ Scripts execute in order: **BuildScripts** (in chroot) -> **PostInstallationScri
 
 ### Immutable Filesystem Constraints
 
+Service group membership uses `m USER GROUP`: saned joins scanner,
+cups-pk-helper joins lpadmin, and usbmux joins plugdev. The latter two use
+Debian-compatible primary groups for newly created accounts; `m` also repairs
+existing accounts without renumbering them. Keep base/Snow usbmux copies in sync.
+`test/service-account-memberships-test.py` checks fresh and existing identities.
+
+
 **NFS accounts belong in base:** base installs `nfs-common` and its `rpcbind`
 dependency. Keep `statd` and `_rpc` in base's `usr/lib/sysusers.d/`, with
 Debian-compatible `nogroup` primary groups and nologin shells. Package

--- a/docs/design/build-pipeline.md
+++ b/docs/design/build-pipeline.md
@@ -586,6 +586,13 @@ identities and NFS state using real systemd tools.
 
 ### shared/snow/tree/
 
+Service group membership uses `m USER GROUP`: saned joins scanner,
+cups-pk-helper joins lpadmin, and usbmux joins plugdev. The latter two use
+Debian-compatible primary groups for newly created accounts; `m` also repairs
+existing accounts without renumbering them. Keep base/Snow usbmux copies in sync.
+`test/service-account-memberships-test.py` checks fresh and existing identities.
+
+
 Desktop configuration overlay:
 - APT sources for Docker, backports
 - dconf/GLib schema overrides for GNOME defaults

--- a/mkosi.images/base/mkosi.extra/usr/lib/sysusers.d/usbmux.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/sysusers.d/usbmux.conf
@@ -1,2 +1,3 @@
-u usbmux - "USB Multiplexer Daemon" /var/lib/usbmux /usr/sbin/nologin
-m plugdev usbmux
+u usbmux -:plugdev "USB Multiplexer Daemon" /var/lib/usbmux /usr/sbin/nologin
+# Also repair membership for an account that already has a different primary group.
+m usbmux plugdev

--- a/shared/snow/tree/usr/lib/sysusers.d/cups-pk-helper.conf
+++ b/shared/snow/tree/usr/lib/sysusers.d/cups-pk-helper.conf
@@ -1,2 +1,3 @@
-u cups-pk-helper - "CUPS PolicyKit Helper" /nonexistent /usr/sbin/nologin
-m lpadmin cups-pk-helper
+u cups-pk-helper -:lpadmin "CUPS PolicyKit Helper" /nonexistent /usr/sbin/nologin
+# Also repair membership for an account that already has a different primary group.
+m cups-pk-helper lpadmin

--- a/shared/snow/tree/usr/lib/sysusers.d/sane.conf
+++ b/shared/snow/tree/usr/lib/sysusers.d/sane.conf
@@ -2,4 +2,4 @@ u saned - "SANE Daemon" /var/lib/saned /usr/sbin/nologin
 g saned
 
 g scanner
-m scanner saned
+m saned scanner

--- a/shared/snow/tree/usr/lib/sysusers.d/usbmux.conf
+++ b/shared/snow/tree/usr/lib/sysusers.d/usbmux.conf
@@ -1,2 +1,3 @@
-u usbmux - "USB Multiplexer Daemon" /var/lib/usbmux /usr/sbin/nologin
-m plugdev usbmux
+u usbmux -:plugdev "USB Multiplexer Daemon" /var/lib/usbmux /usr/sbin/nologin
+# Also repair membership for an account that already has a different primary group.
+m usbmux plugdev

--- a/test/registry.tsv
+++ b/test/registry.tsv
@@ -84,6 +84,7 @@ publication-guards.bats	ci	validate.yml
 required-by-guard-test.sh	ci	validate.yml
 run-qemu.sh	helper	-
 runtime-etc-guard-test.sh	ci	validate.yml
+service-account-memberships-test.py	ci	validate.yml
 secure-vm-fixture-test.sh	unwired	-
 snosi-etc-diff-test.sh	ci	validate.yml
 snosi-firstboot-test.sh	ci	validate.yml

--- a/test/service-account-memberships-test.py
+++ b/test/service-account-memberships-test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Check fresh and existing service-account membership with real sysusers."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+repo = Path(__file__).resolve().parents[1]
+assert os.geteuid() == 0, "run with sudo python3"
+base = repo / "mkosi.images/base/mkosi.extra/usr/lib/sysusers.d"
+snow = repo / "shared/snow/tree/usr/lib/sysusers.d"
+assert (base / "usbmux.conf").read_bytes() == (snow / "usbmux.conf").read_bytes()
+for existing in (False, True):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "etc").mkdir()
+        accounts = "root:x:0:0::/root:/bin/sh\n"
+        groups = "root:x:0:\nplugdev:x:46:\nlpadmin:x:200:\n"
+        if existing:
+            accounts += "saned:x:301:401::/var/lib/saned:/usr/sbin/nologin\n"
+            accounts += "cups-pk-helper:x:302:402::/nonexistent:/usr/sbin/nologin\n"
+            accounts += "usbmux:x:303:403::/var/lib/usbmux:/usr/sbin/nologin\n"
+            groups += "saned:x:401:\ncups-pk-helper:x:402:\nusbmux:x:403:\n"
+        (root / "etc/passwd").write_text(accounts)
+        (root / "etc/group").write_text(groups)
+        dest = root / "usr/lib/sysusers.d"
+        dest.mkdir(parents=True)
+        # Follow the definition if a later PR moves SANE into base.
+        sane = base / "sane.conf" if (base / "sane.conf").exists() else snow / "sane.conf"
+        for source in (sane, snow / "cups-pk-helper.conf", base / "usbmux.conf"):
+            shutil.copyfile(source, dest / source.name)
+        subprocess.run(["systemd-sysusers", f"--root={root}"], check=True)
+        users = {f[0]: f for l in (root / "etc/passwd").read_text().splitlines() if (f := l.split(":"))}
+        groups = {f[0]: f for l in (root / "etc/group").read_text().splitlines() if (f := l.split(":"))}
+        for user, group in (("saned", "scanner"), ("cups-pk-helper", "lpadmin"), ("usbmux", "plugdev")):
+            assert user in groups[group][3].split(","), (user, group)
+            assert group not in users, f"unintended user {group}"
+        if existing:
+            assert (root / "etc/passwd").read_text() == accounts
+        else:
+            assert users["cups-pk-helper"][3] == groups["lpadmin"][2]
+            assert users["usbmux"][3] == groups["plugdev"][2]
+        before = (root / "etc/group").read_bytes()
+        subprocess.run(["systemd-sysusers", f"--root={root}"], check=True)
+        assert (root / "etc/group").read_bytes() == before
+print("PASS: intended memberships, Debian primary groups, preserved existing IDs")


### PR DESCRIPTION
# Summary

Three sysusers membership rules reverse USER and GROUP, creating users named scanner, lpadmin, and plugdev instead of granting the intended service access. Correct saned→scanner, cups-pk-helper→lpadmin, and usbmux→plugdev. New cups-pk-helper and usbmux accounts use Debian-compatible primary groups; supplementary membership also repairs already-existing accounts without changing their IDs or primary groups. Both base and Snow usbmux copies are updated.

Risk tier: 3 — device/printing service access. Membership is limited to the intended Debian service relationships. Existing IDs and previously-created unintended accounts are preserved; reverting definitions does not revoke memberships already applied.

## Type of change

- [x] Image or profile change
- [x] Focused CI regression coverage and relevant documentation

## Validation

Real sysusers tests cover fresh and existing accounts, correct primary and supplementary groups, absence of unintended newly-created users, and idempotence. Restoring the reversed SANE rule makes the regression fail.

Commands passed:

```text
sudo python3 test/service-account-memberships-test.py
bash test/test-registry-test.sh
bash check-runtime-etc-guard.sh
git diff --check
```

The test is wired into validate.yml and recorded in test/registry.tsv. Python syntax checks also passed. Negative variants were tested in disposable fixture copies. Full image builds, VM boots, and device/application end-to-end tests were not run locally; the focused tests do not claim that coverage.

## Checklist

- [x] One audit category per PR; relevant documentation updated.
- [x] No secrets or host account/service changes.
- [x] No new build-time downloads.
- [x] Changes and validation are ready for maintainer review.
