### PR TITLE
fix(base): scope geoclue state provisioning to Snow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -301,6 +301,9 @@ jobs:
           ./test/required-by-guard-test.sh
           ./test/etc-overlay-prune-test.sh
 
+      - name: Test geoclue account provisioning
+        run: sudo python3 ./test/geoclue-state-scope-test.py
+
       - name: Test gui-base sysext divergent-lib contract
         run: ./test/sysext-divergent-libs-test.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,6 +432,12 @@ production-ready.
 
 ### Configuration Composition
 
+Geoclue state provisioning is Snow-only, alongside `geoclue-2.0` and its
+sysusers definition. Base and Floe must not carry a tmpfiles rule referencing
+the absent geoclue account. `test/geoclue-state-scope-test.py` checks scope and
+real desktop state-directory ownership.
+
+
 mkosi configs use `Include=` directives to compose reusable fragments. The composition chain:
 
 - `mkosi.conf` (root) declares base + sysext dependencies

--- a/docs/design/build-pipeline.md
+++ b/docs/design/build-pipeline.md
@@ -598,6 +598,12 @@ Desktop configuration overlay:
 
 ### shared/floe/tree/
 
+Geoclue state provisioning is Snow-only, alongside `geoclue-2.0` and its
+sysusers definition. Base and Floe must not carry a tmpfiles rule referencing
+the absent geoclue account. `test/geoclue-state-scope-test.py` checks scope and
+real desktop state-directory ownership.
+
+
 Server configuration overlay:
 - APT sources for Docker
 - NetworkManager: no Wi-Fi backend override — floe uses NetworkManager's

--- a/mkosi.images/base/mkosi.extra/usr/lib/tmpfiles.d/geoclue.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/tmpfiles.d/geoclue.conf
@@ -1,1 +1,0 @@
-d /var/lib/geoclue 0755 geoclue geoclue - -

--- a/test/geoclue-state-scope-test.py
+++ b/test/geoclue-state-scope-test.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Ensure desktop-only geoclue state is recreated only with its account."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+repo = Path(__file__).resolve().parents[1]
+assert os.geteuid() == 0, "run with sudo python3"
+for tree in ("mkosi.images/base/mkosi.extra", "shared/floe/tree"):
+    assert not (repo / tree / "usr/lib/tmpfiles.d/geoclue.conf").exists()
+assert "geoclue-2.0" in (repo / "shared/packages/snow/mkosi.conf").read_text()
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
+    (root / "etc").mkdir()
+    (root / "etc/passwd").write_text("root:x:0:0::/root:/bin/sh\n")
+    (root / "etc/group").write_text("root:x:0:\n")
+    for kind in ("sysusers", "tmpfiles"):
+        dest = root / f"usr/lib/{kind}.d"
+        dest.mkdir(parents=True)
+        shutil.copyfile(repo / f"shared/snow/tree/usr/lib/{kind}.d/geoclue.conf", dest / "geoclue.conf")
+    subprocess.run(["systemd-sysusers", f"--root={root}"], check=True)
+    subprocess.run(["systemd-tmpfiles", f"--root={root}", "--create", "geoclue.conf"], check=True)
+    account = next(l.split(":") for l in (root / "etc/passwd").read_text().splitlines() if l.startswith("geoclue:"))
+    state = root / "var/lib/geoclue"
+    assert (state.stat().st_uid, state.stat().st_gid) == (int(account[2]), int(account[3]))
+print("PASS: geoclue state stays with the desktop package and account")

--- a/test/registry.tsv
+++ b/test/registry.tsv
@@ -54,6 +54,7 @@ duplicate-packages-test.sh	ci	validate.yml
 etc-overlay-prune-test.sh	ci	validate.yml
 firn-catalog-test.sh	ci	validate.yml
 firn-installer-iso-test.sh	unwired	-
+geoclue-state-scope-test.py	ci	validate.yml
 generate-sbom-test.sh	unwired	-
 latest-apt-version-test.sh	ci	validate.yml
 lemonade-sysext-test.sh	ci	validate.yml


### PR DESCRIPTION
# Summary

Base ships a tmpfiles rule owned by geoclue even though geoclue-2.0 and its sysusers definition are Snow-only. Base/Floe provisioning therefore reports an unknown geoclue user. Remove the misplaced base copy; the existing Snow copy remains beside its package and account definition.

Risk tier: 3 — image state composition. No existing state is removed. Snow retains its current provisioning; reverting reintroduces the unused server-side rule and its missing-owner error.

## Type of change

- [x] Image or profile change
- [x] Focused CI regression coverage and relevant documentation

## Validation

Checks that base/Floe have no geoclue rule, that Snow still installs the package, and that real sysusers/tmpfiles create the desktop directory with the correct owner. Restoring the base rule makes the regression fail.

Commands passed:

```text
sudo python3 test/geoclue-state-scope-test.py
bash test/test-registry-test.sh
bash check-runtime-etc-guard.sh
git diff --check
```

The test is wired into validate.yml and recorded in test/registry.tsv. Python syntax checks also passed. Negative variants were tested in disposable fixture copies. Full image builds, VM boots, and device/application end-to-end tests were not run locally; the focused tests do not claim that coverage.

## Checklist

- [x] One audit category per PR; relevant documentation updated.
- [x] No secrets or host account/service changes.
- [x] No new build-time downloads.
- [x] Changes and validation are ready for maintainer review.
