### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -1,5 +1,5 @@
-code=1.136.1-1788413865
+code=1.136.2-1788561671
 docker-ce=5:29.8.0-1~debian.13~trixie
 1password-cli=2.39.0-1
-claude-desktop=1.46388.2
+claude-desktop=1.49585.0
 chatgpt=26.901.51231

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -1,7 +1,7 @@
 {
-  "code": "1.136.1-1788413865",
+  "code": "1.136.2-1788561671",
   "docker-ce": "5:29.8.0-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
-  "claude-desktop": "1.46388.2",
+  "claude-desktop": "1.49585.0",
   "chatgpt": "26.901.51231"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

code: 1.136.1-1788413865 -> 1.136.2-1788561671
claude-desktop: 1.46388.2 -> 1.49585.0


**Please verify the builds work before merging.**