### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -2,4 +2,4 @@ code=1.136.2-1788561671
 docker-ce=5:29.8.0-1~debian.13~trixie
 1password-cli=2.39.0-1
 claude-desktop=1.49585.0
-chatgpt=26.901.51231
+chatgpt=26.903.61454

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -3,5 +3,5 @@
   "docker-ce": "5:29.8.0-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
   "claude-desktop": "1.49585.0",
-  "chatgpt": "26.901.51231"
+  "chatgpt": "26.903.61454"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

chatgpt: 26.901.51231 -> 26.903.61454


**Please verify the builds work before merging.**