### PR TITLE
feat(update): add snosi-update-status --pkg-diff (ADR-0014)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -322,6 +322,9 @@ jobs:
       - name: Test staged-update notify unit trigger shape
         run: ./test/update-notify-units-test.sh
 
+      - name: Test --pkg-diff parser, sidecar, and stager contract
+        run: ./test/pkg-diff-test.sh
+
   runtime-etc-guard:
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,6 +500,37 @@ creation and preservation of existing identities/state in disposable roots.
 
 On bootc-installed systems, updates are staged by `bootc-update-stage.timer` (hourly; base `mkosi.extra`): `/usr/libexec/bootc-update-stage` pulls the followed image via **podman**, then stages it with `bootc upgrade` when the spec already follows `containers-storage` (the steady state after the first staged update) or `bootc switch --transport containers-storage` otherwise — `bootc switch` to an IDENTICAL spec is a silent no-op in bootc ≤ 1.16.3 (composefs switch returns before staging when `new_spec == host.spec`), which made every install unable to take a second update while logging success (root-caused 2026-07-06). The script verifies post-stage that `.status.staged.image.imageDigest` equals the pulled digest and fails loudly otherwise. The update applies at the next natural reboot via `bootc-finalize-staged.service`. **Reboot-pending visibility:** after staging (or when finding an update already staged, e.g. via manual `bootc upgrade`), the script writes `/run/snosi/update-staged` (image/digest/timestamp; cleared automatically by the applying reboot). Two consumers: `/etc/update-motd.d/86-bootc-update-staged` (SSH/console logins) and `bootc-update-notify.path`/`.service` (user scope, desktop notification via `/usr/libexec/bootc-update-notify`, ack-gated per staged digest so it fires once per update, not per login). The desktop toast needs the `notify-send` CLI, which lives in `libnotify-bin` (NOT the transitively-pulled `libnotify4` library) — it ships only in the graphical package set (`shared/packages/snow/mkosi.conf`, used by snow+snowfield, not floe); without it both `bootc-update-notify` and `snosi-etc-drift-notify` `command -v notify-send || exit 0` into silent no-ops. Both notify units set `StartLimitIntervalSec=0` because the stager writes the semaphore in several syscalls, so one staging emits a burst of `PathModified` triggers that otherwise trips systemd's default 5/10s start-limit and permanently fails the `.path` watcher (`unit-start-limit-hit`); the per-digest ack makes the repeat triggers harmless no-ops. **The `.path` units are `PathModified=` ONLY — never `PathExists=` (root-caused live 2026-08-26 on a desktop install):** level-triggered path conditions (`PathExists=`, `DirectoryNotEmpty=`, …) re-arm every time the triggered oneshot exits, and the semaphore persists until the applying reboot by design, so `PathExists=` retrigger-loops until systemd's path trigger limit (200/2s) permanently fails the watcher with `trigger-limit-hit` — the StartLimit fix had merely unmasked this second limiter. The login-while-pending case `PathExists=` used to cover is handled by a static `graphical-session.target.wants/` link on the SERVICE (condition- and ack-gated, so it no-ops when nothing is staged). A level-triggered path condition is acceptable only when the triggered unit is long-running (the `snosi-ask-password-serial` pair's `--watch` agent). `test/update-notify-units-test.sh` (validate.yml) pins the trigger shape, the wants links, and directive-parity between the bootc- and native-named twins. **Currency visibility:** the script also writes `/run/snosi/update-check` on EVERY run (`outcome=current|staged|held-rollback|failed` plus timestamp and running/remote version; an EXIT trap records `failed` on any error) so "up to date", "reboot pending", and "checker broken" are three distinguishable states instead of one silent one. The same motd hook prints one line per state, and `snosi-update-status` (root CLI) summarizes running version, last-check outcome, and staged deployment; `snosi-update-status --check` additionally queries the registry live via skopeo and compares `org.opencontainers.image.version` labels — always compare versions, never digests (the same build has a different digest per transport: registry vs ISO vs podman-loaded). podman does the transfer because bootc's registry-transport composefs pull currently fails on snosi images (known upstream bug) — and podman enforces `containers-policy.json` at pull time. The script no-ops when: not a bootc-managed system (nbc installs — `spec.image` is null), already running or already staged the pulled digest, or the pulled digest equals the **rollback** deployment (never auto-flip-flop back to a version the admin rolled away from; bootc refuses that switch anyway). Upstream's `bootc-fetch-apply-updates.timer` is preset-disabled: it force-reboots on update and is gated on `/run/ostree-booted`, which does not exist on composefs deployments. During the transition, `nbc-update-download.timer` still ships for nbc-installed hosts. bootc-update-stage no-ops on nbc installs (`spec.image` null check); the nbc units are gated with `ConditionKernelCommandLine=!composefs` because `nbc update` itself ERRORS (exit 1, permanently failed unit, degraded state) rather than no-opping on bootc/composefs installs (frostyard/nbc#139).
 
+**Staged package delta (`snosi-update-status --pkg-diff`, ADR-0014):** the flag
+appends an `rpm-ostree db diff`-shaped Debian-package delta
+(Upgraded/Downgraded/Added/Removed) between the running image and the *locally*
+staged one; default status stays silent on packages. Both sides are the frozen
+`/usr/share/frostyard/<IMAGE_ID>.packages.txt` (core ADR-0003) — **never**
+`dpkg-query`/`dpkg -l`/`apt list` (bootc leaves `/var/lib/dpkg` at install-time
+state; native relocates it) and never the network; version ordering is
+`dpkg --compare-versions` only. The staged side is an identity-bound sidecar:
+`/run/snosi/staged-packages` symlink → write-once `staged-packages.<id>/`
+backing dir holding `identity` (exactly `digest=sha256:<hex>` **or**
+`version=<14-digit>`, same exclusive invariant as `update-staged`) and the
+staged image's `packages.txt` bytes. Publish is atomic by `mv -T` of a *fresh
+symlink* onto the live name (rename(2) of a file — never `rm` the live name
+first, never `mv -T` a directory onto it, which fails "Directory not empty").
+The ONE parser plus publish/resolve live in
+`mkosi.images/base/mkosi.extra/usr/lib/snosi/staged-packages.sh`, sourced by
+both stagers and `snosi-update-status` — do not re-inline the swap or the parser
+per transport. `bootc-update-stage` **captures the pulled image's
+`packages.txt` before `bootc switch`/`upgrade`** (a capture failure aborts the
+stage; a copy after staging cannot unstage it) and publishes the sidecar on
+both the new-stage and already-staged (repair) paths, before the post-stage
+`podman image prune`; `snosi-sysupdate-stage` reads it from the freshly-labeled
+other root slot (read-only EROFS) on the success and both re-assert paths.
+`--pkg-diff` reads the sidecar only when `identity` matches the live staged
+digest/version (a later manual stage cannot inherit an old list); on
+missing/mismatched sidecar bootc warns-and-skips (never re-pulls) while native
+falls back to one read-only mount of the other slot at query time. Sidecars die
+with `/run` on the applying reboot. `test/pkg-diff-test.sh` (validate.yml) pins
+the parser (captured real Trixie apt lines, not `name/now version` stubs), the
+differ, identity mismatch, and the cross-transport static contract.
+
 ### Native A/B Update UX (Phase 4)
 
 Native A/B images (`/usr/lib/snosi/native-ab` marker) never run bootc/nbc.

--- a/docs/adr/0014-update-status-pkg-diff.md
+++ b/docs/adr/0014-update-status-pkg-diff.md
@@ -1,7 +1,7 @@
 # 0014 — `snosi-update-status --pkg-diff` diffs local deployments from packages.txt
 
-- **Status:** Proposed
-- **Date:** 2026-09-07
+- **Status:** Accepted
+- **Date:** 2026-09-07 (accepted 2026-09-09)
 
 ## Context
 

--- a/docs/design/build-pipeline.md
+++ b/docs/design/build-pipeline.md
@@ -284,9 +284,20 @@ Consumers of the update state:
   staged outside the checker via manual `bootc upgrade`); `--check` does a
   live `skopeo inspect` of the followed registry image and compares
   version labels. No-ops gracefully on nbc (non-bootc) installs.
-  `--pkg-diff` (package-level added/removed/upgraded against a *local*
-  staged image, from `packages.txt`) is proposed in
-  [ADR-0014](../adr/0014-update-status-pkg-diff.md) and is not shipped.
+  `--pkg-diff` ([ADR-0014](../adr/0014-update-status-pkg-diff.md)) appends,
+  after the status block, an `rpm-ostree db diff`-shaped Debian-package delta
+  (Upgraded/Downgraded/Added/Removed) between the running image and the
+  *locally* staged one — both sides read from the frozen
+  `/usr/share/frostyard/<IMAGE_ID>.packages.txt` (core ADR-0003), never from a
+  dpkg database or the network. The staged side is an identity-bound sidecar
+  the stagers capture at stage time (`/run/snosi/staged-packages` symlink →
+  write-once `staged-packages.<id>/` backing dir; see integration-contracts
+  §5.3). Combinable with `--check`. A missing/mismatched sidecar (staged before
+  this shipped, or a manual `bootc upgrade` with no timer run) warns and skips,
+  still exit 0. Default status stays silent on packages. The one parser plus
+  the sidecar publish/resolve live in `usr/lib/snosi/staged-packages.sh`,
+  sourced by both stagers and the status CLI; `test/pkg-diff-test.sh` pins the
+  parser, the differ, and the cross-transport static contract.
 - `bootc-update-notify.path` + `.service` (user scope) with
   `/usr/libexec/bootc-update-notify` — desktop notification. The path unit
   fires when the semaphore appears mid-session or is modified (newer image

--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -323,7 +323,22 @@ staged_at=<iso-8601>          staged_at=<iso-8601>
 - Consumers key off whichever exists: `bootc-update-notify:26-29` (`id="${digest:-$version}"`), motd hook `86:23-26`, `snosi-update-status`. The native stager also re-reads its own file (`snosi-sysupdate-stage:207-209`) — so it must find `version=`, not `digest=`.
 - **Fragility:** 🔴 — the invariant is a convention with no enforcement; a producer emitting both (or the wrong one for its transport) would confuse consumers that prefer `digest`.
 
-### 5.3 Other filesystem contracts
+### 5.3 `/run/snosi/staged-packages` (symlink → write-once backing dir)
+Staged-package inventory for `snosi-update-status --pkg-diff` (ADR-0014). A
+sibling of §5.1/§5.2, **not** a field of either.
+```
+/run/snosi/staged-packages -> staged-packages.sha256-<64hex>   # bootc
+/run/snosi/staged-packages -> staged-packages.<14-digit>       # native
+/run/snosi/staged-packages.<id>/identity      # exactly one of digest= / version=
+/run/snosi/staged-packages.<id>/packages.txt  # exact staged-image packages.txt bytes
+```
+- **Backing-name invariant:** bootc uses `sha256-<64hex>` (never a colon); native uses the 14-digit version. `identity` holds exactly `digest=sha256:<hex>` **or** `version=<14-digit>` — the same exclusive invariant as §5.2, never both.
+- **Write-once:** a backing dir is created complete and never mutated; only the symlink is swapped, atomically, by `mv -T` of a fresh symlink (rename(2) of a file). Publishers never `rm` the live name first, nor `mv -T` a directory onto it.
+- Producers: both stagers via `staged_packages_publish` in `usr/lib/snosi/staged-packages.sh` (bootc captures the pulled image's `packages.txt` before `bootc switch`/`upgrade`; native reads it from the freshly-labeled other root slot).
+- Consumer: `snosi-update-status --pkg-diff` via `staged_packages_resolve` — reads the sidecar **only** when `identity` matches the live staged digest/version; a mismatch (a later manual stage) is treated as missing (warn-and-skip). Dies with `/run` on the applying reboot.
+- **Fragility:** 🟡 — identity is checked before parse, but a stager predating ADR-0014 leaves no sidecar (`--pkg-diff` warns and skips until the next hop).
+
+### 5.4 Other filesystem contracts
 - `/var/lib/extensions.d/` — sysext download target; `/var/lib/extensions/` — sysext discovery symlinks (updex writes, `systemd-sysext refresh` reads).
 - `/etc/sysupdate.<name>.d/<feature>.feature.d/00-updex.conf` — updex enable/disable drop-in (also the whole-file test-override mechanism for `.transfer`).
 - `/run/pilothouse/broker.sock` — HTTP-over-Unix between pilothouse web and broker (see §6).

--- a/mkosi.images/base/mkosi.extra/usr/bin/snosi-update-status
+++ b/mkosi.images/base/mkosi.extra/usr/bin/snosi-update-status
@@ -29,16 +29,23 @@ CHECK=/run/snosi/update-check
 SEM=/run/snosi/update-staged
 MARKER=/usr/lib/snosi/native-ab
 PUBRING=/usr/lib/systemd/import-pubring.gpg
+STAGED_PACKAGES_LIB="${SNOSI_STAGED_PACKAGES_LIB:-/usr/lib/snosi/staged-packages.sh}"
+FROSTYARD_SHARE=/usr/share/frostyard
 
 usage() {
-    echo "Usage: snosi-update-status [--check]" >&2
+    echo "Usage: snosi-update-status [--check] [--pkg-diff]" >&2
+    echo "  --check     also query the update source live (versions, never digests)" >&2
+    echo "  --pkg-diff  after the status block, show the Debian-package delta" >&2
+    echo "              between the running image and the locally staged one" >&2
     exit 2
 }
 
 LIVE=0
+PKGDIFF=0
 for arg in "$@"; do
     case "$arg" in
         --check) LIVE=1 ;;
+        --pkg-diff) PKGDIFF=1 ;;
         *) usage ;;
     esac
 done
@@ -49,12 +56,44 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 running_version=""
+running_image_id=""
 if [[ -r /usr/lib/os-release ]]; then
     running_version=$(. /usr/lib/os-release && echo "${IMAGE_VERSION:-}")
+    running_image_id=$(. /usr/lib/os-release && echo "${IMAGE_ID:-}")
+fi
+
+# The --pkg-diff parser/resolver lives in one shared library (ADR-0014); source
+# it lazily so the default status path is unaffected if it is ever absent.
+STAGED_PACKAGES_OK=0
+if [[ $PKGDIFF -eq 1 ]]; then
+    if [[ -r $STAGED_PACKAGES_LIB ]]; then
+        # shellcheck source=/dev/null
+        source "$STAGED_PACKAGES_LIB"
+        STAGED_PACKAGES_OK=1
+    fi
 fi
 
 # key FILE - print the value of key= from FILE, empty if absent
 key() { sed -n "s/^$1=//p" "$2" 2>/dev/null || true; }
+
+# running_packages_file - path to the booted image's frozen package list
+# (core ADR-0003), or empty if it is missing.
+running_packages_file() {
+    local f="$FROSTYARD_SHARE/${running_image_id}.packages.txt"
+    [[ -n $running_image_id && -r $f ]] && printf '%s\n' "$f"
+}
+
+# print_pkg_diff OLD NEW - emit the "Packages:" block, or a "no changes" line.
+print_pkg_diff() { # old_file new_file
+    local out
+    out="$(pkg_diff "$1" "$2")"
+    echo "Packages:"
+    if [[ -n $out ]]; then
+        sed 's/^/  /' <<<"$out"
+    else
+        echo "  no package changes between the running and staged images"
+    fi
+}
 
 # ---------------------------------------------------------------------------
 # Native A/B backend
@@ -150,6 +189,82 @@ native_status() {
     if [[ $LIVE -eq 1 ]]; then
         native_check_live "$channel" "$image_id"
     fi
+
+    if [[ $PKGDIFF -eq 1 ]]; then
+        native_pkg_diff "$image_id"
+    fi
+}
+
+# native_other_slot IMAGE_ID -- print "<devpath>\t<version>" for the non-booted
+# root slot ("${image_id}_<version>_r"), or nothing when it is still _empty.
+# The booted slot is excluded by LABEL, never by findmnt's mount source (a
+# dm-verity root mounts from /dev/mapper/root, which never equals the partition
+# path -- the same trap the stager documents).
+native_other_slot() { # image_id
+    local image_id=$1
+    lsblk -J -o PATH,PARTLABEL 2>/dev/null | jq -r \
+        --arg running "${image_id}_${running_version}_r" --arg prefix "${image_id}_" '
+        .. | objects
+        | select(.partlabel? != null)
+        | select(.partlabel != $running)
+        | select(.partlabel | startswith($prefix))
+        | select(.partlabel | endswith("_r"))
+        | "\(.path)\t\(.partlabel | ltrimstr($prefix) | rtrimstr("_r"))"' 2>/dev/null | head -1 || true
+}
+
+# native_pkg_diff IMAGE_ID -- prefer the sidecar bound to the staged version;
+# on a missing/mismatched sidecar, fall back to reading packages.txt from the
+# other EROFS slot read-only at query time (the only filesystem this flag may
+# mount). Warn-and-skip, exit 0, if the fallback also fails. No network.
+native_pkg_diff() { # image_id
+    local image_id=$1 running backing slot dev version
+    if [[ $STAGED_PACKAGES_OK -ne 1 ]]; then
+        echo "Packages:   --pkg-diff unavailable ($STAGED_PACKAGES_LIB missing)"
+        return 0
+    fi
+    running="$(running_packages_file)"
+    if [[ -z $running ]]; then
+        echo "Packages:   running image package list not found ($FROSTYARD_SHARE/${running_image_id}.packages.txt)"
+        return 0
+    fi
+
+    slot="$(native_other_slot "$image_id")"
+    dev="${slot%%$'\t'*}"
+    version="${slot##*$'\t'}"
+    if [[ -z $version || $dev == "$version" ]]; then
+        # No non-booted _r slot carries a version: nothing is installed to diff.
+        echo "Packages:   nothing staged to diff"
+        return 0
+    fi
+    if [[ -n $running_version && ! $version > $running_version ]]; then
+        # The other slot is older/equal (a rollback candidate, not a pending
+        # update). A staged delta is forward-looking; there is nothing pending.
+        echo "Packages:   nothing staged to diff (other slot $version is not newer than running)"
+        return 0
+    fi
+
+    backing="$(staged_packages_resolve version "$version")" || backing=""
+    if [[ -n $backing ]]; then
+        print_pkg_diff "$running" "$backing/packages.txt"
+        return 0
+    fi
+
+    # Fallback: mount the other slot read-only and read its packages.txt.
+    local mnt other_pkg
+    mnt="$(mktemp -d)"
+    if mount -o ro "$dev" "$mnt" 2>/dev/null; then
+        other_pkg="$mnt/usr/share/frostyard/${image_id}.packages.txt"
+        if [[ -r $other_pkg ]]; then
+            print_pkg_diff "$running" "$other_pkg"
+            umount "$mnt" 2>/dev/null || true
+            rmdir "$mnt" 2>/dev/null || true
+            return 0
+        fi
+        umount "$mnt" 2>/dev/null || true
+    fi
+    rmdir "$mnt" 2>/dev/null || true
+    echo "Packages:   WARNING: could not read the staged image's package inventory (no sidecar, and $dev could not be read); skipping the delta"
+    return 0
 }
 
 # native_check_live channel image_id -- fetch and gpgv-verify the channel's
@@ -264,6 +379,38 @@ bootc_status() {
             echo "Registry:   $published — differs from running ${running_version:-unknown}"
         fi
     fi
+
+    if [[ $PKGDIFF -eq 1 ]]; then
+        bootc_pkg_diff "$staged_digest"
+    fi
+}
+
+# bootc_pkg_diff STAGED_DIGEST -- diff the running image against the locally
+# captured sidecar for the staged deployment (ADR-0014). Never re-pulls: a
+# missing/mismatched sidecar is warn-and-skip, exit 0. STAGED_DIGEST is the
+# bootc-reported staged imageDigest (sha256:<64hex>), the expected identity.
+bootc_pkg_diff() { # staged_digest
+    local staged_digest=$1 running backing
+    if [[ $STAGED_PACKAGES_OK -ne 1 ]]; then
+        echo "Packages:   --pkg-diff unavailable ($STAGED_PACKAGES_LIB missing)"
+        return 0
+    fi
+    running="$(running_packages_file)"
+    if [[ -z $running ]]; then
+        echo "Packages:   running image package list not found ($FROSTYARD_SHARE/${running_image_id}.packages.txt)"
+        return 0
+    fi
+    if [[ -z $staged_digest ]]; then
+        echo "Packages:   nothing staged to diff"
+        return 0
+    fi
+    backing="$(staged_packages_resolve digest "$staged_digest")" || backing=""
+    if [[ -z $backing ]]; then
+        echo "Packages:   WARNING: the staged deployment's package inventory was not captured; skipping the delta"
+        echo "            (staged before this feature shipped, or by a manual \`bootc upgrade\` with no timer run yet)"
+        return 0
+    fi
+    print_pkg_diff "$running" "$backing/packages.txt"
 }
 
 if [[ -e "$MARKER" ]]; then

--- a/mkosi.images/base/mkosi.extra/usr/lib/snosi/staged-packages.sh
+++ b/mkosi.images/base/mkosi.extra/usr/lib/snosi/staged-packages.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Shared staged-package inventory for `snosi-update-status --pkg-diff`
+# (docs/adr/0014-update-status-pkg-diff.md). Sourced by both stagers
+# (publish side) and by snosi-update-status (resolve + parse + diff side).
+# Deliberately does NOT set shell options: it must be safe to source into a
+# caller running under `set -euo pipefail` without changing its behavior.
+#
+# The staged sidecar is an identity-bound, write-once backing directory with a
+# single mutating name (the symlink):
+#
+#   $RUN_DIR/staged-packages -> staged-packages.sha256-<64hex>   # bootc
+#   $RUN_DIR/staged-packages -> staged-packages.<14-digit>       # native
+#   $RUN_DIR/staged-packages.<id>/identity      # exactly one of digest=/version=
+#   $RUN_DIR/staged-packages.<id>/packages.txt  # exact bytes from the staged image
+#
+# The backing name never contains a colon (bootc uses "sha256-" + 64 hex, not
+# "sha256:"). identity uses the SAME exclusive invariant as update-staged:
+# bootc writes "digest=sha256:<64hex>", native writes "version=<14-digit>",
+# never both. A backing directory is created complete and never mutated; only
+# the symlink is swapped, atomically, with `mv -T` (rename(2) of a symlink).
+
+SNOSI_STAGED_PACKAGES_RUN_DIR="${SNOSI_RUN_DIR:-/run/snosi}"
+
+# staged_packages_backing_name KIND VALUE -- the backing directory basename for
+# an identity. KIND is "digest" (VALUE = sha256:<64hex>) or "version"
+# (VALUE = <14-digit>). Prints nothing and returns 1 on a malformed identity.
+staged_packages_backing_name() { # kind value
+    local kind=$1 value=$2
+    case "$kind" in
+    digest)
+        [[ $value =~ ^sha256:[[:xdigit:]]{64}$ ]] || return 1
+        # sha256:<hex> -> sha256-<hex>; the on-disk name must never hold a colon.
+        printf 'staged-packages.sha256-%s\n' "${value#sha256:}"
+        ;;
+    version)
+        [[ $value =~ ^[0-9]{14}$ ]] || return 1
+        printf 'staged-packages.%s\n' "$value"
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
+# staged_packages_publish KIND VALUE SRC_PACKAGES_FILE -- publish the sidecar
+# for an identity from an already-captured packages.txt file. Idempotent: an
+# existing backing directory of the same identity is left untouched; only the
+# symlink is (re-)swapped. Never `rm`s the live symlink or a previous backing
+# directory first, and never `mv -T`s a directory onto the published name (that
+# would fail with "Directory not empty" on every publish after the first).
+# Returns non-zero without mutating the published symlink on any error.
+staged_packages_publish() { # kind value src_packages_file
+    local kind=$1 value=$2 src=$3
+    local run_dir="$SNOSI_STAGED_PACKAGES_RUN_DIR"
+    local name backing tmpdir identity_line linktmp
+
+    name="$(staged_packages_backing_name "$kind" "$value")" || {
+        echo "staged-packages: refusing to publish a malformed $kind identity: '$value'" >&2
+        return 1
+    }
+    case "$kind" in
+    digest) identity_line="digest=$value" ;;
+    version) identity_line="version=$value" ;;
+    esac
+
+    [[ -r $src ]] || {
+        echo "staged-packages: source package list is missing: $src" >&2
+        return 1
+    }
+
+    mkdir -p "$run_dir" || return 1
+    backing="$run_dir/$name"
+
+    # Step 1: create the backing directory complete, then rename it into place
+    # under a name that must not already exist. If it exists, leave it.
+    if [[ ! -e $backing ]]; then
+        tmpdir="$(mktemp -d "$run_dir/.staged-packages.XXXXXX")" || return 1
+        {
+            printf '%s\n' "$identity_line" >"$tmpdir/identity" &&
+                cp -- "$src" "$tmpdir/packages.txt"
+        } || {
+            rm -rf "$tmpdir"
+            return 1
+        }
+        # `mv -T` onto a NEW name; if a racing publisher created it first, keep
+        # the winner and discard ours (never overwrite an existing backing dir).
+        if ! mv -T "$tmpdir" "$backing" 2>/dev/null; then
+            rm -rf "$tmpdir"
+            [[ -e $backing ]] || return 1
+        fi
+    fi
+
+    # Steps 2-3: point the published symlink at the backing directory by
+    # creating a fresh symlink and atomically renaming it over the live name.
+    # `mv -T` of a symlink is an ordinary atomic rename(2) of a file; because
+    # the target it clobbers is always a symlink (this being the only writer),
+    # it never hits the directory case. The link target is the bare basename so
+    # it resolves within run_dir regardless of how run_dir is reached.
+    linktmp="$(mktemp -u "$run_dir/.staged-packages-link.XXXXXX")" || return 1
+    ln -s "$name" "$linktmp" || return 1
+    mv -T "$linktmp" "$run_dir/staged-packages" || {
+        rm -f "$linktmp"
+        return 1
+    }
+}
+
+# staged_packages_resolve KIND VALUE -- resolve the published sidecar for an
+# EXPECTED identity. Prints the backing directory path and returns 0 only when
+# the symlink resolves to a real directory whose identity file matches the
+# expected KIND/VALUE. Prints nothing and returns 1 on a missing symlink,
+# dangling target, or identity mismatch (a manual stage that replaced the
+# deployment cannot reuse an older inventory).
+staged_packages_resolve() { # kind value
+    local kind=$1 value=$2
+    local run_dir="$SNOSI_STAGED_PACKAGES_RUN_DIR"
+    local link="$run_dir/staged-packages" resolved expected got
+
+    [[ -L $link || -e $link ]] || return 1
+    resolved="$(readlink -f "$link" 2>/dev/null)" || return 1
+    [[ -n $resolved && -d $resolved && -r "$resolved/identity" && -r "$resolved/packages.txt" ]] || return 1
+
+    case "$kind" in
+    digest) expected="digest=$value" ;;
+    version) expected="version=$value" ;;
+    *) return 1 ;;
+    esac
+    got="$(head -n1 "$resolved/identity" 2>/dev/null)" || return 1
+    [[ $got == "$expected" ]] || return 1
+    printf '%s\n' "$resolved"
+}
+
+# apt_list_parse FILE -- emit "<arch-qualified-name><TAB><version>" for each
+# package line of an `apt list --installed` file (core ADR-0003 packages.txt).
+# The comparison key is everything before the first "/" (so libfoo:amd64 and
+# libfoo:i386 stay distinct; :arch is neither stripped nor invented). The
+# version is the second whitespace field. `Listing...` header lines are
+# skipped. This is the ONE parser; both status backends call it.
+apt_list_parse() { # file
+    local file=$1
+    awk '
+        /^Listing/ { next }
+        NF == 0 { next }
+        {
+            split($1, a, "/")
+            print a[1] "\t" $2
+        }
+    ' "$file"
+}
+
+# _staged_packages_section HEADER ARRAYNAME -- print an rpm-ostree-shaped
+# section (header, then two-space-indented sorted entries) iff the named array
+# is non-empty. Returns 0 when it printed, 1 when the array was empty.
+_staged_packages_section() { # header arrayname
+    local header=$1
+    local -n _entries=$2
+    ((${#_entries[@]})) || return 1
+    printf '%s\n' "$header"
+    printf '  %s\n' "${_entries[@]}" | sort
+}
+
+# pkg_diff OLD_FILE NEW_FILE -- print the Debian-package delta between two
+# packages.txt files in rpm-ostree `db diff` shape. Version ordering uses
+# `dpkg --compare-versions` (the dpkg database is never read). Equal versions
+# are omitted; a higher new version is Upgraded, a lower one Downgraded (never
+# folded together). Prints nothing when the two lists are identical.
+pkg_diff() { # old_file new_file
+    local old=$1 new=$2
+    local -A _old=() _new=()
+    local key ver ov nv
+    local -a _upgraded=() _downgraded=() _added=() _removed=()
+
+    while IFS=$'\t' read -r key ver; do
+        [[ -n $key ]] && _old["$key"]=$ver
+    done < <(apt_list_parse "$old")
+    while IFS=$'\t' read -r key ver; do
+        [[ -n $key ]] && _new["$key"]=$ver
+    done < <(apt_list_parse "$new")
+
+    for key in "${!_new[@]}"; do
+        if [[ -z ${_old[$key]+x} ]]; then
+            _added+=("$key ${_new[$key]}")
+            continue
+        fi
+        ov=${_old[$key]}
+        nv=${_new[$key]}
+        [[ $ov == "$nv" ]] && continue
+        # Order with dpkg, never by string; a dpkg-equal pair that differs only
+        # textually (e.g. "1.0" vs "1.0-0") is not a change and is omitted.
+        if dpkg --compare-versions "$ov" lt "$nv"; then
+            _upgraded+=("$key $ov -> $nv")
+        elif dpkg --compare-versions "$ov" gt "$nv"; then
+            _downgraded+=("$key $ov -> $nv")
+        fi
+    done
+    for key in "${!_old[@]}"; do
+        [[ -z ${_new[$key]+x} ]] && _removed+=("$key ${_old[$key]}")
+    done
+
+    _staged_packages_section "Upgraded:" _upgraded || true
+    _staged_packages_section "Downgraded:" _downgraded || true
+    _staged_packages_section "Added:" _added || true
+    _staged_packages_section "Removed:" _removed || true
+}

--- a/mkosi.images/base/mkosi.extra/usr/libexec/bootc-update-stage
+++ b/mkosi.images/base/mkosi.extra/usr/libexec/bootc-update-stage
@@ -19,6 +19,60 @@ set -euo pipefail
 RUN_DIR=${SNOSI_RUN_DIR:-/run/snosi}
 CHECK="$RUN_DIR/update-check"
 
+# Shared staged-package sidecar publisher (ADR-0014). Sourced here (publish
+# side) and by snosi-update-status (resolve side). SNOSI_RUN_DIR, honored
+# above, is also honored by the library for the sidecar location.
+STAGED_PACKAGES_LIB="${SNOSI_STAGED_PACKAGES_LIB:-/usr/lib/snosi/staged-packages.sh}"
+# shellcheck source=/dev/null
+[[ -r $STAGED_PACKAGES_LIB ]] && source "$STAGED_PACKAGES_LIB"
+
+# capture_pulled_packages IMAGE -- copy the pulled image's frozen package list
+# (/usr/share/frostyard/<IMAGE_ID>.packages.txt, core ADR-0003) to a private
+# temp file and print its path. MUST run before `bootc switch`/`upgrade`: once
+# a deployment is staged, a copy failure can no longer unstage it, so this
+# capture is a hard prerequisite of staging, not a post-step (ADR-0014).
+# Copies the whole frostyard dir and globs the single *.packages.txt rather
+# than parsing the image's os-release ID -- more robust, and correct even if a
+# product were renamed between versions (the diff is over bytes, not names).
+capture_pulled_packages() { # image
+    local image=$1 cid extract tmp
+    extract="$(mktemp -d)" || return 1
+    if ! cid="$(podman create --quiet "$image")"; then
+        rm -rf "$extract"
+        return 1
+    fi
+    if ! podman cp "$cid:/usr/share/frostyard/." "$extract" 2>/dev/null; then
+        podman rm -f "$cid" >/dev/null 2>&1 || true
+        rm -rf "$extract"
+        return 1
+    fi
+    podman rm -f "$cid" >/dev/null 2>&1 || true
+
+    shopt -s nullglob
+    local matches=("$extract"/*.packages.txt)
+    shopt -u nullglob
+    if [[ ${#matches[@]} -ne 1 ]]; then
+        echo "ERROR: expected exactly one *.packages.txt in the pulled image, found ${#matches[@]}" >&2
+        rm -rf "$extract"
+        return 1
+    fi
+    tmp="$(mktemp)" || { rm -rf "$extract"; return 1; }
+    cp -- "${matches[0]}" "$tmp" || { rm -rf "$extract" "$tmp"; return 1; }
+    rm -rf "$extract"
+    printf '%s\n' "$tmp"
+}
+
+# publish_pkg_sidecar DIGEST SRC -- best-effort sidecar publish. A publish
+# failure never fails the stage (the deployment is already staged by the time
+# this is called; the next timer run's pulled==staged branch repairs it).
+publish_pkg_sidecar() { # digest src
+    local digest=$1 src=$2
+    [[ -n $src && -r $src ]] || return 0
+    command -v staged_packages_publish >/dev/null 2>&1 || return 0
+    staged_packages_publish digest "$digest" "$src" \
+        || echo "WARNING: could not publish the staged-package sidecar for $digest" >&2
+}
+
 running_version=""
 if [[ -r /usr/lib/os-release ]]; then
     running_version=$(. /usr/lib/os-release && echo "${IMAGE_VERSION:-}")
@@ -34,8 +88,10 @@ write_check() { # outcome
 # A real staged semaphore may coexist with outcome=failed when a later check fails.
 # Any failure (podman pull, bootc, the post-stage digest verify) records
 # outcome=failed; a broken checker must not be indistinguishable from an
-# up-to-date system.
-trap '[[ $? -eq 0 ]] || write_check failed' EXIT
+# up-to-date system. The trap also removes the private packages.txt temp file
+# (ADR-0014 capture-before-stage) on every exit path.
+pkg_temp=""
+trap '[[ $? -eq 0 ]] || write_check failed; [[ -n $pkg_temp ]] && rm -f "$pkg_temp"' EXIT
 
 status=$(bootc status --format json)
 
@@ -98,14 +154,9 @@ if [[ "$pulled" == "$booted" ]]; then
     write_check current
     exit 0
 fi
-if [[ "$pulled" == "$staged" ]]; then
-    echo "$image ($pulled) is already staged; will apply at next reboot."
-    # Re-assert the semaphore: it is runtime state and this covers updates
-    # staged outside this script (e.g. a manual `bootc upgrade`).
-    write_staged_semaphore "$pulled"
-    write_check staged
-    exit 0
-fi
+# held-rollback is decided BEFORE the packages.txt capture: a rollback-equal
+# pull is never staged, so ADR-0014's "skip the copy" applies. (Checked ahead
+# of the already-staged branch too; a pulled digest cannot equal both.)
 if [[ -n "$rollback" && "$pulled" == "$rollback" ]]; then
     # The published image is the deployment the admin rolled back FROM.
     # Do not flip-flop back to it automatically (bootc would refuse anyway:
@@ -113,6 +164,27 @@ if [[ -n "$rollback" && "$pulled" == "$rollback" ]]; then
     # deployment"). Use `bootc rollback` deliberately if that is intended.
     echo "$image ($pulled) equals the rollback deployment; not re-staging automatically."
     write_check held-rollback
+    exit 0
+fi
+
+# Capture the pulled image's package list to a private temp file BEFORE any
+# `bootc switch`/`upgrade` (ADR-0014). A failure here must abort before
+# staging: once a deployment is staged, a copy failure can no longer unstage
+# it, and the next timer run would only re-assert the semaphore. This applies
+# to both the already-staged and the new-stage paths below.
+if ! pkg_temp="$(capture_pulled_packages "$image")"; then
+    echo "ERROR: could not extract packages.txt from the pulled image before staging; aborting." >&2
+    exit 1
+fi
+
+if [[ "$pulled" == "$staged" ]]; then
+    echo "$image ($pulled) is already staged; will apply at next reboot."
+    # Publish the sidecar FIRST: this branch is what repairs a prior run that
+    # staged but failed to publish it (ADR-0014). Then re-assert the semaphore
+    # (runtime state; also covers a manual `bootc upgrade`).
+    publish_pkg_sidecar "$pulled" "$pkg_temp"
+    write_staged_semaphore "$pulled"
+    write_check staged
     exit 0
 fi
 
@@ -138,10 +210,16 @@ if [[ "$staged_now" != "$pulled" ]]; then
     exit 1
 fi
 
+# Publish the staged-package sidecar bound to the staged digest, from the
+# temp captured before staging (ADR-0014), THEN write the semaphore, THEN
+# prune. Never prune before the sidecar is published.
+publish_pkg_sidecar "$pulled" "$pkg_temp"
+
+write_staged_semaphore "$pulled"
+write_check staged
+
 # The image content is copied into the composefs repository at switch time;
 # prune dangling transfer images to keep podman storage bounded.
 podman image prune -f >/dev/null || true
 
-write_staged_semaphore "$pulled"
-write_check staged
 echo "Update staged; it will apply at the next reboot."

--- a/shared/outformat/ab-root/tree/usr/libexec/snosi-sysupdate-stage
+++ b/shared/outformat/ab-root/tree/usr/libexec/snosi-sysupdate-stage
@@ -58,6 +58,12 @@ SEM=/run/snosi/update-staged
 SYSUPDATE=/usr/lib/systemd/systemd-sysupdate
 ESP_UKI_DIR=/boot/EFI/Linux
 
+# Shared staged-package sidecar publisher (ADR-0014). Sourced here (publish
+# side) and by snosi-update-status (resolve side).
+STAGED_PACKAGES_LIB="${SNOSI_STAGED_PACKAGES_LIB:-/usr/lib/snosi/staged-packages.sh}"
+# shellcheck source=/dev/null
+[[ -r $STAGED_PACKAGES_LIB ]] && source "$STAGED_PACKAGES_LIB"
+
 if [[ ! -e "$MARKER" ]]; then
     echo "Not a native A/B system; nothing to do."
     exit 0
@@ -98,6 +104,37 @@ write_staged_semaphore() { # version
     mkdir -p /run/snosi
     printf 'image=%s\nversion=%s\nstaged_at=%s\n' \
         "$channel" "$1" "$(date --iso-8601=seconds)" >/run/snosi/update-staged
+}
+
+# publish_native_sidecar VERSION -- read packages.txt from the newly-labeled
+# other root slot (read-only EROFS access) and publish the ADR-0014 sidecar
+# bound to version=<14-digit>. Best-effort: a failure here never fails an
+# already-successful stage (the deployment is on disk; the next run's
+# already-staged branch repairs the sidecar), so it warns and returns 0.
+publish_native_sidecar() { # version
+    local version=$1 dev mnt pkg
+    command -v staged_packages_publish >/dev/null 2>&1 || return 0
+    dev="$(lsblk -J -o PATH,PARTLABEL 2>/dev/null | jq -r \
+        --arg label "${image_id}_${version}_r" \
+        '.. | objects | select(.partlabel? == $label) | .path' 2>/dev/null | head -1)"
+    if [[ -z $dev ]]; then
+        echo "WARNING: staged-package sidecar: no slot labeled ${image_id}_${version}_r" >&2
+        return 0
+    fi
+    mnt="$(mktemp -d)"
+    if mount -o ro "$dev" "$mnt" 2>/dev/null; then
+        pkg="$mnt/usr/share/frostyard/${image_id}.packages.txt"
+        if [[ -r $pkg ]]; then
+            staged_packages_publish version "$version" "$pkg" \
+                || echo "WARNING: could not publish the staged-package sidecar for $version" >&2
+        else
+            echo "WARNING: staged slot $version has no packages.txt at $pkg" >&2
+        fi
+        umount "$mnt" 2>/dev/null || true
+    else
+        echo "WARNING: staged-package sidecar: could not mount $dev read-only" >&2
+    fi
+    rmdir "$mnt" 2>/dev/null || true
 }
 
 # other_slot_version -- version label of the currently INACTIVE root slot
@@ -207,6 +244,9 @@ if [[ $newest_rc -ne 0 ]]; then
     if [[ -s "$SEM" ]]; then
         echo "A previously staged update is still pending a reboot."
         remote_version="$(sed -n 's/^version=//p' "$SEM")"
+        # Repair the sidecar if this run staged nothing but a pending update
+        # exists (e.g. a stager from before ADR-0014, or a lost sidecar).
+        [[ "$remote_version" =~ ^[0-9]{14}$ ]] && publish_native_sidecar "$remote_version"
         write_check staged
     else
         write_check current
@@ -243,6 +283,7 @@ if [[ "$rollback_or_staged" == "$remote_version" ]]; then
     # previous stager run already staged it and the applying reboot simply
     # hasn't happened yet -- re-assert, don't re-download.
     echo "$remote_version is already installed in the inactive slot; re-asserting staged state."
+    publish_native_sidecar "$remote_version"
     write_staged_semaphore "$remote_version"
     write_check staged
     exit 0
@@ -340,6 +381,9 @@ if [[ ${#uki_matches[@]} -eq 0 ]]; then
 fi
 echo "Post-stage check: UKI present in ESP (${uki_matches[0]})"
 
+# Publish the staged-package sidecar from the freshly-installed other slot
+# (ADR-0014), then the semaphore.
+publish_native_sidecar "$remote_version"
 write_staged_semaphore "$remote_version"
 write_check staged
 echo "Update staged; it will apply at the next reboot."

--- a/test/bootc-container-policy-test.sh
+++ b/test/bootc-container-policy-test.sh
@@ -285,15 +285,31 @@ esac
 EOF
     cat >"$work/bin/podman" <<'EOF'
 #!/bin/bash
-case "$1 $2" in
-"image prune"|"pull --quiet") exit 0 ;;
-"image inspect")
-    case "$*" in
-    *'{{.Digest}}'*) printf '%s\n' "$PULLED_MANIFEST" ;;
-    *'{{.Id}}'*) printf '%s\n' "$PULLED_CONFIG_ID" ;;
-    *'org.opencontainers.image.version'*) printf '%s\n' 20260814141627 ;;
+case "$1" in
+image)
+    case "$2" in
+    prune) exit 0 ;;
+    inspect)
+        case "$*" in
+        *'{{.Digest}}'*) printf '%s\n' "$PULLED_MANIFEST" ;;
+        *'{{.Id}}'*) printf '%s\n' "$PULLED_CONFIG_ID" ;;
+        *'org.opencontainers.image.version'*) printf '%s\n' 20260814141627 ;;
+        *) exit 1 ;;
+        esac
+        ;;
     *) exit 1 ;;
     esac
+    ;;
+pull) exit 0 ;;
+# ADR-0014 packages.txt capture: bootc-update-stage runs `podman create`,
+# `podman cp <cid>:/usr/share/frostyard/. <dir>`, `podman rm -f` before it
+# stages. Serve a single fake packages.txt so the capture succeeds.
+create) printf 'fakecid\n' ;;
+rm) : ;;
+cp)
+    dest=$3
+    mkdir -p "$dest"
+    printf 'Listing... Done\nbash/now 5.2.37-2 amd64 [installed,local]\n' >"$dest/snow.packages.txt"
     ;;
 *) exit 1 ;;
 esac
@@ -305,6 +321,7 @@ EOF
         BOOTC_STATUS_BEFORE="$before" BOOTC_STATUS_AFTER="$after" \
         FIXTURE_STATE="$work/state" PULLED_MANIFEST="$manifest" \
         PULLED_CONFIG_ID=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+        SNOSI_STAGED_PACKAGES_LIB="$PROJECT_ROOT/mkosi.images/base/mkosi.extra/usr/lib/snosi/staged-packages.sh" \
         SNOSI_RUN_DIR="$work/run" "$UPDATER" >"$work/output" 2>&1
     rc=$?
     set -e

--- a/test/fixtures/pkg-diff/expected-diff.txt
+++ b/test/fixtures/pkg-diff/expected-diff.txt
@@ -1,0 +1,11 @@
+Upgraded:
+  libde265-0:amd64 1.0.15-1+deb13u1 -> 1.0.15-1+deb13u2
+  linux-image-amd64 6.12.30-1 -> 6.12.33-1
+Downgraded:
+  libssl3t64:amd64 3.5.1-1 -> 3.4.0-1
+Added:
+  htop 3.3.0-1
+  libnewdep:amd64 1.2-1
+Removed:
+  libc6:i386 2.41-12
+  obsolete-tool 2.0-3

--- a/test/fixtures/pkg-diff/running.packages.txt
+++ b/test/fixtures/pkg-diff/running.packages.txt
@@ -1,0 +1,12 @@
+Listing... Done
+apt/now 3.0.3 amd64 [installed,local]
+bash/now 5.2.37-2 amd64 [installed,local]
+base-files/now 13.9 amd64 [installed,local]
+libc6:amd64/stable,now 2.41-12 amd64 [installed,automatic]
+libc6:i386/stable,now 2.41-12 i386 [installed,automatic]
+libde265-0:amd64/stable,now 1.0.15-1+deb13u1 amd64 [installed,automatic]
+libssl3t64:amd64/stable,now 3.5.1-1 amd64 [installed,automatic]
+linux-image-amd64/stable,now 6.12.30-1 amd64 [installed,automatic]
+obsolete-tool/now 2.0-3 amd64 [installed,local]
+vim-common/stable,now 2:9.1.1230-1 all [installed,automatic]
+zlib1g:amd64/stable,now 1:1.3.dfsg+really1.3.1-1+b1 amd64 [installed,automatic]

--- a/test/fixtures/pkg-diff/staged.packages.txt
+++ b/test/fixtures/pkg-diff/staged.packages.txt
@@ -1,0 +1,12 @@
+Listing... Done
+apt/now 3.0.3 amd64 [installed,local]
+bash/now 5.2.37-2 amd64 [installed,local]
+base-files/now 13.9 amd64 [installed,local]
+htop/stable,now 3.3.0-1 amd64 [installed,automatic]
+libc6:amd64/stable,now 2.41-12 amd64 [installed,automatic]
+libde265-0:amd64/stable,now 1.0.15-1+deb13u2 amd64 [installed,automatic]
+libnewdep:amd64/stable,now 1.2-1 amd64 [installed,automatic]
+libssl3t64:amd64/stable,now 3.4.0-1 amd64 [installed,automatic]
+linux-image-amd64/stable,now 6.12.33-1 amd64 [installed,automatic]
+vim-common/stable,now 2:9.1.1230-1 all [installed,automatic]
+zlib1g:amd64/stable,now 1:1.3.dfsg+really1.3.1-1+b1 amd64 [installed,automatic]

--- a/test/pkg-diff-test.sh
+++ b/test/pkg-diff-test.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# Fixture suite for the ADR-0014 staged-package inventory library
+# (mkosi.images/base/mkosi.extra/usr/lib/snosi/staged-packages.sh): the ONE
+# apt-list parser and package differ used by `snosi-update-status --pkg-diff`,
+# plus the identity-bound sidecar publish/resolve used by both stagers.
+#
+# The parser/diff fixtures are real Debian Trixie `apt list --installed` lines
+# (arch-qualified names, "<suite>,now" and bare "now" lines, "Listing... Done"
+# header, epoch/backport version grammar) -- NOT simplified "name/now version"
+# stubs, per ADR-0014's "captured lines from the target image's APT" rule.
+#
+# Version-ordering assertions require `dpkg --compare-versions` (the dpkg
+# DATABASE is never read); on a host without dpkg they TAP-SKIP rather than
+# fail, so the parser and sidecar coverage still runs everywhere. validate.yml
+# runs on a Debian/Ubuntu runner where dpkg is present.
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+lib="$root/mkosi.images/base/mkosi.extra/usr/lib/snosi/staged-packages.sh"
+fixtures="$root/test/fixtures/pkg-diff"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+export SNOSI_RUN_DIR="$workdir/run"
+
+# shellcheck source=/dev/null
+source "$lib"
+
+test_number=0
+failures=0
+ok() { test_number=$((test_number + 1)); echo "ok $test_number - $1"; }
+fail() {
+    test_number=$((test_number + 1)); failures=$((failures + 1))
+    echo "not ok $test_number - $1"
+    [[ $# -gt 1 ]] && printf '# %s\n' "$2"
+}
+skip() { test_number=$((test_number + 1)); echo "ok $test_number - $1 # SKIP $2"; }
+is() { # actual expected label
+    if [[ "$1" == "$2" ]]; then ok "$3"; else
+        fail "$3" "expected [$2], got [$1]"
+    fi
+}
+
+# --- parser -----------------------------------------------------------------
+
+parsed="$(apt_list_parse "$fixtures/running.packages.txt")"
+
+field() { grep -P "^$1\t" <<<"$parsed" | cut -f2; }
+
+is "$(field 'libc6:amd64')" '2.41-12' 'arch-qualified key (:amd64) preserved, version parsed'
+is "$(field 'libc6:i386')" '2.41-12' 'the i386 Multi-Arch instance is a distinct key'
+is "$(field 'bash')" '5.2.37-2' 'bare "now" (local) line parsed'
+is "$(field 'vim-common')" '2:9.1.1230-1' 'epoch version kept intact'
+is "$(field 'zlib1g:amd64')" '1:1.3.dfsg+really1.3.1-1+b1' 'complex epoch/binNMU version kept intact'
+
+if grep -qiP '^Listing' <<<"$parsed"; then
+    fail 'the "Listing... Done" header is not emitted as a package'
+else
+    ok 'the "Listing... Done" header is skipped'
+fi
+
+# every emitted key is the substring before the first "/" of a source line
+if awk -F'\t' 'NF!=2 || $1=="" || $2=="" {exit 1}' <<<"$parsed"; then
+    ok 'every parsed line is exactly key<TAB>version'
+else
+    fail 'a parsed line was not key<TAB>version'
+fi
+
+# --- diff (dpkg-gated) ------------------------------------------------------
+
+if command -v dpkg >/dev/null 2>&1; then
+    got="$(pkg_diff "$fixtures/running.packages.txt" "$fixtures/staged.packages.txt")"
+    want="$(cat "$fixtures/expected-diff.txt")"
+    is "$got" "$want" 'pkg_diff matches the expected Upgraded/Downgraded/Added/Removed delta'
+
+    # identical lists produce no output
+    empty="$(pkg_diff "$fixtures/running.packages.txt" "$fixtures/running.packages.txt")"
+    is "$empty" '' 'identical package lists produce no delta'
+else
+    skip 'pkg_diff delta' 'dpkg not available'
+    skip 'identical lists produce no delta' 'dpkg not available'
+fi
+
+# --- backing-name shapes ----------------------------------------------------
+
+digest="sha256:$(printf 'a%.0s' {1..64})"
+is "$(staged_packages_backing_name digest "$digest")" \
+   "staged-packages.sha256-$(printf 'a%.0s' {1..64})" \
+   'bootc backing name uses sha256- (no colon)'
+is "$(staged_packages_backing_name version 20260909120000)" \
+   'staged-packages.20260909120000' \
+   'native backing name is the 14-digit version'
+
+if staged_packages_backing_name digest 'sha256:short' >/dev/null 2>&1; then
+    fail 'a malformed digest is rejected by backing-name'
+else
+    ok 'a malformed digest is rejected by backing-name'
+fi
+if staged_packages_backing_name version 12345 >/dev/null 2>&1; then
+    fail 'a malformed version is rejected by backing-name'
+else
+    ok 'a malformed version is rejected by backing-name'
+fi
+
+# --- publish / resolve / identity ------------------------------------------
+
+staged_packages_publish version 20260909120000 "$fixtures/staged.packages.txt" \
+    && ok 'publish (native version identity) succeeds' \
+    || fail 'publish (native version identity) succeeds'
+
+# idempotent: a second publish of the same identity must not error and must
+# not fail on "Directory not empty" (the mv -T directory trap).
+staged_packages_publish version 20260909120000 "$fixtures/staged.packages.txt" \
+    && ok 'a second publish of the same identity is idempotent (no Directory-not-empty)' \
+    || fail 'a second publish of the same identity is idempotent (no Directory-not-empty)'
+
+# staged-packages is always a symlink, never a directory
+if [[ -L "$SNOSI_RUN_DIR/staged-packages" ]]; then
+    ok 'the published /run/snosi/staged-packages is a symlink'
+else
+    fail 'the published /run/snosi/staged-packages is a symlink'
+fi
+
+matchdir="$(staged_packages_resolve version 20260909120000)" || matchdir=""
+if [[ -n $matchdir && -r "$matchdir/packages.txt" && -r "$matchdir/identity" ]]; then
+    ok 'resolve returns the backing dir on identity match'
+else
+    fail 'resolve returns the backing dir on identity match'
+fi
+is "$(cat "$matchdir/packages.txt")" "$(cat "$fixtures/staged.packages.txt")" \
+   'the sidecar packages.txt is the exact staged bytes'
+is "$(cat "$matchdir/identity")" 'version=20260909120000' \
+   'the identity file holds exactly version=<14-digit>'
+
+# identity mismatch: a sidecar bound to one version must not be returned for a
+# different expected version (a manual stage cannot inherit an old inventory).
+if staged_packages_resolve version 20260101000000 >/dev/null 2>&1; then
+    fail 'resolve rejects a version-identity mismatch'
+else
+    ok 'resolve rejects a version-identity mismatch'
+fi
+
+# cross-kind mismatch: a version sidecar must not resolve for a digest query.
+if staged_packages_resolve digest "$digest" >/dev/null 2>&1; then
+    fail 'resolve rejects a cross-kind (digest vs version) mismatch'
+else
+    ok 'resolve rejects a cross-kind (digest vs version) mismatch'
+fi
+
+# swap the published symlink to a bootc identity; resolve must follow the new
+# generation and read its identity, not the previous one.
+staged_packages_publish digest "$digest" "$fixtures/running.packages.txt" \
+    && ok 'publish (bootc digest identity) swaps the live symlink' \
+    || fail 'publish (bootc digest identity) swaps the live symlink'
+newdir="$(staged_packages_resolve digest "$digest")" || newdir=""
+is "$(cat "${newdir:-/dev/null}/identity" 2>/dev/null)" "digest=$digest" \
+   'after the swap, resolve reads the new generation identity'
+
+# --- static contract (source-level, both stagers + status CLI) -------------
+#
+# ADR-0014 pins these as source invariants so the two transport paths cannot
+# drift (this subsystem's recurring failure mode).
+
+bootc_stage="$root/mkosi.images/base/mkosi.extra/usr/libexec/bootc-update-stage"
+native_stage="$root/shared/outformat/ab-root/tree/usr/libexec/snosi-sysupdate-stage"
+status_cli="$root/mkosi.images/base/mkosi.extra/usr/bin/snosi-update-status"
+
+# The bootc stager captures packages.txt BEFORE staging: the capture_pulled_packages
+# call site must precede the first `bootc switch`/`bootc upgrade`.
+cap_line="$(grep -nE '! pkg_temp="\$\(capture_pulled_packages' "$bootc_stage" | head -1 | cut -d: -f1)"
+stage_line="$(grep -nE '^[[:space:]]*bootc (switch|upgrade)' "$bootc_stage" | head -1 | cut -d: -f1)"
+if [[ -n $cap_line && -n $stage_line && $cap_line -lt $stage_line ]]; then
+    ok 'bootc: packages.txt is captured before bootc switch/upgrade'
+else
+    fail 'bootc: packages.txt is captured before bootc switch/upgrade' \
+        "capture line=${cap_line:-none}, first stage line=${stage_line:-none}"
+fi
+
+# The bootc already-staged (pulled==staged) branch publishes the sidecar (this
+# is what repairs a post-switch publish failure), and the new-stage path does
+# too: at least two publish_pkg_sidecar call sites.
+if [[ "$(grep -c 'publish_pkg_sidecar ' "$bootc_stage")" -ge 2 ]]; then
+    ok 'bootc: both the already-staged and new-stage paths publish the sidecar'
+else
+    fail 'bootc: both the already-staged and new-stage paths publish the sidecar'
+fi
+
+# Publish before prune: the last packages-sidecar publish precedes the last podman prune.
+last_pub="$(grep -n 'publish_pkg_sidecar ' "$bootc_stage" | tail -1 | cut -d: -f1)"
+last_prune="$(grep -n 'podman image prune' "$bootc_stage" | tail -1 | cut -d: -f1)"
+if [[ -n $last_pub && -n $last_prune && $last_pub -lt $last_prune ]]; then
+    ok 'bootc: the sidecar is published before the post-stage podman prune'
+else
+    fail 'bootc: the sidecar is published before the post-stage podman prune'
+fi
+
+# The native stager publishes/repairs the sidecar on the success path AND both
+# re-assert branches: at least three publish_native_sidecar call sites.
+if [[ "$(grep -c 'publish_native_sidecar ' "$native_stage")" -ge 3 ]]; then
+    ok 'native: success and both re-assert paths publish the sidecar'
+else
+    fail 'native: success and both re-assert paths publish the sidecar'
+fi
+
+# Atomic swap lives in the ONE library, not re-inlined per stager: neither
+# stager touches the published symlink name directly (the only permitted
+# mention is the `staged-packages.sh` library path in the source line).
+inlined="$(grep -hE 'staged-packages' "$bootc_stage" "$native_stage" | grep -vE 'staged-packages\.sh' || true)"
+if [[ -n $inlined ]]; then
+    fail 'the staged-packages symlink is owned by the library, not re-inlined in a stager' "$inlined"
+else
+    ok 'the staged-packages symlink is owned by the library, not re-inlined in a stager'
+fi
+
+# The library swaps a SYMLINK onto the live name (rename(2) of a file) and
+# never `rm`s the live name first, nor `mv -T`s a directory onto it.
+if grep -q 'mv -T "\$linktmp" "\$run_dir/staged-packages"' "$lib"; then
+    ok 'library publishes by mv -T of a fresh symlink onto staged-packages'
+else
+    fail 'library publishes by mv -T of a fresh symlink onto staged-packages'
+fi
+if grep -qE 'rm .*"\$run_dir/staged-packages"' "$lib"; then
+    fail 'library never rm-s the live staged-packages symlink before the swap'
+else
+    ok 'library never rm-s the live staged-packages symlink before the swap'
+fi
+if grep -q 'mv -T "\$tmpdir" "\$run_dir/staged-packages"' "$lib"; then
+    fail 'library never mv -T-s a directory onto the live staged-packages name'
+else
+    ok 'library never mv -T-s a directory onto the live staged-packages name'
+fi
+
+# The status CLI never builds either side of the diff from the dpkg database.
+if grep -qE 'dpkg-query|dpkg[[:space:]]+-l|apt[[:space:]]+list' "$status_cli"; then
+    fail 'snosi-update-status does not use dpkg-query / dpkg -l / apt list'
+else
+    ok 'snosi-update-status does not use dpkg-query / dpkg -l / apt list'
+fi
+
+echo "1..$test_number"
+[[ $failures -eq 0 ]] || { echo "# $failures failure(s)"; exit 1; }


### PR DESCRIPTION
## What

Implements [ADR-0014](docs/adr/0014-update-status-pkg-diff.md): `snosi-update-status --pkg-diff` prints an `rpm-ostree db diff`-shaped Debian-package delta (Upgraded/Downgraded/Added/Removed) between the running image and the *locally* staged one. Default status is unchanged and stays silent on packages. Combinable with `--check`.

## Why

Operators coming from Fedora bootc/Silverblue expect a "what will this reboot change?" command. snosi answered currency but never a package delta. Both sides of the diff come from the frozen `/usr/share/frostyard/<IMAGE_ID>.packages.txt` (core ADR-0003) — **never** the dpkg database (`/var/lib/dpkg` is install-time state on bootc; native relocates it) and never the network.

## How

- **New shared library** `usr/lib/snosi/staged-packages.sh` — the *one* apt-list parser + differ (`dpkg --compare-versions` for ordering) and the identity-bound, write-once sidecar publish/resolve. Sourced by both stagers and the status CLI so the two transports cannot drift.
- **Sidecar**: `/run/snosi/staged-packages` symlink → write-once `staged-packages.<id>/` backing dir (`identity` = exactly `digest=sha256:<hex>` or `version=<14-digit>`, same exclusive invariant as `update-staged`; plus the staged image's `packages.txt` bytes). Published atomically by `mv -T` of a fresh symlink (never `rm`-first, never a directory onto the live name). Dies with `/run` on the applying reboot.
- **`bootc-update-stage`** captures `packages.txt` from the pulled image *before* `bootc switch`/`upgrade` (a capture failure aborts the stage) and publishes on the new-stage and already-staged repair paths, before the post-stage prune.
- **`snosi-sysupdate-stage`** reads it from the freshly-labeled other root slot (read-only EROFS) on the success and both re-assert paths.
- **`--pkg-diff`** reads the sidecar only when `identity` matches the live staged digest/version; on a missing/mismatched sidecar bootc warns-and-skips (never re-pulls) while native falls back to one read-only mount of the other slot at query time.

## Tests

- New `test/pkg-diff-test.sh` (wired into `validate.yml`): parser (captured real Trixie apt lines, not `name/now version` stubs), differ, publish/resolve/identity-mismatch, and the cross-transport source-level static contract. 32 assertions.
- Fixed `test/bootc-container-policy-test.sh`: its mocked `bootc-update-stage` harness now serves a `packages.txt` for the new capture.
- Local runs (all pass): whole-repo shellcheck sweep; `pkg-diff-test` (32/32), `update-notify-units-test` (22), `native-ab-static-test`, `native-ab-contracts-test` (55), `bootc-container-policy-test` (38), `bootc-secure-update-test --fixtures` (20).
- Live native/bootc update-harness assertions are ADR-deferred until those lanes boot a staged hop (they run only inside QEMU guests).

## Docs

ADR-0014 → Accepted; `build-pipeline.md`, `integration-contracts.md` §5.3 (new), and `CLAUDE.md`/`AGENTS.md` updated.

https://claude.ai/code/session_01UK7PjNcRkJX3CXvp596wQS