### PR TITLE
fix(nix): provision the daemon client access group

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -282,6 +282,9 @@ jobs:
           file-install: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Test Nix client group access
+        run: sudo python3 ./test/nix-client-group-test.py
+
       - name: Test publication guards
         run: bats --print-output-on-failure test/publication-guards.bats
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -539,13 +539,6 @@ these before changing anything under the native A/B tree:
 
 ### Sysext Constraints
 
-Nix recreates Debian's `nix-users` client group at boot. Client access is
-opt-in: after merging the extension, run `sudo usermod -aG nix-users USER` and
-start a new login session. This grants daemon-socket access, not Nix
-`trusted-users` privileges. `test/nix-client-group-test.py` checks real socket
-access for a group member, denial for a nonmember, and existing-GID preservation.
-
-
 **Sysext udev rules and kernel modules (2026-08-28):** a
 `/usr/lib/udev/rules.d/` entry shipped inside a sysext is applied on NO boot
 unless the sysext also wires the post-merge reload.
@@ -695,6 +688,12 @@ rendered blank even though Snow's package manifest contained
 bump each affected `SYSEXT_REVISION`; otherwise `skip-duplicates` leaves the
 broken raw image published. Full contract and fixture coverage:
 `docs/design/sysexts.md` and `test/sysext-authoring-contract-test.sh`.
+
+Nix recreates Debian's `nix-users` client group at boot. Client access is
+opt-in: after merging the extension, run `sudo usermod -aG nix-users USER` and
+start a new login session. This grants daemon-socket access, not Nix
+`trusted-users` privileges. `test/nix-client-group-test.py` checks real socket
+access for a group member, denial for a nonmember, and existing-GID preservation.
 
 The shared sysext postoutput script (`shared/sysext/postoutput/sysext-postoutput.sh`) handles versioned naming and manifest processing. It requires the `KEYPACKAGE` env var set in each sysext's `mkosi.conf`. If `SYSEXT_REVISION` is also set, the version gets a `+rN` suffix — bump this to force a republish of tree/content fixes when the KEYPACKAGE version hasn't changed (publishing skips existing filenames via `skip-duplicates`, so tree fixes otherwise never reach users; remove the setting when the package version bumps). Every sysext must also ship `mkosi.images/<name>/required-paths.txt` (one absolute path per line); the shared finalize check (`shared/sysext/finalize/sysext-required-paths.sh`) fails the build if any listed path is missing from the buildroot — guard against publishing structurally broken sysexts (the 2026-07-01 incus publish shipped with no incusd/CLI/units and nothing noticed). The sibling `shared/sysext/finalize/sysext-usr-only.sh` guard fails any delta with an entry below `/opt` (the empty mountpoint directory itself is permitted; symlinks are reported, never followed). It deliberately does NOT inspect `/var`: mkosi's sysext repart definition (`sysext.repart.d/10-root.conf`) copies exactly `/usr/` and `/opt/` into the published erofs, so buildroot `/var` — dpkg logs, package caches, postinst trigger state such as `/var/lib/emacsen-common` — is inert build residue that never ships, while `/opt` does ship and is shadowed at runtime by the `/var/opt` bind mount. `test/sysext-usr-only-test.sh` pins that `CopyFiles=` set whenever the `.mkosi` checkout is present, so a mkosi bump that widens the packed tree re-opens the question instead of silently widening the payload. An earlier draft of the guard checked `/var` too and had to grow a per-package residue allowlist one CI round at a time (dpkg.log, dictionaries-common, emacsen-common, coder's preinst home); do not reintroduce that. For `Overlay=yes` images the finalize `$BUILDROOT` is the sysext DELTA (upper layer), so list only paths the sysext itself ships — packages also present in the base image never appear in the delta and will always fail the check.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -539,6 +539,13 @@ these before changing anything under the native A/B tree:
 
 ### Sysext Constraints
 
+Nix recreates Debian's `nix-users` client group at boot. Client access is
+opt-in: after merging the extension, run `sudo usermod -aG nix-users USER` and
+start a new login session. This grants daemon-socket access, not Nix
+`trusted-users` privileges. `test/nix-client-group-test.py` checks real socket
+access for a group member, denial for a nonmember, and existing-GID preservation.
+
+
 **Sysext udev rules and kernel modules (2026-08-28):** a
 `/usr/lib/udev/rules.d/` entry shipped inside a sysext is applied on NO boot
 unless the sysext also wires the post-merge reload.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ image inherits those chunked layers and overlays only `/boot`; its bootc must
 return the same digest in the second of exactly two digest probes. Protected
 assembly never runs a post-assembly chunk pass.
 
+Nix clients need membership in `nix-users` after the Nix extension is merged;
+see [Nix client setup](docs/design/sysexts.md#nix).
+
 ## Architecture
 
 All OS profiles inherit NFS client support from base. Base sysusers definitions

--- a/docs/design/sysexts.md
+++ b/docs/design/sysexts.md
@@ -263,6 +263,13 @@ Some sysexts include extra files via `mkosi.extra/`:
 - `usr/lib/systemd/system/multi-user.target.d/10-lemonade.conf` — `Upholds=lemond.service` drop-in for reliable boot activation
 
 ### nix
+
+Nix recreates Debian's `nix-users` client group at boot. Client access is
+opt-in: after merging the extension, run `sudo usermod -aG nix-users USER` and
+start a new login session. This grants daemon-socket access, not Nix
+`trusted-users` privileges. `test/nix-client-group-test.py` checks real socket
+access for a group member, denial for a nonmember, and existing-GID preservation.
+
 - `mkosi.finalize` — Captures `/etc/nix` to factory defaults
 - `usr/lib/systemd/system/nix.mount` + `nix-daemon.service.d/mount-binding.conf` — `/nix` bind mount wiring
 - `usr/lib/systemd/system-preset/40-nix.preset` — Enable nix.mount + nix-daemon

--- a/mkosi.images/nix/mkosi.conf
+++ b/mkosi.images/nix/mkosi.conf
@@ -19,7 +19,6 @@ Packages=nix-setup-systemd
 
 [Build]
 Environment=KEYPACKAGE=nix-setup-systemd
-# r1 (2026-07-06): nix-setup-systemd version has not bumped since 2026-03;
-# republish so the sysext picks up the multi-user.target.d Upholds drop-in
-# (52b2bfb) and all tree fixes since March. Remove when the package version bumps.
-Environment=SYSEXT_REVISION=1
+# r2: recreate Debian's nix-users client group after the sysext merge.
+# Remove when the package version bumps.
+Environment=SYSEXT_REVISION=2

--- a/mkosi.images/nix/mkosi.extra/usr/lib/sysusers.d/nix.conf
+++ b/mkosi.images/nix/mkosi.extra/usr/lib/sysusers.d/nix.conf
@@ -1,6 +1,9 @@
 # Nix package manager build users
 # Group and users required by nix-daemon for multi-user builds.
 # GID/UIDs match the official Nix installer defaults.
+# Debian restricts access to the daemon socket directory to this client group.
+# Administrators explicitly add client users; build users are not client users.
+g nix-users -
 g nixbld 30000
 u nixbld1 30001:30000 "Nix build user 1" /var/empty /usr/sbin/nologin
 u nixbld2 30002:30000 "Nix build user 2" /var/empty /usr/sbin/nologin

--- a/mkosi.images/nix/required-paths.txt
+++ b/mkosi.images/nix/required-paths.txt
@@ -1,5 +1,6 @@
 # nix sysext: nix-bin payload (dependency of nix-setup-systemd) and activation
 /usr/bin/nix
+/usr/lib/sysusers.d/nix.conf
 /usr/lib/systemd/system/nix-daemon.service
 /usr/lib/systemd/system/nix.mount
 /usr/lib/systemd/system/multi-user.target.d/10-nix.conf

--- a/test/nix-client-group-test.py
+++ b/test/nix-client-group-test.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Validate Nix client-group provisioning and Unix socket access controls."""
+import os
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+
+repo = Path(__file__).resolve().parents[1]
+assert os.geteuid() == 0, "run with sudo python3"
+for existing in (False, True):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        root.chmod(0o755)
+        (root / "etc").mkdir()
+        (root / "etc/passwd").write_text("root:x:0:0::/root:/bin/sh\n")
+        groups = "root:x:0:\n" + ("nix-users:x:432:\n" if existing else "")
+        (root / "etc/group").write_text(groups)
+        dest = root / "usr/lib/sysusers.d"
+        dest.mkdir(parents=True)
+        shutil.copyfile(repo / "mkosi.images/nix/mkosi.extra/usr/lib/sysusers.d/nix.conf", dest / "nix.conf")
+        dest = root / "usr/lib/tmpfiles.d"
+        dest.mkdir(parents=True)
+        # The access rule shipped by Debian nix-setup-systemd 2.26.3+dfsg-1.
+        (dest / "nix-daemon.conf").write_text("d /nix/var/nix/daemon-socket 770 root nix-users\n")
+        subprocess.run(["systemd-sysusers", f"--root={root}"], check=True)
+        subprocess.run(["systemd-tmpfiles", f"--root={root}", "--create", "nix-daemon.conf"], check=True)
+        group = next(l.split(":") for l in (root / "etc/group").read_text().splitlines() if l.startswith("nix-users:"))
+        gid = int(group[2])
+        assert gid != 0 and (not existing or gid == 432)
+        assert group[3] == "", "client membership must remain an administrator decision"
+        directory = root / "nix/var/nix/daemon-socket"
+        assert (directory.stat().st_uid, directory.stat().st_gid) == (0, gid)
+        assert directory.stat().st_mode & 0o777 == 0o770
+        path = str(directory / "socket")
+        # Exercise filesystem access to a real Unix socket, without a host daemon.
+        with socket.socket(socket.AF_UNIX) as server:
+            server.bind(path)
+            os.chmod(path, 0o666)
+            server.listen(2)
+            client = """import os,socket,sys
+os.setgroups([int(sys.argv[2])] if sys.argv[3] == 'member' else [])
+os.setgid(65534)
+os.setuid(65534)
+with socket.socket(socket.AF_UNIX) as s:
+    try: s.connect(sys.argv[1])
+    except PermissionError: sys.exit(13)
+"""
+            for member, expected in (("member", 0), ("nonmember", 13)):
+                result = subprocess.run([sys.executable, "-c", client, path, str(gid), member], check=False)
+                assert result.returncode == expected, (member, result.returncode)
+        before = (root / "etc/group").read_bytes()
+        subprocess.run(["systemd-sysusers", f"--root={root}"], check=True)
+        assert (root / "etc/group").read_bytes() == before
+print("PASS: Nix client group, socket access for members, rejection of nonmembers, existing GID")

--- a/test/registry.tsv
+++ b/test/registry.tsv
@@ -76,6 +76,7 @@ native-iso-boot-smoke-test.sh	ci	build-installer-iso.yml,build-native-images.yml
 native-publication-pipeline-test.sh	ci	validate.yml
 native-publish-test.sh	ci	validate.yml
 native-rclone-install-test.py	ci	validate.yml
+nix-client-group-test.py	ci	validate.yml
 nfs-system-accounts-test.sh	ci	validate.yml
 output-organizer-test.sh	unwired	-
 pilothouse-sysext-test.sh	ci	validate.yml


### PR DESCRIPTION
# Summary

Debian's nix-daemon.conf requires nix-users for the mode-0770 daemon socket directory, but the sysext only recreates build identities. Normal tmpfiles fails, while graceful tmpfiles creates a root-only directory that ordinary clients cannot traverse. Add the missing group, pin the sysusers file in required-paths, and bump SYSEXT_REVISION to 2 so the change republishes. Client membership remains an explicit administrator decision, documented alongside Nix setup; it grants no trusted-users privilege.

Risk tier: 3 — local daemon access and sysext publication revision. The package's intended opt-in group policy is retained, without automatically enrolling users or changing trusted-users. Existing GIDs are preserved; reverting does not remove the group or memberships.

## Type of change

- [x] Sysext change
- [x] Focused CI regression coverage and relevant documentation

## Validation

Real sysusers/tmpfiles tests cover fresh and pre-existing group IDs, then use a real disposable Unix socket to verify that a member can connect and a nonmember gets PermissionError. No host daemon is used. Removing the group definition makes the regression fail. Debian 2.26.3+dfsg-1 packaging was inspected to verify its postinst group creation and packaged socket-directory rule.

Commands passed:

```text
sudo python3 test/nix-client-group-test.py
bash test/test-registry-test.sh
bash check-runtime-etc-guard.sh
git diff --check
```

The test is wired into validate.yml and recorded in test/registry.tsv. Python syntax checks also passed. Negative variants were tested in disposable fixture copies. Full image builds, VM boots, and device/application end-to-end tests were not run locally; the focused tests do not claim that coverage.

## Checklist

- [x] One audit category per PR; relevant documentation updated.
- [x] No secrets or host account/service changes.
- [x] No new build-time downloads.
- [x] Changes and validation are ready for maintainer review.
