### PR TITLE
chore: update sysext package versions

### DIFF
--- a/latest-versions.txt
+++ b/latest-versions.txt
@@ -1,6 +1,6 @@
 code=1.137.0-1788902055
 docker-ce=5:29.8.0-1~debian.13~trixie
 1password-cli=2.39.0-1
-claude-desktop=1.52386.0
+claude-desktop=1.52386.3
 chatgpt=26.908.40834
 himmelblau=4.0.2-debian13

--- a/shared/download/package-versions.json
+++ b/shared/download/package-versions.json
@@ -2,7 +2,7 @@
   "code": "1.137.0-1788902055",
   "docker-ce": "5:29.8.0-1~debian.13~trixie",
   "1password-cli": "2.39.0-1",
-  "claude-desktop": "1.52386.0",
+  "claude-desktop": "1.52386.3",
   "chatgpt": "26.908.40834",
   "himmelblau": "4.0.2-debian13"
 }


### PR DESCRIPTION
Automated update of external APT package version sentinels for sysext builds.

claude-desktop: 1.52386.0 -> 1.52386.3


**Please verify the builds work before merging.**