### PR TITLE
chore: update sysext dependency checksums

### DIFF
--- a/shared/download/sysext-checksums.json
+++ b/shared/download/sysext-checksums.json
@@ -1,8 +1,8 @@
 {
   "1password": {
-    "url": "https://downloads.1password.com/linux/debian/amd64/pool/main/1/1password/1password-8.12.34.amd64.deb",
-    "sha256": "25609b8b9e2d684d487c10957c0c012addc177d293dfc5a09469f7879afcefad",
-    "version": "8.12.34"
+    "url": "https://downloads.1password.com/linux/debian/amd64/pool/main/1/1password/1password-8.12.36.amd64.deb",
+    "sha256": "b458fc1312f923454f32d88cef45cecb647cb8d4e57956f82e7f66271ca2c0b0",
+    "version": "8.12.36"
   },
   "bitwarden": {
     "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2026.8.0/Bitwarden-2026.8.0-amd64.deb",
@@ -35,9 +35,9 @@
     "version": "2.36.4"
   },
   "github-copilot": {
-    "url": "https://github.com/github/app/releases/download/v1.1.16/GitHub-Copilot-linux-x64.deb",
-    "sha256": "61b3791e1e224a609333658c91a4befeb00259b7a63e2c41e216c5c9c720eac0",
-    "version": "1.1.16"
+    "url": "https://github.com/github/app/releases/download/v1.1.17/GitHub-Copilot-linux-x64.deb",
+    "sha256": "d03c82683606c82cd0c333a1ffa3724920e0ee914970f851aab1d7426ca27111",
+    "version": "1.1.17"
   },
   "k3s": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.4%2Bk3s1/k3s",


### PR DESCRIPTION
Automated update of pinned direct-download dependencies consumed by sysext builds.

These updates modify `shared/download/sysext-checksums.json` and should trigger `build.yml`, not the OCI image matrix.

**Please verify the sysext build works before merging.**